### PR TITLE
Feat/tagged runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ sonar-tray
 dist/
 install-local.sh
 .claude
+*.dash

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -24,6 +24,7 @@ var (
 	statsFlag      bool
 	ipv4Flag       bool
 	ipv6Flag       bool
+	tagFlag        string
 )
 
 var listCmd = &cobra.Command{
@@ -45,6 +46,7 @@ func init() {
 	listCmd.Flags().StringVar(&hostFlag, "host", "", "Scan a remote host via SSH (e.g. user@hostname)")
 	listCmd.Flags().BoolVarP(&ipv4Flag, "ipv4", "4", false, "Show only IPv4 ports")
 	listCmd.Flags().BoolVarP(&ipv6Flag, "ipv6", "6", false, "Show only IPv6 ports")
+	listCmd.Flags().StringVar(&tagFlag, "tag", "", "Show only ports attributed to this `sonar run` tag")
 	listCmd.MarkFlagsMutuallyExclusive("ipv4", "ipv6")
 	rootCmd.AddCommand(listCmd)
 }
@@ -93,6 +95,10 @@ func listRun(cmd *cobra.Command, args []string) error {
 		results = filterByIPVersion(results, "IPv4")
 	} else if ipv6Flag {
 		results = filterByIPVersion(results, "IPv6")
+	}
+
+	if tagFlag != "" {
+		results = filterByTag(results, tagFlag)
 	}
 
 	if jsonFlag {
@@ -187,6 +193,18 @@ func excludeApps(pp []ports.ListeningPort) []ports.ListeningPort {
 		}
 	}
 	return result
+}
+
+// filterByTag keeps only ports whose tag matches (also matching against the
+// run id, so callers can filter by either the human label or the stable id).
+func filterByTag(pp []ports.ListeningPort, tag string) []ports.ListeningPort {
+	var out []ports.ListeningPort
+	for _, p := range pp {
+		if p.Tag == tag || p.RunID == tag {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func filterByIPVersion(pp []ports.ListeningPort, ver string) []ports.ListeningPort {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/raskrebs/sonar/internal/runs"
+	"github.com/spf13/cobra"
+)
+
+var (
+	runTag string
+	runID  string
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run --tag <label> [--id <runid>] -- <command> [args...]",
+	Short: "Run a command, tagging its process so `sonar list` can attribute its ports",
+	Long: "Spawn <command> with inherited stdio (transparent passthrough) and record\n" +
+		"it in sonar's runs registry, keyed by PID. While it runs, `sonar list`\n" +
+		"attributes any port opened by it (or its descendants) to the given --tag.\n" +
+		"The registry entry is removed when the command exits.\n\n" +
+		"Everything after -- is the command and its arguments, passed through verbatim.",
+	// Args validated in RunE so we can give a clear message about the `--` separator.
+	Args:                  cobra.ArbitraryArgs,
+	DisableFlagsInUseLine: true,
+	RunE:                  runRun,
+}
+
+func init() {
+	runCmd.Flags().StringVar(&runTag, "tag", "", "Label to attribute this run's ports to (required)")
+	runCmd.Flags().StringVar(&runID, "id", "", "Stable caller-supplied id (default: generated short id)")
+	_ = runCmd.MarkFlagRequired("tag")
+	rootCmd.AddCommand(runCmd)
+}
+
+func runRun(cmd *cobra.Command, args []string) error {
+	// cobra hands us everything after `--` as args. Require a command.
+	if len(args) == 0 {
+		return errors.New("no command given; usage: sonar run --tag <label> -- <command> [args...]")
+	}
+
+	id := runID
+	if id == "" {
+		id = generateShortID()
+	}
+
+	// Spawn with inherited stdio in the caller's cwd/env (transparent passthrough).
+	child := exec.Command(args[0], args[1:]...)
+	child.Stdin = os.Stdin
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+	// Leave Dir/Env unset so the child inherits the caller's cwd and environment.
+
+	if err := child.Start(); err != nil {
+		return fmt.Errorf("failed to start %q: %w", args[0], err)
+	}
+
+	pid := child.Process.Pid
+	entry := runs.Entry{
+		PID: pid,
+		Tag: runTag,
+		ID:  id,
+		Cmd: strings.Join(args, " "),
+	}
+	if err := runs.Add(entry); err != nil {
+		// Non-fatal: the command should still run even if tagging failed.
+		fmt.Fprintf(os.Stderr, "sonar: warning: could not record run: %v\n", err)
+	}
+
+	// Always clean up the registry entry, regardless of how we exit.
+	defer func() {
+		if err := runs.Remove(pid); err != nil {
+			fmt.Fprintf(os.Stderr, "sonar: warning: could not remove run entry: %v\n", err)
+		}
+	}()
+
+	// Forward SIGINT/SIGTERM to the child so it can shut down cleanly; the wait
+	// below then observes the child's exit and we reap its registry entry.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		for sig := range sigCh {
+			if child.Process != nil {
+				_ = child.Process.Signal(sig)
+			}
+		}
+	}()
+
+	// Wait for the child and propagate its exit code.
+	err := child.Wait()
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// SilenceUsage/Errors so cobra doesn't print usage on a passthrough failure;
+		// we just mirror the child's exit code.
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		os.Exit(exitErr.ExitCode())
+	}
+	return fmt.Errorf("running %q: %w", args[0], err)
+}
+
+// generateShortID returns a short random hex id (8 chars) for runs without an
+// explicit --id. crypto/rand keeps it collision-resistant without a dep.
+func generateShortID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to a fixed-but-unique-ish id from the pid if rand fails.
+		return fmt.Sprintf("run%d", os.Getpid())
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/internal/cmd/runs.go
+++ b/internal/cmd/runs.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/runs"
+	"github.com/spf13/cobra"
+)
+
+var runsJSONFlag bool
+
+var runsCmd = &cobra.Command{
+	Use:   "runs",
+	Short: "List active tagged runs recorded by `sonar run`",
+	RunE:  runsRun,
+}
+
+func init() {
+	runsCmd.Flags().BoolVar(&runsJSONFlag, "json", false, "Output as JSON")
+	rootCmd.AddCommand(runsCmd)
+}
+
+func runsRun(cmd *cobra.Command, args []string) error {
+	// Load prunes dead pids, so what remains is the set of live tagged runs.
+	reg := runs.Load()
+	active := reg.Active()
+	sort.Slice(active, func(i, j int) bool { return active[i].PID < active[j].PID })
+
+	if runsJSONFlag {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(active)
+	}
+
+	if len(active) == 0 {
+		fmt.Println("No active tagged runs.")
+		return nil
+	}
+
+	fmt.Printf("%s   %s   %s   %s\n",
+		display.Bold("PID"), display.Bold("ID"), display.Bold("TAG"), display.Bold("CMD"))
+	for _, e := range active {
+		fmt.Printf("%-6d %-10s %-20s %s\n", e.PID, e.ID, display.Cyan(e.Tag), e.Cmd)
+	}
+	return nil
+}

