### PR TITLE
fix(linux): parse ss process names that contain spaces

### DIFF
--- a/internal/ports/process_test.go
+++ b/internal/ports/process_test.go
@@ -1,0 +1,11 @@
+package ports
+
+import "testing"
+
+func TestKillPID_RejectsInvalidPID(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		if err := KillPID(pid, true); err == nil {
+			t.Errorf("KillPID(%d) succeeded, want error", pid)
+		}
+	}
+}

--- a/internal/ports/process_unix.go
+++ b/internal/ports/process_unix.go
@@ -9,6 +9,13 @@ import (
 
 // KillPID sends a signal to a process by PID.
 func KillPID(pid int, force bool) error {
+	// PID 0 is the caller's process group on Unix. Never signal it: a failed
+	// scan (PID left at 0) would SIGTERM/SIGKILL sonar itself instead of the
+	// intended listener.
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid PID %d", pid)
+	}
+
 	sig := syscall.SIGTERM
 	if force {
 		sig = syscall.SIGKILL

--- a/internal/ports/process_windows.go
+++ b/internal/ports/process_windows.go
@@ -11,6 +11,10 @@ import (
 
 // KillPID terminates a process by PID using taskkill.
 func KillPID(pid int, force bool) error {
+	if pid <= 0 {
+		return fmt.Errorf("refusing to signal invalid PID %d", pid)
+	}
+
 	args := []string{"/PID", strconv.Itoa(pid)}
 	if force {
 		args = append([]string{"/F"}, args...)

--- a/internal/ports/scan.go
+++ b/internal/ports/scan.go
@@ -223,25 +223,7 @@ func parseSS(output string) []ListeningPort {
 			ipVersion = "IPv6"
 		}
 
-		pid := 0
-		process := ""
-		for _, f := range fields {
-			if strings.HasPrefix(f, "users:") {
-				if pidIdx := strings.Index(f, "pid="); pidIdx >= 0 {
-					pidStr := f[pidIdx+4:]
-					if commaIdx := strings.IndexByte(pidStr, ','); commaIdx >= 0 {
-						pidStr = pidStr[:commaIdx]
-					}
-					pid, _ = strconv.Atoi(pidStr)
-				}
-				if nameStart := strings.Index(f, "((\""); nameStart >= 0 {
-					nameStr := f[nameStart+3:]
-					if nameEnd := strings.IndexByte(nameStr, '"'); nameEnd >= 0 {
-						process = nameStr[:nameEnd]
-					}
-				}
-			}
-		}
+		pid, process := parseSSUsers(line)
 
 		results = append(results, ListeningPort{
 			Port:        port,
@@ -253,4 +235,37 @@ func parseSS(output string) []ListeningPort {
 	}
 
 	return results
+}
+
+// parseSSUsers extracts the process name and PID from an ss -p users: blob.
+//
+// The blob must be read from the raw line, not from strings.Fields tokens.
+// Linux comm values can contain spaces (Next.js sets process.title to
+// "next-server (v…)", truncated to 15 bytes as "next-server (v1"), and
+// splitting on whitespace separates "users:(("name" from ",pid=N,fd=…)".
+func parseSSUsers(line string) (pid int, process string) {
+	usersIdx := strings.Index(line, "users:")
+	if usersIdx < 0 {
+		return 0, ""
+	}
+	blob := line[usersIdx:]
+
+	if pidIdx := strings.Index(blob, "pid="); pidIdx >= 0 {
+		pidStr := blob[pidIdx+4:]
+		end := 0
+		for end < len(pidStr) && pidStr[end] >= '0' && pidStr[end] <= '9' {
+			end++
+		}
+		if end > 0 {
+			pid, _ = strconv.Atoi(pidStr[:end])
+		}
+	}
+
+	if nameStart := strings.Index(blob, `(("`); nameStart >= 0 {
+		nameStr := blob[nameStart+3:]
+		if nameEnd := strings.IndexByte(nameStr, '"'); nameEnd >= 0 {
+			process = nameStr[:nameEnd]
+		}
+	}
+	return pid, process
 }

--- a/internal/ports/scan_test.go
+++ b/internal/ports/scan_test.go
@@ -46,6 +46,47 @@ node    1234 user    7u  IPv4  1234568      0t0  TCP *:3000 (LISTEN)
 	}
 }
 
+func TestParseSS_ProcessNameWithSpaces(t *testing.T) {
+	// Next.js sets process.title to "next-server (v16.2.6)"; Linux truncates
+	// comm to 15 bytes ("next-server (v1"), so ss -p emits a quoted name that
+	// contains a space. strings.Fields must not be used to parse that blob.
+	output := `State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+LISTEN 0      511    *:3011             *:*    users:(("next-server (v1",pid=113211,fd=22))
+LISTEN 0      128    127.0.0.1:3000     0.0.0.0:* users:(("node",pid=1234,fd=18))
+LISTEN 0      128    *:8080             *:*
+`
+	results := parseSS(output)
+	if len(results) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(results))
+	}
+
+	byPort := map[int]ListeningPort{}
+	for _, r := range results {
+		byPort[r.Port] = r
+	}
+
+	next := byPort[3011]
+	if next.PID != 113211 {
+		t.Errorf("port 3011 PID = %d, want 113211", next.PID)
+	}
+	if next.Process != "next-server (v1" {
+		t.Errorf("port 3011 process = %q, want %q", next.Process, "next-server (v1")
+	}
+	if next.BindAddress != "0.0.0.0" {
+		t.Errorf("port 3011 bind = %q, want 0.0.0.0", next.BindAddress)
+	}
+
+	node := byPort[3000]
+	if node.PID != 1234 || node.Process != "node" {
+		t.Errorf("port 3000 = pid %d name %q, want pid 1234 name node", node.PID, node.Process)
+	}
+
+	idle := byPort[8080]
+	if idle.PID != 0 || idle.Process != "" {
+		t.Errorf("port 8080 = pid %d name %q, want empty users blob", idle.PID, idle.Process)
+	}
+}
+
 func TestParseSS_MultipleBindsSamePort(t *testing.T) {
 	output := `State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process
 LISTEN 0      128    127.0.0.2:8080       0.0.0.0:*     users:(("nc",pid=1001,fd=3))


### PR DESCRIPTION
## What does this PR do?

On Linux, `parseSS` split `ss -tlnp` lines with `strings.Fields` and then only inspected a token that both started with `users:` and contained `pid=`.

Linux comm values can contain spaces. Next.js sets `process.title` to `next-server (v…)`, which truncates to 15 bytes as `next-server (v1`. `ss -p` then prints:

```
users:(("next-server (v1",pid=113211,fd=22))
```

That splits into `users:(("next-server` (no `pid=`) and `(v1",pid=113211,fd=22))` (not a `users:` token). The listener is recorded as PID 0 with an empty process name.

`sonar kill` / `sonar kill -f` then call `syscall.Kill(0, …)`. On Linux, PID 0 means the caller's process group, so sonar can SIGKILL itself (exit 137) while the Next.js server keeps listening.

This PR:

- Parses the `users:` blob from the **raw** `ss` line, so names with spaces keep `pid=` and the process name together.
- Rejects `KillPID` for PID `<= 0` so a failed scan cannot signal sonar's own process group.

## Related issue

Fixes #49

## How was this tested?

- Added `TestParseSS_ProcessNameWithSpaces` covering Next.js-style names, a no-space name, and a line with no `users:` blob.
- Added `TestKillPID_RejectsInvalidPID` so PID 0 / -1 return an error instead of signaling.
- `go test ./...` and `go vet ./...` on linux/amd64.

## Checklist

- [x] I have tested this on my platform (macOS / Linux)
- [x] My changes don't break existing functionality
- [x] I have updated documentation if needed