### PR TITLE
fix(ports): harden ss users parsing and guard unresolved PIDs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: raskrebs

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -87,6 +87,11 @@ var downCmd = &cobra.Command{
 					continue
 				}
 			} else {
+				if p.PID <= 0 {
+					errs = append(errs, fmt.Sprintf("port %d: could not resolve the listening process \u2014 re-run with sudo for full visibility", p.Port))
+					continue
+				}
+
 				sigName := "SIGTERM"
 				if downForceFlag {
 					sigName = "SIGKILL"

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -51,6 +51,10 @@ var killCmd = &cobra.Command{
 			return nil
 		}
 
+		if lp.PID <= 0 {
+			return fmt.Errorf("could not resolve the process listening on port %d \u2014 re-run with sudo for full visibility", port)
+		}
+
 		sigName := "SIGTERM"
 		if forceFlag {
 			sigName = "SIGKILL"

--- a/internal/cmd/killall.go
+++ b/internal/cmd/killall.go
@@ -85,6 +85,11 @@ Examples:
 					continue
 				}
 			} else {
+				if p.PID <= 0 {
+					errors = append(errors, fmt.Sprintf("port %d: could not resolve the listening process \u2014 re-run with sudo for full visibility", p.Port))
+					continue
+				}
+
 				sigName := "SIGTERM"
 				if killAllForceFlag {
 					sigName = "SIGKILL"

--- a/internal/ports/scan.go
+++ b/internal/ports/scan.go
@@ -237,35 +237,41 @@ func parseSS(output string) []ListeningPort {
 	return results
 }
 
-// parseSSUsers extracts the process name and PID from an ss -p users: blob.
+// parseSSUsers extracts the process name and PID from an ss -p users: blob,
+// which looks like:
+//
+//	users:(("nginx",pid=1234,fd=6),("nginx",pid=1235,fd=6))
 //
 // The blob must be read from the raw line, not from strings.Fields tokens.
 // Linux comm values can contain spaces (Next.js sets process.title to
 // "next-server (v…)", truncated to 15 bytes as "next-server (v1"), and
 // splitting on whitespace separates "users:(("name" from ",pid=N,fd=…)".
+//
+// The name is read first and the PID only from what follows it, so a process
+// title that itself contains "pid=" cannot be mistaken for the real PID. Only
+// the first entry is used; ss lists one per file descriptor.
 func parseSSUsers(line string) (pid int, process string) {
-	usersIdx := strings.Index(line, "users:")
-	if usersIdx < 0 {
+	nameStart := strings.Index(line, `users:(("`)
+	if nameStart < 0 {
 		return 0, ""
 	}
-	blob := line[usersIdx:]
+	entry := line[nameStart+len(`users:(("`):]
 
-	if pidIdx := strings.Index(blob, "pid="); pidIdx >= 0 {
-		pidStr := blob[pidIdx+4:]
-		end := 0
-		for end < len(pidStr) && pidStr[end] >= '0' && pidStr[end] <= '9' {
-			end++
-		}
-		if end > 0 {
-			pid, _ = strconv.Atoi(pidStr[:end])
-		}
+	nameEnd := strings.Index(entry, `",`)
+	if nameEnd < 0 {
+		return 0, ""
+	}
+	process = entry[:nameEnd]
+
+	// iproute2 before v4.0 omits the "pid=" label and prints a bare number.
+	rest := strings.TrimPrefix(entry[nameEnd+2:], "pid=")
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end > 0 {
+		pid, _ = strconv.Atoi(rest[:end])
 	}
 
-	if nameStart := strings.Index(blob, `(("`); nameStart >= 0 {
-		nameStr := blob[nameStart+3:]
-		if nameEnd := strings.IndexByte(nameStr, '"'); nameEnd >= 0 {
-			process = nameStr[:nameEnd]
-		}
-	}
 	return pid, process
 }

--- a/internal/ports/scan_test.go
+++ b/internal/ports/scan_test.go
@@ -87,6 +87,53 @@ LISTEN 0      128    *:8080             *:*
 	}
 }
 
+func TestParseSS_UsersBlobVariants(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantProcess string
+		wantPID     int
+	}{
+		{
+			name:        "one entry per file descriptor",
+			line:        `LISTEN 0      128    0.0.0.0:80    0.0.0.0:*    users:(("nginx",pid=1234,fd=6),("nginx",pid=1235,fd=6))`,
+			wantProcess: "nginx",
+			wantPID:     1234,
+		},
+		{
+			// A process title can contain anything, including "pid=". The real
+			// PID is the one after the closing quote, not the one in the name.
+			name:        "name containing pid=",
+			line:        `LISTEN 0      511    *:3011        *:*          users:(("worker pid=7",pid=99001,fd=22))`,
+			wantProcess: "worker pid=7",
+			wantPID:     99001,
+		},
+		{
+			name:        "iproute2 without pid label",
+			line:        `LISTEN 0      128    0.0.0.0:22    0.0.0.0:*    users:(("sshd",987,3))`,
+			wantProcess: "sshd",
+			wantPID:     987,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := "State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process\n" + tt.line + "\n"
+			results := parseSS(output)
+
+			if len(results) != 1 {
+				t.Fatalf("expected 1 entry, got %d", len(results))
+			}
+			if results[0].Process != tt.wantProcess {
+				t.Errorf("Process = %q, want %q", results[0].Process, tt.wantProcess)
+			}
+			if results[0].PID != tt.wantPID {
+				t.Errorf("PID = %d, want %d", results[0].PID, tt.wantPID)
+			}
+		})
+	}
+}
+
 func TestParseSS_MultipleBindsSamePort(t *testing.T) {
 	output := `State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process
 LISTEN 0      128    127.0.0.2:8080       0.0.0.0:*     users:(("nc",pid=1001,fd=3))


### PR DESCRIPTION
Follow-up to #50 (issue #49), plus a funding config.

## Parser

`parseSSUsers` searched the `users:` blob for `pid=` and for `((\"` independently, so a process title containing `pid=` won the race:

```
users:(("worker pid=7",pid=99001,fd=22))   ->   process="worker pid=7" pid=7
```

Since the whole bug class comes from unusual `process.title` values, the name is now read first and the PID only from what follows its closing quote. The `pid=` label is also treated as optional, so the pre-v4.0 iproute2 format (`users:(("sshd",987,3))`) resolves a PID instead of 0.

## Command layer

`sonar kill` on a listener whose PID could not be resolved printed `Killing  (PID 0) on port 3011 with SIGKILL` and only then failed in `KillPID`. `kill`, `killall` and `down` now stop first and point at sudo, matching the hint `list` already prints for hidden processes.

## Funding

Adds `.github/FUNDING.yml` for the Buy Me a Coffee sponsor button.

## Tests

`TestParseSS_UsersBlobVariants` covers multi-fd entries, a title containing `pid=`, and the unlabeled format. `go vet`, `go test ./...`, and linux/windows cross-builds pass.
