### PR TITLE
feat: add config file and sonar config subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,36 @@ sonar --no-color                           # disable colors (also respects NO_CO
 
 The `--stats` flag fetches per-process and per-container resource usage. For Docker containers, it uses the Docker Engine API for accurate per-container metrics. Without `--stats`, sonar returns instantly.
 
+## Configuration
+
+`sonar` reads optional defaults from `~/.config/sonar/config.yaml`. The file is
+optional — without it, built-in defaults apply. Command-line flags always
+override the config file.
+
+Create a starter file:
+
+```bash
+sonar config init       # write a commented template
+sonar config path       # print the file location
+sonar config edit       # open it in $EDITOR
+```
+
+Example config:
+
+```yaml
+list:
+  columns: [port, process, container, image, containerport, url]
+  sort: port            # port | pid | name | type
+  filter: ""            # docker | user | system | "" (all)
+  all: false            # include desktop apps by default
+color: true             # set false to disable colored output
+services:               # label custom/unknown ports
+  9000: php-fpm
+  5050: my-dashboard
+```
+
+Invalid values are ignored with a warning; sonar continues with defaults.
+
 ## Tray app
 
 The menu bar tray app (macOS only) is a native Swift binary that shows live port stats in your menu bar. If you installed sonar via the install script or a GitHub release, the tray binary (`sonar-tray`) is included automatically.

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var configForce bool
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage the sonar config file",
+}
+
+var configPathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Print the config file path",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(config.Path())
+		return nil
+	},
+}
+
+var configInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Write a starter config file",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runConfigInit(configForce); err != nil {
+			return err
+		}
+		fmt.Printf("wrote %s\n", config.Path())
+		return nil
+	},
+}
+
+var configEditCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Open the config file in $EDITOR",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runConfigEdit()
+	},
+}
+
+func init() {
+	configInitCmd.Flags().BoolVar(&configForce, "force", false, "Overwrite an existing config file")
+	configCmd.AddCommand(configPathCmd, configInitCmd, configEditCmd)
+	rootCmd.AddCommand(configCmd)
+}
+
+func runConfigInit(force bool) error {
+	return config.WriteTemplate(force)
+}
+
+func runConfigEdit() error {
+	// Ensure a file exists so the editor opens something real.
+	if _, err := os.Stat(config.Path()); os.IsNotExist(err) {
+		if err := config.WriteTemplate(false); err != nil {
+			return err
+		}
+	}
+	editor := resolveEditor()
+	if editor == "" {
+		return fmt.Errorf("no editor found: set $EDITOR (or $VISUAL)")
+	}
+	c := exec.Command(editor, config.Path())
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return c.Run()
+}
+
+func resolveEditor() string {
+	if e := os.Getenv("EDITOR"); e != "" {
+		return e
+	}
+	if e := os.Getenv("VISUAL"); e != "" {
+		return e
+	}
+	if runtime.GOOS == "windows" {
+		return "notepad"
+	}
+	if _, err := exec.LookPath("vi"); err == nil {
+		return "vi"
+	}
+	return ""
+}

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/display"
+)
+
+func TestEffectiveString(t *testing.T) {
+	// Flag explicitly set wins over config.
+	if got := effectiveString(true, "pid", "name"); got != "pid" {
+		t.Errorf("changed flag should win, got %q", got)
+	}
+	// Flag unchanged, config provides value.
+	if got := effectiveString(false, "port", "name"); got != "name" {
+		t.Errorf("config should win when flag unchanged, got %q", got)
+	}
+	// Flag unchanged, no config value -> keep flag default.
+	if got := effectiveString(false, "port", ""); got != "port" {
+		t.Errorf("default should win when no config, got %q", got)
+	}
+}
+
+func TestEffectiveBool(t *testing.T) {
+	tru := true
+	fls := false
+	if got := effectiveBool(true, true, &fls); got != true {
+		t.Error("changed flag should win over config")
+	}
+	if got := effectiveBool(false, false, &tru); got != true {
+		t.Error("config should win when flag unchanged")
+	}
+	if got := effectiveBool(false, false, nil); got != false {
+		t.Error("default should win when config nil")
+	}
+}
+
+func TestEffectiveColumns(t *testing.T) {
+	// --all-columns wins.
+	if got := effectiveColumns(true, "", false, []string{"port"}); !reflect.DeepEqual(got, display.AllColumns) {
+		t.Errorf("all-columns should win, got %v", got)
+	}
+	// --columns flag wins over config.
+	if got := effectiveColumns(false, "pid,url", false, []string{"port"}); !reflect.DeepEqual(got, []string{"pid", "url"}) {
+		t.Errorf("columns flag should win, got %v", got)
+	}
+	// config columns used when no flags, no stats.
+	if got := effectiveColumns(false, "", false, []string{"port", "pid"}); !reflect.DeepEqual(got, []string{"port", "pid"}) {
+		t.Errorf("config columns should be used, got %v", got)
+	}
+	// no flags, no config, no stats -> nil (RenderTable uses its defaults).
+	if got := effectiveColumns(false, "", false, nil); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+	// stats with config base appends stats columns to config columns.
+	got := effectiveColumns(false, "", true, []string{"port"})
+	want := []string{"port", "cpu", "mem", "state", "uptime", "connections"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("stats+config columns = %v, want %v", got, want)
+	}
+}

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -33,6 +35,25 @@ func TestEffectiveBool(t *testing.T) {
 	}
 	if got := effectiveBool(false, false, nil); got != false {
 		t.Error("default should win when config nil")
+	}
+}
+
+func TestConfigInitWritesTemplate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := runConfigInit(false); err != nil {
+		t.Fatalf("runConfigInit: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "sonar", "config.yaml")); err != nil {
+		t.Errorf("config file not created: %v", err)
+	}
+	// Second call without force must fail.
+	if err := runConfigInit(false); err == nil {
+		t.Error("expected error on overwrite without force")
+	}
+	// With force it succeeds.
+	if err := runConfigInit(true); err != nil {
+		t.Errorf("force should overwrite: %v", err)
 	}
 }
 

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -144,6 +144,46 @@ func parseColumns(s string) []string {
 	return cols
 }
 
