### PR TITLE
refactor: replace custom contains with strings.Contains

### DIFF
--- a/internal/ports/health.go
+++ b/internal/ports/health.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -62,24 +63,11 @@ func isConnectionRefused(err error) bool {
 		}
 		// Check the string as a fallback — the stdlib wraps the
 		// syscall error in various layers.
-		if contains(fmt.Sprintf("%v", err), "connection refused") ||
-			contains(err.Error(), "connection refused") {
+		if strings.Contains(fmt.Sprintf("%v", err), "connection refused") ||
+			strings.Contains(err.Error(), "connection refused") {
 			return true
 		}
 		break
-	}
-	return false
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
 	}
 	return false
 }

--- a/internal/ports/health_test.go
+++ b/internal/ports/health_test.go
@@ -1,0 +1,44 @@
+package ports
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+)
+
+func TestIsConnectionRefused(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "connection refused",
+			err:  errors.New("connection refused"),
+			want: true,
+		},
+		{
+			name: "wrapped in url.Error",
+			err:  &url.Error{Op: "Get", URL: "http://localhost:9999", Err: errors.New("connection refused")},
+			want: true,
+		},
+		{
+			name: "timeout error",
+			err:  errors.New("i/o timeout"),
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("something else went wrong"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isConnectionRefused(tt.err); got != tt.want {
+				t.Errorf("isConnectionRefused(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Removes two hand-rolled functions, `contains` and `searchString`, that duplicate the behavior of `strings.Contains` exactly. They were used in one place in `isConnectionRefused` to check if an error message contains "connection refused".

Also adds a test for `isConnectionRefused` covering the connection refused case, a wrapped `url.Error`, a timeout, and an unrelated error.

## Related issue

N/A

## How was this tested?

`go test ./...`, `go vet ./...`, `go build ./...`, and a local `sonar list` all pass clean.

## Checklist
- [x] I have tested this on my platform (macOS / Linux)
- [x] My changes don't break existing functionality
- [x] I have updated documentation if needed