### PR TITLE
[feature] Add "--bind" argument to "sonar list"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ sonar completion fish | source                 # fish
 
 ```sh
 sonar list                     # show all ports
+sonar list --bind              # include the IP address the port is bound to
 sonar list --stats             # include CPU, memory, state, uptime
 sonar list --filter docker     # only Docker ports
 sonar list --sort name         # sort by process name

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -22,6 +22,7 @@ var (
 	healthFlag     bool
 	hostFlag       string
 	statsFlag      bool
+	bindFlag       bool
 )
 
 var listCmd = &cobra.Command{
@@ -41,6 +42,7 @@ func init() {
 	listCmd.Flags().BoolVar(&healthFlag, "health", false, "Run HTTP health checks on each port")
 	listCmd.Flags().BoolVar(&statsFlag, "stats", false, "Include resource stats (CPU, memory, threads, uptime, state)")
 	listCmd.Flags().StringVar(&hostFlag, "host", "", "Scan a remote host via SSH (e.g. user@hostname)")
+	listCmd.Flags().BoolVarP(&bindFlag, "bind", "b", false, "Display the IP address the port is bound to")
 	rootCmd.AddCommand(listCmd)
 }
 
@@ -92,6 +94,22 @@ func listRun(cmd *cobra.Command, args []string) error {
 		columns = parseColumns(columnsFlag)
 	} else if statsFlag {
 		columns = append(display.DefaultColumns, "cpu", "mem", "state", "uptime", "connections")
+	}
+
+	if bindFlag {
+		if len(columns) == 0 {
+			columns = display.DefaultColumns
+		}
+
+		// Search the list of columns for the word "port", and insert the word "bind" immediately after it
+		for i, v := range columns {
+			if v == "port" {
+				columns = append(columns, "")      // grow by one
+				copy(columns[i+2:], columns[i+1:]) // shift tail right
+				columns[i+1] = "bind"
+				break
+			}
+		}
 	}
 
 	display.RenderTable(os.Stdout, results, display.TableOptions{


### PR DESCRIPTION
## What does this PR do?

Adds `sonar list --bind` argument, to easily display the IP address a port is bound to.

Searches the list of display columns for the word `port` and inserts the word `bind` immediately after it. This lets it work nicely when only `--bind` is passed, or when called with `--stats --bind`, or even with `--columns port,name --bind`

## Related issue

None

## How was this tested?

Tested on Linux and macOS with:

```bash
sonar list
sonar list --bind
sonar list --bind --stats
sonar list --columns port --bind
sonar list --columns pid,port --bind
sonar list --columns port,pid --bind
sonar list --columns port,name --bind
sonar list --columns pid --bind # bind address not displayed, because "port" not shown
sonar list --columns pid,process,type --bind # bind address not displayed, because "port" not shown
```

## Checklist
- [x] I have tested this on my platform (macOS / Linux)
- [x] My changes don't break existing functionality
- [x] I have updated documentation if needed