+// effectiveString applies precedence: explicit flag > config value > flag default.
+func effectiveString(flagChanged bool, flagVal, cfgVal string) string {
+	if !flagChanged && cfgVal != "" {
+		return cfgVal
+	}
+	return flagVal
+}
+
+// effectiveBool applies precedence: explicit flag > config value > flag default.
+func effectiveBool(flagChanged bool, flagVal bool, cfgVal *bool) bool {
+	if !flagChanged && cfgVal != nil {
+		return *cfgVal
+	}
+	return flagVal
+}
+
+// effectiveColumns resolves the column list. Returns nil when no flag, config,
+// or stats override applies, so RenderTable falls back to its built-in defaults
+// (preserving current behavior when no config is present).
+func effectiveColumns(allCols bool, columnsFlag string, stats bool, cfgCols []string) []string {
+	switch {
+	case allCols:
+		return display.AllColumns
+	case columnsFlag != "":
+		return parseColumns(columnsFlag)
+	}
+	base := display.DefaultColumns
+	if len(cfgCols) > 0 {
+		base = cfgCols
+	}
+	if stats {
+		out := append([]string{}, base...)
+		return append(out, "cpu", "mem", "state", "uptime", "connections")
+	}
+	if len(cfgCols) > 0 {
+		return cfgCols
+	}
+	return nil
+}
+
 func excludeApps(pp []ports.ListeningPort) []ports.ListeningPort {
 	var result []ports.ListeningPort
 	for _, p := range pp {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -167,18 +167,16 @@ func effectiveColumns(allCols bool, columnsFlag string, stats bool, cfgCols []st
 	case columnsFlag != "":
 		return parseColumns(columnsFlag)
 	}
-	base := display.DefaultColumns
-	if len(cfgCols) > 0 {
-		base = cfgCols
-	}
 	if stats {
+		base := display.DefaultColumns
+		if len(cfgCols) > 0 {
+			base = cfgCols
+		}
 		out := append([]string{}, base...)
 		return append(out, "cpu", "mem", "state", "uptime", "connections")
 	}
-	if len(cfgCols) > 0 {
-		return cfgCols
-	}
-	return nil
+	// nil when no config columns → RenderTable falls back to its defaults.
+	return cfgCols
 }
 
 func excludeApps(pp []ports.ListeningPort) []ports.ListeningPort {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -77,13 +77,16 @@ func listRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Hide desktop apps unless --all is set
-	if !allFlag {
+	// Resolve row-affecting settings (config fills in where no flag was passed).
+	cfg := loadedConfig
+	showApps := effectiveBool(cmd.Flags().Changed("all"), allFlag, cfg.List.All)
+	activeFilter := effectiveString(cmd.Flags().Changed("filter"), filterFlag, cfg.List.Filter)
+
+	if !showApps {
 		results = excludeApps(results)
 	}
-
-	if filterFlag != "" {
-		results = display.FilterPorts(results, filterFlag)
+	if activeFilter != "" {
+		results = display.FilterPorts(results, activeFilter)
 	}
 
 	if ipv4Flag {
@@ -96,17 +99,11 @@ func listRun(cmd *cobra.Command, args []string) error {
 		return display.RenderJSON(os.Stdout, results)
 	}
 
-	var columns []string
-	if allColumnsFlag {
-		columns = display.AllColumns
-	} else if columnsFlag != "" {
-		columns = parseColumns(columnsFlag)
-	} else if statsFlag {
-		columns = append(display.DefaultColumns, "cpu", "mem", "state", "uptime", "connections")
-	}
+	sortBy := effectiveString(cmd.Flags().Changed("sort"), sortFlag, cfg.List.Sort)
+	columns := effectiveColumns(allColumnsFlag, columnsFlag, statsFlag, cfg.List.Columns)
 
 	display.RenderTable(os.Stdout, results, display.TableOptions{
-		SortBy:  sortFlag,
+		SortBy:  sortBy,
 		Columns: columns,
 	})
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,9 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/raskrebs/sonar/internal/config"
 	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/spf13/cobra"
 )
+
+// loadedConfig holds the parsed config for the duration of a command run.
+// Populated by PersistentPreRun; never nil after Execute starts.
+var loadedConfig = &config.Config{}
 
 const banner = `
   ███████╗ ██████╗ ███╗   ██╗ █████╗ ██████╗
@@ -27,9 +33,22 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		cfg, warnings := config.Load()
+		for _, w := range warnings {
+			fmt.Fprintln(os.Stderr, w)
+		}
+		loadedConfig = cfg
+
+		// color: false in config disables ANSI; an explicit --no-color flag
+		// also wins. We never force color ON (would corrupt piped output).
+		if cfg.Color != nil && !*cfg.Color {
+			display.NoColor = true
+		}
 		if nc, _ := cmd.Flags().GetBool("no-color"); nc {
 			display.NoColor = true
 		}
+
+		ports.RegisterServices(cfg.Services)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds user preferences loaded from ~/.config/sonar/config.yaml.
+type Config struct {
+	List     ListConfig     `yaml:"list"`
+	Color    *bool          `yaml:"color"`    // pointer: nil = unset, distinguishes from explicit false
+	Services map[int]string `yaml:"services"` // port -> label, merged over built-in table
+}
+
+// ListConfig holds defaults for the `sonar list` command.
+type ListConfig struct {
+	Columns []string `yaml:"columns"`
+	Sort    string   `yaml:"sort"`
+	Filter  string   `yaml:"filter"`
+	All     *bool    `yaml:"all"`
+}
+
+// Path returns the absolute path to the config file.
+func Path() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".config", "sonar", "config.yaml")
+}
+
+// Load reads and validates the config file. It never returns an error: a
+// missing file yields an empty Config with no warnings; a malformed file or
+// invalid values yield a Config with the bad settings dropped plus
+// human-readable warning strings for the caller to print.
+func Load() (*Config, []string) {
+	cfg := &Config{}
+
+	data, err := os.ReadFile(Path())
+	if err != nil {
+		// Missing/unreadable file is not an error — run with defaults.
+		return cfg, nil
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return &Config{}, []string{fmt.Sprintf("ignoring %s: %v", Path(), err)}
+	}
+
+	return cfg, validate(cfg)
+}
+
+// validate is implemented in a later task.
+func validate(cfg *Config) []string {
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/raskrebs/sonar/internal/display"
 	"gopkg.in/yaml.v3"
 )
 
@@ -52,7 +53,43 @@ func Load() (*Config, []string) {
 	return cfg, validate(cfg)
 }
 
-// validate is implemented in a later task.
+var validSorts = map[string]bool{"port": true, "pid": true, "name": true, "type": true}
+var validFilters = map[string]bool{"docker": true, "user": true, "system": true}
+
+// validate checks list settings and service ports, dropping any invalid value
+// and returning a warning for each. Valid neighboring settings are preserved.
 func validate(cfg *Config) []string {
-	return nil
+	var warnings []string
+
+	// Columns: every entry must be a known display column.
+	known := make(map[string]bool, len(display.AllColumns))
+	for _, c := range display.AllColumns {
+		known[c] = true
+	}
+	for _, c := range cfg.List.Columns {
+		if !known[c] {
+			warnings = append(warnings, fmt.Sprintf("config: unknown column %q — using default columns", c))
+			cfg.List.Columns = nil
+			break
+		}
+	}
+
+	if cfg.List.Sort != "" && !validSorts[cfg.List.Sort] {
+		warnings = append(warnings, fmt.Sprintf("config: invalid sort %q — using default", cfg.List.Sort))
+		cfg.List.Sort = ""
+	}
+
+	if cfg.List.Filter != "" && !validFilters[cfg.List.Filter] {
+		warnings = append(warnings, fmt.Sprintf("config: invalid filter %q — ignoring", cfg.List.Filter))
+		cfg.List.Filter = ""
+	}
+
+	for port := range cfg.Services {
+		if port < 1 || port > 65535 {
+			warnings = append(warnings, fmt.Sprintf("config: invalid service port %d — ignoring", port))
+			delete(cfg.Services, port)
+		}
+	}
+
+	return warnings
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,45 @@ func Load() (*Config, []string) {
 	return cfg, validate(cfg)
 }
 
+const template = `# sonar configuration
+# All settings are optional. Uncomment and edit to override built-in defaults.
+# Explicit command-line flags always take precedence over this file.
+
+# list:
+#   # Columns shown by default. Available: port, process, pid, type, url,
+#   # cpu, mem, threads, uptime, state, connections, container, image,
+#   # containerport, compose, project, user, bind, ip, health, latency
+#   columns: [port, process, container, image, containerport, url]
+#   sort: port      # port | pid | name | type
+#   filter: ""      # docker | user | system | "" (all)
+#   all: false      # include desktop apps by default
+
+# color: true       # set false to disable colored output
+
+# services:         # label custom/unknown ports (port: name)
+#   9000: php-fpm
+#   5050: my-dashboard
+`
+
+// WriteTemplate writes a commented starter config to Path(), creating the
+// parent directory if needed. It refuses to overwrite an existing file unless
+// force is true.
+func WriteTemplate(force bool) error {
+	path := Path()
+	if !force {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("config already exists at %s (use --force to overwrite)", path)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("could not create config directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(template), 0o644); err != nil {
+		return fmt.Errorf("could not write config: %w", err)
+	}
+	return nil
+}
+
 var validSorts = map[string]bool{"port": true, "pid": true, "name": true, "type": true}
 var validFilters = map[string]bool{"docker": true, "user": true, "system": true}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fakehome")
+	want := filepath.Join("/tmp/fakehome", ".config", "sonar", "config.yaml")
+	if got := Path(); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no config.yaml inside
+	cfg, warnings := Load()
+	if cfg == nil {
+		t.Fatal("Load() returned nil config")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("missing file produced warnings: %v", warnings)
+	}
+	if len(cfg.List.Columns) != 0 || cfg.Color != nil || len(cfg.Services) != 0 {
+		t.Errorf("missing file should yield empty config, got %+v", cfg)
+	}
+}
+
+func TestLoadValidFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "sonar")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "list:\n  columns: [port, process]\n  sort: name\nservices:\n  9000: php-fpm\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, warnings := Load()
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(cfg.List.Columns) != 2 || cfg.List.Columns[0] != "port" {
+		t.Errorf("columns = %v", cfg.List.Columns)
+	}
+	if cfg.List.Sort != "name" {
+		t.Errorf("sort = %q", cfg.List.Sort)
+	}
+	if cfg.Services[9000] != "php-fpm" {
+		t.Errorf("services = %v", cfg.Services)
+	}
+}
+
+func TestLoadMalformedYAML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "sonar")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("list: [this is not: valid"), 0o644)
+	cfg, warnings := Load()
+	if cfg == nil {
+		t.Fatal("Load() returned nil config")
+	}
+	if len(warnings) == 0 {
+		t.Error("malformed YAML should produce a warning")
+	}
+}
+
+func TestLoadEmptyFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "sonar")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("   \n"), 0o644)
+	cfg, warnings := Load()
+	if len(warnings) != 0 {
+		t.Errorf("empty file produced warnings: %v", warnings)
+	}
+	if len(cfg.List.Columns) != 0 {
+		t.Errorf("empty file should yield empty config")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -157,3 +157,39 @@ func TestValidateServicePortRange(t *testing.T) {
 		t.Error("valid service should survive")
 	}
 }
+
+func TestWriteTemplateCreatesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := WriteTemplate(false); err != nil {
+		t.Fatalf("WriteTemplate: %v", err)
+	}
+	data, err := os.ReadFile(Path())
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("template is empty")
+	}
+	cfg, warnings := Load()
+	if len(warnings) != 0 {
+		t.Errorf("template produced warnings: %v", warnings)
+	}
+	if len(cfg.List.Columns) != 0 {
+		t.Errorf("template should be all-commented, got columns %v", cfg.List.Columns)
+	}
+}
+
+func TestWriteTemplateRefusesOverwrite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := WriteTemplate(false); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteTemplate(false); err == nil {
+		t.Error("expected error when file exists and force=false")
+	}
+	if err := WriteTemplate(true); err != nil {
+		t.Errorf("force=true should overwrite, got %v", err)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -83,3 +83,77 @@ func TestLoadEmptyFile(t *testing.T) {
 		t.Errorf("empty file should yield empty config")
 	}
 }
+
+func writeConfig(t *testing.T, content string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "sonar")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateUnknownColumn(t *testing.T) {
+	writeConfig(t, "list:\n  columns: [port, bogus, url]\n")
+	cfg, warnings := Load()
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for unknown column")
+	}
+	if len(cfg.List.Columns) != 0 {
+		t.Errorf("columns should be cleared on bad value, got %v", cfg.List.Columns)
+	}
+}
+
+func TestValidateBadSortKeepsOtherSettings(t *testing.T) {
+	writeConfig(t, "list:\n  sort: sideways\n  filter: docker\n")
+	cfg, warnings := Load()
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for bad sort")
+	}
+	if cfg.List.Sort != "" {
+		t.Errorf("bad sort should be cleared, got %q", cfg.List.Sort)
+	}
+	if cfg.List.Filter != "docker" {
+		t.Errorf("valid filter should survive, got %q", cfg.List.Filter)
+	}
+}
+
+func TestValidateBadFilter(t *testing.T) {
+	writeConfig(t, "list:\n  filter: nonsense\n")
+	cfg, warnings := Load()
+	if len(warnings) == 0 || cfg.List.Filter != "" {
+		t.Errorf("bad filter should warn and clear; warnings=%v filter=%q", warnings, cfg.List.Filter)
+	}
+}
+
+func TestValidateEmptyColumnsTreatedAsUnset(t *testing.T) {
+	writeConfig(t, "list:\n  columns: []\n")
+	cfg, warnings := Load()
+	if len(warnings) != 0 {
+		t.Errorf("empty columns should not warn: %v", warnings)
+	}
+	if len(cfg.List.Columns) != 0 {
+		t.Errorf("empty columns stays empty (falls back to defaults)")
+	}
+}
+
+func TestValidateServicePortRange(t *testing.T) {
+	writeConfig(t, "services:\n  0: bad\n  70000: bad\n  8000: good\n")
+	cfg, warnings := Load()
+	if len(warnings) == 0 {
+		t.Fatal("expected warnings for out-of-range ports")
+	}
+	if _, ok := cfg.Services[0]; ok {
+		t.Error("port 0 should be removed")
+	}
+	if _, ok := cfg.Services[70000]; ok {
+		t.Error("port 70000 should be removed")
+	}
+	if cfg.Services[8000] != "good" {
+		t.Error("valid service should survive")
+	}
+}

--- a/internal/ports/service.go
+++ b/internal/ports/service.go
@@ -61,3 +61,15 @@ var wellKnownServices = map[int]string{
 func ServiceName(port int) string {
 	return wellKnownServices[port]
 }
+
+// RegisterServices merges user-supplied port->label mappings into the
+// well-known service table, overriding built-in entries on conflict. Empty
+// labels are ignored.
+func RegisterServices(m map[int]string) {
+	for port, name := range m {
+		if name == "" {
+			continue
+		}
+		wellKnownServices[port] = name
+	}
+}

--- a/internal/ports/service_test.go
+++ b/internal/ports/service_test.go
@@ -20,3 +20,28 @@ func TestServiceName(t *testing.T) {
 		}
 	}
 }
+
+func TestRegisterServices(t *testing.T) {
+	// Save and restore so we don't pollute other tests.
+	orig := make(map[int]string, len(wellKnownServices))
+	for k, v := range wellKnownServices {
+		orig[k] = v
+	}
+	t.Cleanup(func() { wellKnownServices = orig })
+
+	RegisterServices(map[int]string{
+		9000: "php-fpm", // new port
+		53:   "my-dns",  // override built-in
+		1234: "",        // empty name — must be skipped
+	})
+
+	if got := ServiceName(9000); got != "php-fpm" {
+		t.Errorf("ServiceName(9000) = %q, want php-fpm", got)
+	}
+	if got := ServiceName(53); got != "my-dns" {
+		t.Errorf("ServiceName(53) = %q, want my-dns (override)", got)
+	}
+	if got := ServiceName(1234); got != "" {
+		t.Errorf("ServiceName(1234) = %q, want empty (skipped)", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an optional `~/.config/sonar/config.yaml` for user defaults: `list.columns/sort/filter/all`, top-level `color`, and `services` (custom port→label entries that extend the well-known service-name table).
- Adds a `sonar config path|init|edit` subcommand (`init` writes a commented template and refuses to overwrite without `--force`; `edit` opens `$EDITOR`/`$VISUAL`/`vi`/`notepad`).
- Precedence is **explicit flag > config value > built-in default**, detected via cobra's `Flags().Changed`.
- New dependency-free `internal/config` package, modeled on the existing `internal/profile` package (reuses `gopkg.in/yaml.v3`).

## Behavior notes
- No config file → behavior is unchanged.
- Malformed YAML or invalid values (unknown column, bad sort/filter, out-of-range service port) print a warning to stderr and fall back to defaults — a command never errors out over config.
- `color: false` disables ANSI; `--no-color` and `NO_COLOR` still win; color is never force-enabled into a pipe.
- `all`/`filter` are resolved before the `--json` branch so JSON and table see the same rows; `columns`/`sort` are display-only and don't affect JSON.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (and `-race`) pass
- [x] Unit tests: config load/validate/template, `RegisterServices`, precedence helpers, `config init`
- [x] Manual: `config path/init/init-refuse`; `list` honors config columns/sort; `--columns` overrides config; malformed config warns + renders
- [ ] Reviewer: confirm `~/.config/sonar/config.yaml` precedence on your platform