### PR TITLE
doc: make the kill dry-run example act only on a listener it starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,12 +298,18 @@ sonar kill -g my-app                       # a whole group, confirms unless -y
 sonar kill --all --filter docker -y        # every container publishing a port
 sonar kill --all --project my-app          # one Compose project
 sonar kill 3000 --ip 127.0.0.1             # one bind address of several
+sonar kill --all --dry-run --json          # the plan for the whole machine
 ```
 
-Show the plan and change nothing:
+`--dry-run` takes any selector and changes nothing: it prints the actions the
+kill would take, children first, and leaves everything running. End to end,
+against a listener of your own:
 
 ```sh
-sonar kill --all --dry-run --json
+sonar start --detach --name plan --port 8231 -- sonar map 3000 8231
+sonar wait 8231
+sonar kill 8231 --dry-run --json           # the plan; the mapping keeps running
+sonar kill 8231 -y                         # and now for real
 # check
 ```
 

--- a/scripts/readme-check.sh
+++ b/scripts/readme-check.sh
@@ -59,14 +59,18 @@ cd "$(cd "$project" && pwd -P)"
 # collected, and kept only if one of its lines is the `# check` marker.
 blocks=$work/blocks
 mkdir -p "$blocks"
-awk -v out="$blocks" '
-  /^```sh$/ && !inblock { inblock = 1; n = 0; checked = 0; next }
+awk -v out="$blocks" -v src="$readme" '
+  /^```sh$/ && !inblock { inblock = 1; n = 0; checked = 0; first = NR + 1; next }
   /^```/ && inblock {
     if (checked) {
       count++
       file = sprintf("%s/%03d.sh", out, count)
       for (i = 1; i <= n; i++) print body[i] > file
       close(file)
+      # Where the block lives, so a failure in CI names the lines to edit.
+      where = sprintf("%s/%03d.where", out, count)
+      printf "%s:%d-%d\n", src, first, NR - 1 > where
+      close(where)
     }
     inblock = 0
     next
@@ -90,8 +94,12 @@ for file in "${files[@]}"; do
   if output=$(bash -euo pipefail "$file" 2>&1); then
     printf 'ok   %s\n' "$name"
   else
+    status=$?
     failed=$((failed + 1))
-    printf 'FAIL %s\n' "$name"
+    printf 'FAIL %s (exit %d)\n' "$name" "$status"
+    # The block itself first, then what it printed: a CI log is the only thing
+    # anyone reads after a failure, and it has to be diagnosable on its own.
+    printf '     --- %s ---\n' "$(cat "${file%.sh}.where")"
     sed 's/^/     | /' "$file"
     printf '     --- output ---\n'
     printf '%s\n' "$output" | sed 's/^/     | /'


### PR DESCRIPTION
The README check failed on the Linux runner because `sonar kill --all --dry-run --json` swept the runner's root-owned listeners (sshd on 22, systemd-resolved on 53), which an unprivileged scan cannot resolve, so the dry run exited 1.

The checked example now starts its own listener with `sonar start --detach` (a `sonar map` so no interpreter is needed), waits for it, shows the dry-run plan, and kills it. The `--all` form stays documented in the unchecked example list.

`scripts/readme-check.sh` now prints the failing block's source location and exit code above its output.

Follow-up (not in this PR): a dry run should not report root-owned listeners as `permission_denied` failures; it changes nothing, so it should list them with `ok: false` only when the real kill would fail, or note them as unresolved without failing the command.