### PR TITLE
Handle Java -cp and -classpath in process display names

### DIFF
--- a/internal/ports/displayname.go
+++ b/internal/ports/displayname.go
@@ -76,6 +76,13 @@ func interpreterAwareBasename(cmd string) string {
 		if name := extractRunnerSubcommand(parts); name != "" {
 			return name
 		}
+		// java -cp/-classpath: skip the classpath value, return main class.
+		if base == "java" {
+			if name := extractJavaMainClass(parts); name != "" {
+				return name
+			}
+			return base
+		}
 		// `python /path/to/script.py arg1`: use the script basename.
 		if name := extractScriptArg(parts); name != "" {
 			return name
@@ -134,6 +141,31 @@ func extractScriptArg(parts []string) string {
 			continue
 		}
 		return filepath.Base(arg)
+	}
+	return ""
+}
+
+// extractJavaMainClass handles java command lines.
+// Returns the main class for -cp/-classpath invocations,
+// the jar basename for -jar, or "" if no main class found.
+func extractJavaMainClass(parts []string) string {
+	for i := 1; i < len(parts); i++ {
+		arg := parts[i]
+		if arg == "-jar" {
+			if i+1 < len(parts) {
+				return filepath.Base(parts[i+1])
+			}
+			return ""
+		}
+		if arg == "-cp" || arg == "-classpath" {
+			i++ // skip the classpath value
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		// first non-flag, non-classpath-value token is the main class
+		return arg
 	}
 	return ""
 }

--- a/internal/ports/displayname_test.go
+++ b/internal/ports/displayname_test.go
@@ -91,6 +91,28 @@ func TestResolveProcessName(t *testing.T) {
 			want: "server.js",
 		},
 
+		// java
+		{
+			name: "java -cp classpath ClassName",
+			cmd:  "/usr/bin/java -cp dep1.jar:dep2.jar:dep3.jar com.myapp.SomeClass",
+			want: "com.myapp.SomeClass",
+		},
+		{
+			name: "java -classpath classpath ClassName",
+			cmd:  "java -classpath /path/to/dep1.jar:/path/to/dep2.jar com.example.Main",
+			want: "com.example.Main",
+		},
+		{
+			name: "java -jar app.jar",
+			cmd:  "java -jar /path/to/app.jar",
+			want: "app.jar",
+		},
+		{
+			name: "java with no class",
+			cmd:  "java",
+			want: "java",
+		},
+
 		// Cwd should not be added when name already starts with it
 		{
 			name: "no double-prefix when name already includes cwd",


### PR DESCRIPTION
## What does this PR do?
Java processes with `-cp` or `-classpath` were getting the wrong display name. The code was grabbing the classpath value instead of extracting the main class. Fixed the parsing to extract the actual main class for `-cp`/`-classpath` invocations, and handle `-jar` correctly.

## Related issue
Fixes #39

## How was this tested?
Added test cases for the main scenarios: `-cp`, `-classpath`, `-jar`, and plain `java` invocations. Tested locally, all passing.

## Checklist
- [x] I have tested this on my platform (macOS / Linux)
- [x] My changes don't break existing functionality
- [x] I have updated documentation if needed