### PR TITLE
ci: build static linux binaries with CGO_ENABLED=0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           GOOS: linux
           GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
         run: |
           VERSION="${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || format('{0}-dev', github.ref_name) }}"
           go build -ldflags="-s -w -X github.com/raskrebs/sonar/internal/selfupdate.Version=${VERSION}" -o sonar .


### PR DESCRIPTION
Closes #35.

Sets `CGO_ENABLED=0` on the linux release build so the produced binaries are statically linked and run on any glibc version (CentOS 7/8, Alpine, etc.). Safe because the project and its deps have no CGO usage (`go list -deps -f '{{if .CgoFiles}}{{.ImportPath}}{{end}}' ./...` returns empty, no `import "C"`).

Verified locally: `file` reports "statically linked", binary size ~7.5M.

Only touches the linux job — macOS and Windows builds unchanged.