### PR TITLE
feat(list): surface service names and sudo hint for hidden processes

### DIFF
--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -109,7 +109,27 @@ func listRun(cmd *cobra.Command, args []string) error {
 		SortBy:  sortFlag,
 		Columns: columns,
 	})
+
+	if hostFlag == "" && hasHiddenProcesses(results) {
+		fmt.Fprintln(os.Stderr, "\nnote: some processes are hidden — re-run with sudo for full visibility")
+	}
 	return nil
+}
+
+// hasHiddenProcesses reports whether the scan ran unprivileged and at least one
+// listening socket came back without a resolvable process name — the signature
+// of the OS withholding process info for sockets owned by other users.
+func hasHiddenProcesses(pp []ports.ListeningPort) bool {
+	// Geteuid returns -1 on Windows; the >0 check naturally excludes it and root.
+	if os.Geteuid() <= 0 {
+		return false
+	}
+	for _, p := range pp {
+		if p.DisplayName() == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func parseColumns(s string) []string {

--- a/internal/display/table.go
+++ b/internal/display/table.go
@@ -223,6 +223,15 @@ func columnValue(p ports.ListeningPort, col string) string {
 
 func colorProcess(p ports.ListeningPort) string {
 	name := p.DisplayName()
+	// Process unknown (typically hidden by privileges) — fall back to the
+	// well-known service name for the port, dimmed and marked with "~" to
+	// signal it's inferred from the port number, not a detected process.
+	if name == "" {
+		if svc := ports.ServiceName(p.Port); svc != "" {
+			return Dim("~" + svc)
+		}
+		return ""
+	}
 	// If it's Docker and we have the image, show "name (image)"
 	if p.Type == ports.PortTypeDocker && p.DockerImage != "" && p.DockerContainer != "" {
 		display := p.DisplayName()

--- a/internal/display/table_test.go
+++ b/internal/display/table_test.go
@@ -1,0 +1,29 @@
+package display
+
+import (
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+func TestColorProcessServiceFallback(t *testing.T) {
+	NoColor = true
+
+	// Unknown process on a well-known port falls back to the service hint.
+	got := colorProcess(ports.ListeningPort{Port: 53})
+	if got != "~dns" {
+		t.Errorf("colorProcess(port 53, no process) = %q, want %q", got, "~dns")
+	}
+
+	// Unknown process on a non-well-known port stays blank.
+	got = colorProcess(ports.ListeningPort{Port: 3000})
+	if got != "" {
+		t.Errorf("colorProcess(port 3000, no process) = %q, want empty", got)
+	}
+
+	// A resolved process name is used as-is, not overridden by the hint.
+	got = colorProcess(ports.ListeningPort{Port: 53, Process: "dnsmasq"})
+	if got != "dnsmasq" {
+		t.Errorf("colorProcess(port 53, process dnsmasq) = %q, want %q", got, "dnsmasq")
+	}
+}

--- a/internal/ports/service.go
+++ b/internal/ports/service.go
@@ -1,0 +1,63 @@
+package ports
+
+// wellKnownServices maps common listening ports to their IANA-registered
+// service names. It is used only as a display hint when the actual process
+// behind a port can't be determined (e.g. running unprivileged, where the OS
+// hides process info for sockets owned by other users).
+var wellKnownServices = map[int]string{
+	20:    "ftp-data",
+	21:    "ftp",
+	22:    "ssh",
+	23:    "telnet",
+	25:    "smtp",
+	53:    "dns",
+	67:    "dhcp",
+	68:    "dhcp",
+	69:    "tftp",
+	80:    "http",
+	110:   "pop3",
+	111:   "rpcbind",
+	119:   "nntp",
+	123:   "ntp",
+	135:   "msrpc",
+	139:   "netbios-ssn",
+	143:   "imap",
+	161:   "snmp",
+	179:   "bgp",
+	389:   "ldap",
+	443:   "https",
+	445:   "smb",
+	465:   "smtps",
+	514:   "syslog",
+	515:   "printer",
+	587:   "smtp-submission",
+	631:   "ipp",
+	636:   "ldaps",
+	873:   "rsync",
+	993:   "imaps",
+	995:   "pop3s",
+	1080:  "socks",
+	1194:  "openvpn",
+	1433:  "mssql",
+	1521:  "oracle",
+	2049:  "nfs",
+	2375:  "docker",
+	2376:  "docker",
+	3306:  "mysql",
+	3389:  "rdp",
+	5353:  "mdns",
+	5432:  "postgresql",
+	5672:  "amqp",
+	5900:  "vnc",
+	6379:  "redis",
+	6443:  "kube-apiserver",
+	9200:  "elasticsearch",
+	11211: "memcached",
+	27017: "mongodb",
+}
+
+// ServiceName returns the well-known IANA service name for a port, or "" if
+// the port is not a recognized well-known port.
+func ServiceName(port int) string {
+	return wellKnownServices[port]
+}

--- a/internal/ports/service_test.go
+++ b/internal/ports/service_test.go
@@ -1,0 +1,22 @@
+package ports
+
+import "testing"
+
+func TestServiceName(t *testing.T) {
+	tests := []struct {
+		port int
+		want string
+	}{
+		{53, "dns"},
+		{631, "ipp"},
+		{443, "https"},
+		{5432, "postgresql"},
+		{3000, ""},  // not a well-known port
+		{99999, ""}, // out of range
+	}
+	for _, tt := range tests {
+		if got := ServiceName(tt.port); got != tt.want {
+			t.Errorf("ServiceName(%d) = %q, want %q", tt.port, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #34.

When `sonar list` runs unprivileged, the OS hides process info for sockets owned by other users (systemd-resolve on :53, cupsd on :631, etc.), leaving the PROCESS column blank with no indication of what's listening.

This adds two complementary hints:

- **Service-name fallback** — when the process can't be resolved, show the well-known IANA service name for the port, dimmed and prefixed with `~` to mark it as inferred from the port number rather than detected (e.g. `~dns`, `~ipp`). Built-in table, no I/O, cross-platform.
- **Sudo hint** — when running unprivileged and at least one socket came back unnamed, print a one-line note to stderr: `note: some processes are hidden — re-run with sudo for full visibility`. Skipped for `--json`, remote (`--host`), root, and Windows.

Default columns are intentionally left unchanged.

## Testing
- `ServiceName` lookup table (`internal/ports/service_test.go`)
- `colorProcess` fallback rendering — hint shown only when process is empty, real names preserved (`internal/display/table_test.go`)
- `go vet ./...`, `go test ./...`, `go build ./...` all pass