### PR TITLE
ci: add PR check workflow with cross-platform build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build & vet (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+        run: go test ./...
+
+      - name: Build
+        run: go build ./...

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,22 @@
+package selfupdate
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		current, remote string
+		want            bool
+	}{
+		{"v1.0.0", "v1.0.1", true},
+		{"v1.0.1", "v1.0.0", false},
+		{"v1.0.0", "v1.0.0", false},
+		{"dev", "v1.0.0", false},
+		{"v1.0.0", "v2.0.0", true},
+	}
+
+	for _, tt := range tests {
+		if got := IsNewer(tt.current, tt.remote); got != tt.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", tt.current, tt.remote, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds a CI workflow that runs on every PR and push to main. Currently there are no checks, so anything can be merged without verification. The workflow runs `go vet` and `go build` across all six platform targets (linux, darwin, windows x amd64/arm64), matching the release matrix. Tests run on linux/amd64 only since cross-compiled binaries can't execute on the runner.

Also bootstraps the test infrastructure with an initial test for `IsNewer` in the selfupdate package, the function that controls whether the binary replaces itself on update.

## Related issue

N/A

## How was this tested?

Verified locally with `go vet ./...`, `go build ./...`, and `go test ./...`, all pass clean.

## Checklist
- [x] I have tested this on my platform (macOS / Linux)
- [x] My changes don't break existing functionality
- [x] I have updated documentation if needed