### PR TITLE
Add sonar wait command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ sonar wait 5432                        # block until port is accepting connectio
 sonar wait 5432 3000 6379              # wait for multiple ports
 sonar wait 5432 --timeout 30s         # fail after 30 seconds
 sonar wait 5432 --http                # wait for HTTP 200, not just TCP open
+sonar wait 5432 --http=/health        # check a specific endpoint
 sonar wait 5432 -i 500ms              # custom polling interval
 sonar wait 5432 -q                    # no output, just exit code (for scripts)
 ```
 
-Useful for scripting around `docker compose up -d` or background services. The `--http` flag waits for an actual HTTP 200-399 response, not just a TCP socket, which catches services that accept connections before they're truly ready. Exit codes: `0` (ready), `1` (timeout), `2` (interrupted).
+Useful for scripting around `docker compose up -d` or background services. The `--http` flag waits for an actual HTTP 200-399 response, not just a TCP socket, which catches services that accept connections before they're truly ready. Use `--http=/health` to check a specific endpoint. Exit codes: `0` (ready), `1` (timeout), `2` (interrupted).
 
 ```sh
 docker compose up -d

--- a/cli/cmd/wait.go
+++ b/cli/cmd/wait.go
@@ -16,7 +16,7 @@ import (
 var (
 	waitTimeoutFlag  time.Duration
 	waitIntervalFlag time.Duration
-	waitHTTPFlag     bool
+	waitHTTPFlag     string
 	waitQuietFlag    bool
 )
 
@@ -27,7 +27,8 @@ var waitCmd = &cobra.Command{
 
 By default, sonar wait checks for a TCP connection. Use --http to wait
 for an HTTP 200-399 response instead (useful for services that accept
-TCP connections before they are truly ready).
+TCP connections before they are truly ready). You can specify a custom
+path with --http=<path> (e.g. --http=/health).
 
 Exit codes:
   0  all ports are ready
@@ -38,6 +39,7 @@ Examples:
   sonar wait 5432
   sonar wait 5432 --timeout 30s
   sonar wait 5432 --http
+  sonar wait 5432 --http=/health
   sonar wait 5432 3000 6379
   sonar wait 5432 --quiet
   sonar wait 5432 --interval 500ms`,
@@ -60,8 +62,8 @@ Examples:
 
 		if !waitQuietFlag {
 			label := "TCP"
-			if waitHTTPFlag {
-				label = "HTTP"
+			if waitHTTPFlag != "" {
+				label = fmt.Sprintf("HTTP (%s)", waitHTTPFlag)
 			}
 			fmt.Printf("%s Waiting for %s on port(s) %v (timeout %s)\n",
 				display.Dim("⏳"), label, portList, waitTimeoutFlag)
@@ -120,9 +122,10 @@ Examples:
 }
 
 // isPortReady checks whether a port is ready via TCP or HTTP.
-func isPortReady(port int, httpCheck bool) bool {
-	if httpCheck {
-		result := ports.ProbeHealth(port, 2*time.Second)
+// If httpPath is non-empty, an HTTP check is performed against that path.
+func isPortReady(port int, httpPath string) bool {
+	if httpPath != "" {
+		result := ports.ProbeHealth(port, httpPath, 2*time.Second)
 		return result.Status == "healthy"
 	}
 
@@ -137,7 +140,8 @@ func isPortReady(port int, httpCheck bool) bool {
 func init() {
 	waitCmd.Flags().DurationVar(&waitTimeoutFlag, "timeout", 30*time.Second, "Maximum time to wait (e.g. 30s, 1m)")
 	waitCmd.Flags().DurationVarP(&waitIntervalFlag, "interval", "i", 1*time.Second, "Polling interval (e.g. 1s, 500ms)")
-	waitCmd.Flags().BoolVar(&waitHTTPFlag, "http", false, "Wait for HTTP 200-399 instead of TCP connection")
+	waitCmd.Flags().StringVar(&waitHTTPFlag, "http", "", "Wait for HTTP 200-399 instead of TCP connection (optionally specify path: --http=/health)")
+	waitCmd.Flags().Lookup("http").NoOptDefVal = "/"
 	waitCmd.Flags().BoolVarP(&waitQuietFlag, "quiet", "q", false, "No output, just exit code (for scripts)")
 	rootCmd.AddCommand(waitCmd)
 }

--- a/cli/internal/ports/health.go
+++ b/cli/internal/ports/health.go
@@ -15,8 +15,12 @@ type HealthResult struct {
 	Latency    time.Duration
 }
 
-// ProbeHealth performs an HTTP GET to localhost:port and classifies the result.
-func ProbeHealth(port int, timeout time.Duration) HealthResult {
+// ProbeHealth performs an HTTP GET to localhost:port/path and classifies the result.
+// If path is empty, "/" is used.
+func ProbeHealth(port int, path string, timeout time.Duration) HealthResult {
+	if path == "" {
+		path = "/"
+	}
 	client := &http.Client{
 		Timeout: timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -25,7 +29,7 @@ func ProbeHealth(port int, timeout time.Duration) HealthResult {
 	}
 
 	start := time.Now()
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/", port))
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%d%s", port, path))
 	latency := time.Since(start)
 
 	if err != nil {
@@ -92,7 +96,7 @@ func EnrichHealth(pp []ListeningPort, timeout time.Duration) {
 		go func(idx int) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			result := ProbeHealth(pp[idx].Port, timeout)
+			result := ProbeHealth(pp[idx].Port, "/", timeout)
 			pp[idx].HealthStatus = result.Status
 			pp[idx].HealthCode = result.StatusCode
 			pp[idx].HealthLatency = result.Latency


### PR DESCRIPTION
## Summary
- Adds `sonar wait <port> [port...]` command that blocks until ports are accepting connections
- Supports TCP (default) and HTTP readiness checks via `--http` flag
- Configurable `--timeout` (default 30s) and `--interval` (default 1s)
- Multiple ports, quiet mode (`-q`) for scripting, and meaningful exit codes (0/1/2)
- Updates README with usage examples

## Test plan
- [x] `sonar wait <closed-port> --timeout 2s` exits with code 1
- [x] `sonar wait <open-port>` exits with code 0 immediately
- [x] `sonar wait 99999` rejects invalid port
- [x] `--quiet` suppresses all output
- [x] `--help` displays correctly
- [x] Builds cleanly after rebase on latest main

Closes #6