### PR TITLE
[feature] add sonar next command

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Proxies traffic so the service on port 6873 is also available on port 3002.
 sonar next                                 # first next free port from 3000
 sonar next 8000                            # first next free port from 8000
 sonar next 3000-3100                       # first next free port in range
-sonar next --count 3                       # 3 consecutive free ports
+sonar next -n 3                            # 3 consecutive free ports
 sonar next --json                          # JSON output
 ```
 

--- a/cli/cmd/next.go
+++ b/cli/cmd/next.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	nextCountFlag int
+	nextConsecutiveFlag int
 	nextJSONFlag  bool
 )
 
@@ -22,7 +22,7 @@ var nextCmd = &cobra.Command{
 	Long: `Find the next available TCP port not currently in use.
 
 By default, searches starting from port 3000. You can specify a start port
-or a range (e.g. 3000-3100). Use --count to find multiple consecutive free ports.
+or a range (e.g. 3000-3100). Use -n/--consecutive to find multiple consecutive free ports.
 
 Results reflect a point-in-time snapshot; a port could be allocated by another process before you bind it.
 
@@ -30,14 +30,14 @@ Examples:
   sonar next              # first free port starting from 3000
   sonar next 8000         # first free port starting from 8000
   sonar next 3000-3100    # first free port in range 3000-3100
-  sonar next --count 3    # find 3 consecutive free ports from 3000
+  sonar next -n 3          # find 3 consecutive free ports from 3000
   sonar next 8000 --json  # JSON output`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: nextRun,
 }
 
 func init() {
-	nextCmd.Flags().IntVar(&nextCountFlag, "count", 1, "Number of consecutive free ports to find")
+	nextCmd.Flags().IntVarP(&nextConsecutiveFlag, "consecutive", "n", 1, "Number of consecutive free ports to find")
 	nextCmd.Flags().BoolVar(&nextJSONFlag, "json", false, "Output as JSON")
 	rootCmd.AddCommand(nextCmd)
 }
@@ -72,8 +72,8 @@ func nextRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if nextCountFlag < 1 {
-		return fmt.Errorf("--count must be at least 1")
+	if nextConsecutiveFlag < 1 {
+		return fmt.Errorf("--consecutive must be at least 1")
 	}
 
 	results, err := ports.Scan()
@@ -86,12 +86,12 @@ func nextRun(cmd *cobra.Command, args []string) error {
 		occupied[r.Port] = true
 	}
 
-	freePorts := findFreePorts(occupied, startPort, endPort, nextCountFlag)
-	if len(freePorts) < nextCountFlag {
+	freePorts := findFreePorts(occupied, startPort, endPort, nextConsecutiveFlag)
+	if len(freePorts) < nextConsecutiveFlag {
 		if endPort < 65535 {
-			return fmt.Errorf("no %d consecutive free port(s) in range %d-%d", nextCountFlag, startPort, endPort)
+			return fmt.Errorf("no %d consecutive free port(s) in range %d-%d", nextConsecutiveFlag, startPort, endPort)
 		}
-		return fmt.Errorf("no %d consecutive free port(s) starting from %d", nextCountFlag, startPort)
+		return fmt.Errorf("no %d consecutive free port(s) starting from %d", nextConsecutiveFlag, startPort)
 	}
 
 	if nextJSONFlag {


### PR DESCRIPTION
## What does this PR do?
Adds a `sonar next` command that finds the next available (free) TCP port. Useful for scripting and quickly finding open ports without manual trial-and-error.

Supports:
- `sonar next` - first free port from 3000
- `sonar next 8000` - start from a specific port
- `sonar next 3000-3100` - search within a range
- `--count N` - find N consecutive free ports
- `--json` - structured output

Uses `ports.Scan()` internally (same as `sonar list`), no network probing.

## Related issue
Closes #5

## Checklist
- [x] I have tested this on my platform (macOS / Linux)
- [x] My changes don't break existing functionality
- [x] I have updated documentation if needed