--- a/internal/display/json.go
+++ b/internal/display/json.go
@@ -19,6 +19,10 @@ type JSONPort struct {
 	Type        string `json:"type"`
 	URL         string `json:"url"`
 
+	// Tagged-run attribution (set when spawned via `sonar run --tag`).
+	Tag   string `json:"tag,omitempty"`
+	RunID string `json:"run_id,omitempty"`
+
 	// Process stats
 	CPUPercent  float64 `json:"cpu_percent"`
 	MemoryRSS   int64   `json:"memory_rss_bytes"`
@@ -54,6 +58,8 @@ func RenderJSON(w io.Writer, pp []ports.ListeningPort) error {
 			IPVersion:            p.IPVersion,
 			Type:                 p.Type.String(),
 			URL:                  p.URL(),
+			Tag:                  p.Tag,
+			RunID:                p.RunID,
 			CPUPercent:           p.CPUPercent,
 			MemoryRSS:            p.MemoryRSS,
 			ThreadCount:          p.ThreadCount,

--- a/internal/display/table.go
+++ b/internal/display/table.go
@@ -22,6 +22,7 @@ var AllColumns = []string{
 	"container", "image", "containerport", "compose", "project",
 	"user", "bind", "ip",
 	"health", "latency",
+	"tag",
 }
 
 // TableOptions controls table rendering.
@@ -44,6 +45,13 @@ func RenderTable(w io.Writer, pp []ports.ListeningPort, opts TableOptions) {
 	cols := opts.Columns
 	if len(cols) == 0 {
 		cols = DefaultColumns
+		// Surface the TAG column automatically when at least one row carries a
+		// tag, but never bloat the default table when no `sonar run` is active.
+		if anyTagged(filtered) {
+			withTag := make([]string, len(cols), len(cols)+1)
+			copy(withTag, cols)
+			cols = append(withTag, "tag")
+		}
 	}
 
 	// Build header row
@@ -155,6 +163,8 @@ func columnLabel(col string) string {
 		return "HEALTH"
 	case "latency":
 		return "LATENCY"
+	case "tag":
+		return "TAG"
 	default:
 		return col
 	}
@@ -216,9 +226,24 @@ func columnValue(p ports.ListeningPort, col string) string {
 			return fmt.Sprintf("%dms", p.HealthLatency.Milliseconds())
 		}
 		return ""
+	case "tag":
+		if p.Tag != "" {
+			return Cyan(p.Tag)
+		}
+		return ""
 	default:
 		return ""
 	}
+}
+
+// anyTagged reports whether any port carries a tagged-run label.
+func anyTagged(pp []ports.ListeningPort) bool {
+	for _, p := range pp {
+		if p.Tag != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func colorProcess(p ports.ListeningPort) string {

--- a/internal/ports/displayname_signals.go
+++ b/internal/ports/displayname_signals.go
@@ -32,6 +32,11 @@ func enrichDisplayNameSignals(pp []ListeningPort) {
 	//    no exec), launchd label on macOS (one launchctl list call).
 	units := batchGetServiceUnits(pids)
 
+	// 4. Tagged-run attribution: load the runs registry once, then for each
+	//    listener walk its PPID ancestry (reusing the pidInfo map built above —
+	//    no extra exec) looking for an ancestor pid recorded by `sonar run`.
+	tagger := newRunTagger()
+
 	for i := range pp {
 		pid := pp[i].PID
 		if pid <= 0 {
@@ -47,6 +52,10 @@ func enrichDisplayNameSignals(pp []ListeningPort) {
 		}
 		if unit, ok := units[pid]; ok {
 			pp[i].ServiceUnit = unit
+		}
+		if tag, id, ok := tagger.lookup(pid, pidInfo); ok {
+			pp[i].Tag = tag
+			pp[i].RunID = id
 		}
 	}
 }

--- a/internal/ports/model.go
+++ b/internal/ports/model.go
@@ -40,6 +40,12 @@ type ListeningPort struct {
 	Type        PortType
 	IsApp       bool // true for desktop apps (Figma, Discord, etc.)
 
+	// Tagged-run attribution: set when this listener (or one of its ancestors)
+	// was spawned via `sonar run --tag`. Populated during Enrich by walking the
+	// PPID ancestry against the runs registry.
+	Tag   string // caller-supplied label
+	RunID string // caller-supplied (or generated) stable run id
+
 	// Process stats
 	CPUPercent  float64 // CPU usage percentage
 	MemoryRSS   int64   // resident set size in bytes

--- a/internal/ports/runtag.go
+++ b/internal/ports/runtag.go
@@ -1,0 +1,70 @@
+package ports
+
+import "github.com/raskrebs/sonar/internal/runs"
+
+// runTagger attributes a listening PID to a tagged `sonar run` by walking the
+// PPID ancestry: a dev server is typically a descendant of the `sonar run`
+// process (e.g. `sonar run -- npm` -> npm -> vite -> esbuild). If any ancestor
+// PID is in the runs registry, the listener inherits that entry's tag/id.
+//
+// Results are memoized per PID across the whole listener set, so an ancestry
+// chain shared by sibling listeners is only walked once.
+type runTagger struct {
+	reg   *runs.Registry
+	cache map[int]tagResult // pid -> resolved tag (including negative results)
+}
+
+type tagResult struct {
+	tag string
+	id  string
+	ok  bool
+}
+
+// newRunTagger loads (and prunes) the runs registry once. When the registry is
+// empty, lookups short-circuit so there is no per-PID work in the common case.
+func newRunTagger() *runTagger {
+	return &runTagger{
+		reg:   runs.Load(),
+		cache: make(map[int]tagResult),
+	}
+}
+
+// lookup resolves the tag for a listener PID by walking up its ancestry using
+// the already-collected pidInfo map (pid -> {ppid, cmd}). No syscalls/exec are
+// performed here: the parent map is reused, and per-PID results are cached.
+func (t *runTagger) lookup(pid int, pidInfo map[int]pidEntry) (string, string, bool) {
+	if t == nil || len(t.reg.Runs) == 0 {
+		return "", "", false
+	}
+	return t.walk(pid, pidInfo, 0)
+}
+
+// walk recurses up the PPID chain, caching every PID it visits (positive and
+// negative) so shared ancestry is only resolved once. A depth bound guards
+// against pathological / cyclic process tables.
+func (t *runTagger) walk(pid int, pidInfo map[int]pidEntry, depth int) (string, string, bool) {
+	if pid <= 1 || depth > 64 {
+		return "", "", false
+	}
+	if cached, ok := t.cache[pid]; ok {
+		return cached.tag, cached.id, cached.ok
+	}
+
+	// Direct hit: this PID is itself a tagged run.
+	if e, ok := t.reg.LookupByPID(pid); ok {
+		res := tagResult{tag: e.Tag, id: e.ID, ok: true}
+		t.cache[pid] = res
+		return res.tag, res.id, res.ok
+	}
+
+	// Otherwise climb to the parent.
+	info, ok := pidInfo[pid]
+	if !ok || info.ppid <= 1 || info.ppid == pid {
+		t.cache[pid] = tagResult{}
+		return "", "", false
+	}
+	tag, id, found := t.walk(info.ppid, pidInfo, depth+1)
+	res := tagResult{tag: tag, id: id, ok: found}
+	t.cache[pid] = res
+	return res.tag, res.id, res.ok
+}

--- a/internal/ports/runtag_test.go
+++ b/internal/ports/runtag_test.go
@@ -1,0 +1,97 @@
+package ports
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/runs"
+)
+
+// setupRegistry points HOME at a temp dir and seeds the runs registry with the
+// given entries, returning nothing (Load reads from HOME).
+func setupRegistry(t *testing.T, entries ...runs.Entry) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	for _, e := range entries {
+		if err := runs.Add(e); err != nil {
+			t.Fatalf("seed registry: %v", err)
+		}
+	}
+}
+
+func TestRunTagger_AncestryWalk(t *testing.T) {
+	// `sonar run` pid 100 (tag "demo") -> npm 200 -> vite 300 -> esbuild 400.
+	// The listener is esbuild (400); it should inherit the tag via ancestry.
+	// Use our own pid as the tagged-run pid so the registry prune keeps it alive.
+	runPID := os.Getpid()
+	setupRegistry(t, runs.Entry{PID: runPID, Tag: "demo", ID: "chg-1", Cmd: "npm run dev"})
+
+	pidInfo := map[int]pidEntry{
+		runPID: {ppid: 1, cmd: "sonar run"},
+		200:    {ppid: runPID, cmd: "npm run dev"},
+		300:    {ppid: 200, cmd: "vite"},
+		400:    {ppid: 300, cmd: "esbuild"},
+		// An unrelated process tree, should NOT be tagged.
+		500: {ppid: 1, cmd: "redis-server"},
+	}
+
+	tagger := newRunTagger()
+
+	tag, id, ok := tagger.lookup(400, pidInfo)
+	if !ok || tag != "demo" || id != "chg-1" {
+		t.Fatalf("descendant listener: got (%q,%q,%v), want (demo,chg-1,true)", tag, id, ok)
+	}
+
+	// Direct hit on the run pid itself.
+	if tag, _, ok := tagger.lookup(runPID, pidInfo); !ok || tag != "demo" {
+		t.Errorf("direct pid: got (%q,%v), want (demo,true)", tag, ok)
+	}
+
+	// Unrelated tree is untagged.
+	if _, _, ok := tagger.lookup(500, pidInfo); ok {
+		t.Error("unrelated process should not be tagged")
+	}
+}
+
+func TestRunTagger_EmptyRegistryShortCircuits(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no runs.json
+	tagger := newRunTagger()
+	pidInfo := map[int]pidEntry{42: {ppid: 1, cmd: "x"}}
+	if _, _, ok := tagger.lookup(42, pidInfo); ok {
+		t.Error("empty registry should yield no tag")
+	}
+}
+
+func TestRunTagger_CachesNegativeAndPositive(t *testing.T) {
+	runPID := os.Getpid()
+	setupRegistry(t, runs.Entry{PID: runPID, Tag: "t"})
+	tagger := newRunTagger()
+	pidInfo := map[int]pidEntry{
+		runPID: {ppid: 1, cmd: "sonar run"},
+		10:     {ppid: runPID, cmd: "child"},
+		20:     {ppid: 1, cmd: "other"},
+	}
+	// Resolve a descendant (positive) and an unrelated (negative).
+	tagger.lookup(10, pidInfo)
+	tagger.lookup(20, pidInfo)
+	if res, ok := tagger.cache[10]; !ok || !res.ok {
+		t.Error("positive result not cached")
+	}
+	if res, ok := tagger.cache[20]; !ok || res.ok {
+		t.Error("negative result not cached")
+	}
+}
+
+func TestRunTagger_CycleGuard(t *testing.T) {
+	runPID := os.Getpid()
+	setupRegistry(t, runs.Entry{PID: runPID, Tag: "t"})
+	tagger := newRunTagger()
+	// Pathological cycle: 10 <-> 11, neither in registry. Must terminate.
+	pidInfo := map[int]pidEntry{
+		10: {ppid: 11, cmd: "a"},
+		11: {ppid: 10, cmd: "b"},
+	}
+	if _, _, ok := tagger.lookup(10, pidInfo); ok {
+		t.Error("cycle should not produce a tag")
+	}
+}

--- a/internal/runs/alive_unix.go
+++ b/internal/runs/alive_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package runs
+
+import "syscall"
+
+// pidAlive reports whether a process with the given PID currently exists.
+// Signal 0 performs error checking without actually sending a signal: a nil
+// error (or EPERM, meaning the process exists but we can't signal it) means the
+// process is alive; ESRCH means it's gone.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return err == syscall.EPERM
+}

--- a/internal/runs/alive_windows.go
+++ b/internal/runs/alive_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package runs
+
+import "os/exec"
+
+// pidAlive reports whether a process with the given PID currently exists.
+// Best-effort on Windows: query tasklist for the PID and check for output.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	out, err := exec.Command("tasklist", "/FI", "PID eq "+itoa(pid), "/NH").Output()
+	if err != nil {
+		// If we can't tell, assume alive so we don't prematurely prune.
+		return true
+	}
+	return len(out) > 0 && !containsNoTasks(string(out))
+}
+
+func containsNoTasks(s string) bool {
+	// tasklist prints "INFO: No tasks are running..." when the PID is gone.
+	for i := 0; i+4 < len(s); i++ {
+		if s[i] == 'N' && s[i+1] == 'o' && s[i+2] == ' ' && s[i+3] == 't' {
+			return true
+		}
+	}
+	return false
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		b[pos] = '-'
+	}
+	return string(b[pos:])
+}

--- a/internal/runs/lock.go
+++ b/internal/runs/lock.go
@@ -1,0 +1,63 @@
+package runs
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// withLock runs fn while holding an exclusive sidecar lock on the registry.
+// The lock is an O_CREATE|O_EXCL file: whoever creates it wins. We spin with a
+// short backoff and treat a sufficiently old lock file as stale (a previous
+// holder that crashed before unlocking) so the registry can never deadlock.
+//
+// This is intentionally lightweight: contention is rare (only concurrent
+// `sonar run` start/stop), holds are sub-millisecond (read+write a tiny file),
+// and the cost of an occasional double-write is just a redundant atomic save.
+func withLock(fn func() error) error {
+	lp := lockPath()
+	if err := os.MkdirAll(parentDir(lp), 0o755); err != nil {
+		return fmt.Errorf("runs: could not create config dir: %w", err)
+	}
+
+	const (
+		maxWait     = 2 * time.Second
+		staleAfter  = 5 * time.Second
+		pollBackoff = 5 * time.Millisecond
+	)
+	deadline := time.Now().Add(maxWait)
+
+	for {
+		f, err := os.OpenFile(lp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err == nil {
+			f.Close()
+			defer os.Remove(lp)
+			return fn()
+		}
+		if !os.IsExist(err) {
+			return fmt.Errorf("runs: acquire lock: %w", err)
+		}
+		// Lock held by someone else. Break a stale lock left by a crash.
+		if info, statErr := os.Stat(lp); statErr == nil {
+			if time.Since(info.ModTime()) > staleAfter {
+				os.Remove(lp)
+				continue
+			}
+		}
+		if time.Now().After(deadline) {
+			// Give up waiting and force the lock so we never block forever.
+			os.Remove(lp)
+			continue
+		}
+		time.Sleep(pollBackoff)
+	}
+}
+
+func parentDir(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' || p[i] == '\\' {
+			return p[:i]
+		}
+	}
+	return "."
+}

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -1,0 +1,168 @@
+// Package runs implements the tagged-runs registry: a small on-disk JSON file
+// recording processes spawned via `sonar run`, keyed by PID. Each entry carries
+// a caller-supplied tag (and optional stable id) so that `sonar list` can
+// attribute listening ports back to whoever started them.
+//
+// The registry lives next to sonar's config (e.g. ~/.config/sonar/runs.json).
+// Writes are serialized with a sidecar lock file and an atomic rename so that
+// multiple concurrent `sonar run` invocations don't clobber each other.
+package runs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Entry is a single tagged run, keyed in the registry by its PID.
+type Entry struct {
+	PID       int    `json:"pid"`
+	Tag       string `json:"tag"`
+	ID        string `json:"id,omitempty"`
+	Cmd       string `json:"cmd,omitempty"`
+	StartedAt string `json:"startedAt,omitempty"` // RFC3339
+}
+
+// Registry is the in-memory view of the on-disk runs file: pid -> entry.
+type Registry struct {
+	Runs map[int]Entry `json:"runs"`
+}
+
+// Path returns the absolute path to the runs registry file. It mirrors the
+// config package's layout (~/.config/sonar) without importing it, to avoid a
+// dependency cycle and to keep this package self-contained.
+func Path() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".config", "sonar", "runs.json")
+}
+
+// lockPath returns the sidecar lock file path for the registry.
+func lockPath() string {
+	return Path() + ".lock"
+}
+
+// load reads the registry from path without pruning. A missing file yields an
+// empty registry. A malformed file is treated as empty (best-effort recovery)
+// rather than an error, so a corrupted registry never breaks `sonar list`.
+func load() *Registry {
+	reg := &Registry{Runs: map[int]Entry{}}
+	data, err := os.ReadFile(Path())
+	if err != nil {
+		return reg
+	}
+	if err := json.Unmarshal(data, reg); err != nil || reg.Runs == nil {
+		return &Registry{Runs: map[int]Entry{}}
+	}
+	return reg
+}
+
+// Load reads the registry and prunes entries whose PID is no longer alive
+// (stale after a crash or hard kill). Pruned entries are written back to disk
+// so the file self-heals. Pruning failures to persist are ignored.
+func Load() *Registry {
+	reg := load()
+	pruned := false
+	for pid := range reg.Runs {
+		if !pidAlive(pid) {
+			delete(reg.Runs, pid)
+			pruned = true
+		}
+	}
+	if pruned {
+		_ = withLock(func() error {
+			// Re-read under lock and re-prune to avoid racing a concurrent add.
+			fresh := load()
+			for pid := range fresh.Runs {
+				if !pidAlive(pid) {
+					delete(fresh.Runs, pid)
+				}
+			}
+			reg = fresh
+			return save(fresh)
+		})
+	}
+	return reg
+}
+
+// LookupByPID returns the entry for a PID if present.
+func (r *Registry) LookupByPID(pid int) (Entry, bool) {
+	e, ok := r.Runs[pid]
+	return e, ok
+}
+
+// Active returns all live entries (pruning is already applied by Load).
+func (r *Registry) Active() []Entry {
+	out := make([]Entry, 0, len(r.Runs))
+	for _, e := range r.Runs {
+		out = append(out, e)
+	}
+	return out
+}
+
+// Add records (or replaces) an entry for e.PID, atomically and under lock.
+func Add(e Entry) error {
+	if e.PID <= 0 {
+		return fmt.Errorf("runs: invalid pid %d", e.PID)
+	}
+	if e.StartedAt == "" {
+		e.StartedAt = time.Now().Format(time.RFC3339)
+	}
+	return withLock(func() error {
+		reg := load()
+		reg.Runs[e.PID] = e
+		return save(reg)
+	})
+}
+
+// Remove deletes the entry for pid, atomically and under lock. Removing a
+// missing pid is a no-op.
+func Remove(pid int) error {
+	return withLock(func() error {
+		reg := load()
+		if _, ok := reg.Runs[pid]; !ok {
+			return nil
+		}
+		delete(reg.Runs, pid)
+		return save(reg)
+	})
+}
+
+// save writes the registry atomically: marshal -> temp file -> rename. Callers
+// must already hold the lock (see withLock).
+func save(reg *Registry) error {
+	path := Path()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("runs: could not create config dir: %w", err)
+	}
+	if reg.Runs == nil {
+		reg.Runs = map[int]Entry{}
+	}
+	data, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("runs: marshal: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".runs-*.json")
+	if err != nil {
+		return fmt.Errorf("runs: temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("runs: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("runs: close: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("runs: rename: %w", err)
+	}
+	return nil
+}

--- a/internal/runs/runs_test.go
+++ b/internal/runs/runs_test.go
@@ -1,0 +1,130 @@
+package runs
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fakehome")
+	want := filepath.Join("/tmp/fakehome", ".config", "sonar", "runs.json")
+	if got := Path(); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	reg := Load()
+	if reg == nil || reg.Runs == nil {
+		t.Fatal("Load() of missing file should yield empty registry, not nil")
+	}
+	if len(reg.Runs) != 0 {
+		t.Errorf("missing file should yield empty registry, got %+v", reg.Runs)
+	}
+}
+
+func TestAddSaveLoadRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Use our own (live) pid so prune doesn't drop it.
+	self := os.Getpid()
+	if err := Add(Entry{PID: self, Tag: "demo", ID: "abc123", Cmd: "python -m http.server"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	reg := Load()
+	e, ok := reg.LookupByPID(self)
+	if !ok {
+		t.Fatalf("entry for pid %d not found after Add", self)
+	}
+	if e.Tag != "demo" || e.ID != "abc123" {
+		t.Errorf("round-trip mismatch: got %+v", e)
+	}
+	if e.StartedAt == "" {
+		t.Error("Add should stamp StartedAt")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	self := os.Getpid()
+	if err := Add(Entry{PID: self, Tag: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(self); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, ok := Load().LookupByPID(self); ok {
+		t.Error("entry still present after Remove")
+	}
+	// Removing a missing pid is a no-op.
+	if err := Remove(999999); err != nil {
+		t.Errorf("Remove of missing pid should be no-op, got %v", err)
+	}
+}
+
+func TestLoadPrunesDeadPIDs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// A live pid (ours) and a dead pid (a process we start then reap).
+	self := os.Getpid()
+	dead := spawnAndReap(t)
+
+	if err := Add(Entry{PID: self, Tag: "live"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Add(Entry{PID: dead, Tag: "dead"}); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := Load()
+	if _, ok := reg.LookupByPID(self); !ok {
+		t.Errorf("live pid %d was pruned", self)
+	}
+	if _, ok := reg.LookupByPID(dead); ok {
+		t.Errorf("dead pid %d should have been pruned", dead)
+	}
+
+	// Prune should have persisted: re-reading the file shows only the live pid.
+	reg2 := load()
+	if _, ok := reg2.Runs[dead]; ok {
+		t.Error("dead pid not removed from disk after prune")
+	}
+}
+
+func TestLoadMalformedFileRecovers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "sonar")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "runs.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := Load()
+	if reg == nil || reg.Runs == nil || len(reg.Runs) != 0 {
+		t.Errorf("malformed file should recover to empty registry, got %+v", reg)
+	}
+}
+
+// spawnAndReap starts a trivial short-lived process, waits for it to exit, and
+// returns its (now-dead) pid.
+func spawnAndReap(t *testing.T) int {
+	t.Helper()
+	c := exec.Command("true")
+	if err := c.Start(); err != nil {
+		// Fall back to a portable no-op if `true` is unavailable.
+		c = exec.Command("sh", "-c", "exit 0")
+		if err := c.Start(); err != nil {
+			t.Skipf("cannot spawn helper process: %v", err)
+		}
+	}
+	pid := c.Process.Pid
+	_ = c.Wait()
+	return pid
+}


### PR DESCRIPTION
## Related issue
None

## How was this tested?

- `go build ./...`, `go vet ./...` and `go test ./...` green — new test files across
  `internal/state`, `internal/daemon/rpc`, `internal/install`, `internal/hooks`,
  `internal/ports` and `internal/display`.
- **Schema gate:** `go generate ./... && git diff --exit-code docs/schema` is clean,
  i.e. the committed schema reproduces exactly from the Go types.
- **Real output validates:** captured live `sonar list --json` (11 rows on my machine)
  and validated it against `docs/schema/protocol.schema.json#/definitions/Port`.
- **Tray:** `swiftc -parse` passes, and the decoder was exercised against both real new
  output and a synthetic pre-change payload — both decode.
- **Installers:** table tests against a temp `HOME` and temp git root cover create,
  merge-preserving-other-servers, idempotent re-run, uninstall, and `--print` writing
  nothing. Then smoke-tested the real binary in a scratch repo: all three installers
  write their files, coexist, and re-running each is a no-op.
- **Hook matcher** probed directly: fires on `npm run dev`, `pnpm dev`, `vite`,
  `next dev`, `uv run uvicorn app:app`, `python -m http.server 8000`; stays silent on
  `npm run build`, `uv run pytest`, `vite --version`, `git commit -m dev`,
  `go test ./...` and `echo npm run dev`.
- **Skill and hooks end-to-end** against real nested Claude Code sessions: the skill is
  listed by a fresh session, and `npm run dev` is allowed to run with sonar's suggestion
  attached. That run is what caught `vite --version` firing, fixed in 2c49064.

## Checklist
- [x] I have tested this on my platform (macOS / Linux)
- [x] My changes don't break existing functionality
- [ ] I have updated documentation if needed