### PR TITLE
fix: make the daemon integration suite pass on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# The checked-in protocol schema is compared byte for byte against what
+# `go generate ./...` writes, so it has to reach every checkout with the line
+# endings it was generated with — a Windows checkout with core.autocrlf=true
+# would otherwise fail the freshness test on line endings alone.
+docs/schema/*.json text eol=lf
+
+# Go source is gofmt'd with LF and `gofmt -l` is a CI gate.
+*.go text eol=lf

--- a/README.md
+++ b/README.md
@@ -298,12 +298,18 @@ sonar kill -g my-app                       # a whole group, confirms unless -y
 sonar kill --all --filter docker -y        # every container publishing a port
 sonar kill --all --project my-app          # one Compose project
 sonar kill 3000 --ip 127.0.0.1             # one bind address of several
+sonar kill --all --dry-run --json          # the plan for the whole machine
 ```
 
-Show the plan and change nothing:
+`--dry-run` takes any selector and changes nothing: it prints the actions the
+kill would take, children first, and leaves everything running. End to end,
+against a listener of your own:
 
 ```sh
-sonar kill --all --dry-run --json
+sonar start --detach --name plan --port 8231 -- sonar map 3000 8231
+sonar wait 8231
+sonar kill 8231 --dry-run --json           # the plan; the mapping keeps running
+sonar kill 8231 -y                         # and now for real
 # check
 ```
 

--- a/internal/daemon/groups_config_test.go
+++ b/internal/daemon/groups_config_test.go
@@ -92,10 +92,12 @@ func TestGroupsConfigGetByName(t *testing.T) {
 func TestGroupsConfigGetByPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// Claimed before the harness so the harness stops before the directory it
+	// has indexed is removed.
+	dir := resolvedDir(t, t.TempDir())
 	h := newHarness(t, ctx)
 	c := h.dial(ctx)
 
-	dir := resolvedDir(t, t.TempDir())
 	path := filepath.Join(dir, groups.ConfigName)
 	if err := os.WriteFile(path, []byte(configFixture), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/daemon/handlers_store_test.go
+++ b/internal/daemon/handlers_store_test.go
@@ -17,8 +17,12 @@ import (
 // listening, which is what every write path needs.
 func storeHarness(t *testing.T, ctx context.Context, rows ...ports.ListeningPort) (*testHarness, *store.Store) {
 	t.Helper()
+	// The temp directory is claimed first so its removal is the last cleanup
+	// to run: the harness holds the database inside it and has to close it
+	// before anything deletes the file.
+	db := filepath.Join(t.TempDir(), "sonar.db")
 	h := newHarness(t, ctx)
-	st := h.withStore(filepath.Join(t.TempDir(), "sonar.db"))
+	st := h.withStore(db)
 	if len(rows) == 0 {
 		rows = []ports.ListeningPort{{
 			Port: 8123, PID: 42, Process: "python3", Command: "python3 -m http.server",

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -22,12 +22,14 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/raskrebs/sonar/internal/daemon"
 	"github.com/raskrebs/sonar/internal/daemon/client"
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/runs"
 	"github.com/raskrebs/sonar/internal/state"
 )
 
@@ -90,9 +92,51 @@ func newEnv(t *testing.T) *env {
 
 	socket := filepath.Join(sockDir, "d.sock")
 	if runtime.GOOS == "windows" {
-		socket = fmt.Sprintf(`\\.\pipe\sonar-itest-%d`, os.Getpid())
+		// Named pipes share one flat namespace, so the pipe is numbered as
+		// well as pid-stamped: two envs in one test binary must not land on
+		// the same address, or a daemon still shutting down from an earlier
+		// test owns the name this one is about to bind.
+		socket = fmt.Sprintf(`\\.\pipe\sonar-itest-%d-%d`, os.Getpid(), pipeSeq.Add(1))
 	}
 	return &env{t: t, bin: bin, home: home, socket: socket}
+}
+
+// pipeSeq numbers this test binary's named pipes.
+var pipeSeq atomic.Int64
+
+// lockPath is where this env's daemon takes its single-instance lock: beside
+// the socket, or in the config dir when the transport is a named pipe
+// (contract §15).
+func (e *env) lockPath() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(e.home, ".config", "sonar", "daemon.lock")
+	}
+	return filepath.Join(filepath.Dir(e.socket), "daemon.lock")
+}
+
+// stopDaemon stops a daemon this env started detached and waits until it is
+// really gone, not merely unreachable.
+//
+// Windows refuses to delete a file another process still has open, so a test
+// whose temp HOME holds the daemon's lock and log has to see that process exit
+// before t.TempDir's own cleanup runs — otherwise the test fails in teardown
+// with "the process cannot access the file because it is being used by another
+// process". pid may be 0 when the caller does not know it; the socket and the
+// lock are then the only evidence.
+func (e *env) stopDaemon(pid int) {
+	_ = e.command("daemon", "stop").Run()
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if !daemon.SocketAlive(e.socket) && (pid <= 0 || !runs.PIDAlive(pid)) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// The lock is the last thing a daemon lets go of.
+	if err := daemon.WaitForLockRelease(e.lockPath(), 10*time.Second); err != nil {
+		e.t.Logf("the daemon still holds %s: %v", e.lockPath(), err)
+	}
 }
 
 // command builds a `sonar` invocation pinned to this env.
@@ -399,10 +443,12 @@ func TestAutostart(t *testing.T) {
 	if c.Hello().PID <= 0 {
 		t.Errorf("autostarted daemon reported pid %d", c.Hello().PID)
 	}
-	t.Cleanup(func() {
-		var ok rpc.OKResult
-		_ = c.Call(context.Background(), "daemon.shutdown", rpc.Empty{}, &ok)
-	})
+	// The daemon autostart created is detached: nothing else in this test owns
+	// it. Cleanups run after the test's own defers, so this one cannot reuse c
+	// (already closed) — it stops the daemon through the CLI and waits for the
+	// process, so the temp HOME it holds the lock and log in can be removed.
+	daemonPID := c.Hello().PID
+	t.Cleanup(func() { e.stopDaemon(daemonPID) })
 
 	var snap state.Snapshot
 	if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{}, &snap); err != nil {
@@ -434,7 +480,7 @@ func TestDaemonRestartIsRepeatable(t *testing.T) {
 	e.serve()
 	// After the first restart the daemon is detached, so the env's own cleanup
 	// (which kills the foreground child) no longer owns it.
-	t.Cleanup(func() { _ = e.command("daemon", "stop").Run() })
+	t.Cleanup(func() { e.stopDaemon(0) })
 
 	lastPID := ""
 	for i := 1; i <= 5; i++ {
@@ -465,7 +511,7 @@ func TestDaemonRestartIsRepeatable(t *testing.T) {
 		// replacement raced the old daemon's teardown the lock file was left
 		// holding a dead pid, or removed from under the live daemon.
 		if runtime.GOOS != "windows" {
-			lockPath := filepath.Join(filepath.Dir(e.socket), "daemon.lock")
+			lockPath := e.lockPath()
 			if holder := daemon.LockHolderPID(lockPath); fmt.Sprint(holder) != pid {
 				t.Errorf("after restart %d the lock at %s records pid %d, but the daemon reports pid %s",
 					i, lockPath, holder, pid)

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -95,9 +95,16 @@ func newEnv(t *testing.T) *env {
 	return &env{t: t, bin: bin, home: home, socket: socket}
 }
 
+// waitDelay bounds how long Wait may block on a pipe after the process it was
+// waiting for has exited. A stray grandchild holding the inherited stdout
+// keeps that pipe open forever, so without this a test that has already failed
+// hangs until `go test -timeout` shoots it.
+const waitDelay = 5 * time.Second
+
 // command builds a `sonar` invocation pinned to this env.
 func (e *env) command(args ...string) *exec.Cmd {
 	cmd := exec.Command(e.bin, args...)
+	cmd.WaitDelay = waitDelay
 	cmd.Env = append(os.Environ(),
 		"HOME="+e.home,
 		"USERPROFILE="+e.home,
@@ -114,14 +121,12 @@ func (e *env) serve() *exec.Cmd {
 	cmd := e.command("serve")
 	var out strings.Builder
 	cmd.Stdout, cmd.Stderr = &out, &out
+	ownProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		e.t.Fatalf("starting sonar serve: %v", err)
 	}
 	e.t.Cleanup(func() {
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-		}
+		stopCommand(cmd)
 		if e.t.Failed() && out.Len() > 0 {
 			e.t.Logf("daemon output:\n%s", out.String())
 		}

--- a/internal/daemon/kill_handlers.go
+++ b/internal/daemon/kill_handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/scanner"
 	"github.com/raskrebs/sonar/internal/state"
 )
@@ -50,6 +51,7 @@ func handlePortsKill(ctx context.Context, req *Request) (any, error) {
 		Grace:    time.Duration(p.GraceMs) * time.Millisecond,
 		Escalate: p.Escalate,
 		DryRun:   p.DryRun,
+		Ports:    killerRows(snap),
 	}
 	rows := killer.KillPorts(ctx, targets, opts)
 	afterKill(req, opts.DryRun)
@@ -84,6 +86,7 @@ func handleGroupsKill(ctx context.Context, req *Request) (any, error) {
 		Force:  p.Force,
 		Grace:  time.Duration(p.GraceMs) * time.Millisecond,
 		DryRun: p.DryRun,
+		Ports:  killerRows(snap),
 	}
 	rows := killer.KillPorts(ctx, targets, opts)
 	afterKill(req, opts.DryRun)
@@ -116,6 +119,25 @@ func killSnapshot(req *Request) (state.Snapshot, error) {
 			"check `sonar daemon log` for the scanner error")
 	}
 	return snap, nil
+}
+
+// killerRows hands the killer the scan the handler just took.
+//
+// Without it killer.KillPorts scans the machine again from inside the RPC, so
+// one `ports.kill` cost two full scans: the §25 rescan-before-select and the
+// killer's own. The second one is pure duplication — the rows are the same
+// enriched pipeline (ports.Scan + Docker + Enrich) the daemon's scanner ran a
+// moment earlier — and it is what made a dry run of an unknown port take
+// seconds. Every other caller of the killer (`sonar kill`, `kill-all`, `down`)
+// already passes the snapshot it resolved its targets against; the daemon now
+// does the same, which is also what keeps the two paths' output identical.
+func killerRows(snap state.Snapshot) []ports.ListeningPort {
+	rows := state.ToListeningAll(snap.Ports)
+	if rows == nil {
+		// Never nil: a nil slice tells the killer to go and scan for itself.
+		rows = []ports.ListeningPort{}
+	}
+	return rows
 }
 
 // selectorTarget validates one wire selector and turns it into a killer target.

--- a/internal/daemon/kill_handlers_test.go
+++ b/internal/daemon/kill_handlers_test.go
@@ -181,6 +181,69 @@ func TestPortsKillDryRunReportsAnUnknownPortAsAFailedRow(t *testing.T) {
 	}
 }
 
+// TestKillResolvesAgainstTheDaemonsOwnScan: the handler hands the killer the
+// rows it just scanned, instead of letting killer.KillPorts scan the machine a
+// second time inside the RPC. The proof is a listener that exists only in the
+// daemon's scan: a killer that went looking for itself would find nothing on
+// that port and report a failed "none" row, so a planned signal carrying the
+// snapshot's own pid and name is the daemon's scan being used.
+func TestKillResolvesAgainstTheDaemonsOwnScan(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+	c := h.dial(ctx)
+
+	const fakePID = 424242
+	port := freeTestPort(t)
+	h.setRows(ports.ListeningPort{
+		Port: port, BindAddress: "127.0.0.1", PID: fakePID,
+		Process: "node", Display: "fake-api",
+	})
+
+	var env rpc.KillEnvelope
+	if e := c.call("ports.kill", rpc.PortsKillParams{
+		Targets: []rpc.Selector{{Port: ptr(port)}}, DryRun: true,
+	}, &env); e != nil {
+		t.Fatalf("ports.kill: %v", e)
+	}
+	if len(env.Results) != 1 {
+		t.Fatalf("results = %+v, want one row for the snapshot's listener", env.Results)
+	}
+	row := env.Results[0]
+	if row.Method == state.MethodNone {
+		t.Fatalf("row = %+v, want a planned signal: the killer resolved against its own scan, not the daemon's", row)
+	}
+	if row.PID != fakePID || row.Name != "fake-api" || row.Port != port {
+		t.Fatalf("row = %+v, want the daemon snapshot's pid %d and name fake-api on port %d",
+			row, fakePID, port)
+	}
+}
+
+// TestKillCostsExactlyOneScan pins the other half: resolving targets rescans
+// once (contract §25) and nothing scans again behind it.
+func TestKillCostsExactlyOneScan(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+	c := h.dial(ctx)
+
+	h.setRows(ports.ListeningPort{Port: 4323, BindAddress: "127.0.0.1", PID: 424243, Process: "node"})
+	if _, err := h.loop.Snapshot(scanner.Include{}); err != nil {
+		t.Fatalf("priming: %v", err)
+	}
+	before := h.loop.Status().Scans
+
+	var env rpc.KillEnvelope
+	if e := c.call("ports.kill", rpc.PortsKillParams{
+		Targets: []rpc.Selector{{Port: ptr(4323)}}, DryRun: true,
+	}, &env); e != nil {
+		t.Fatalf("ports.kill: %v", e)
+	}
+	if after := h.loop.Status().Scans; after != before+1 {
+		t.Errorf("scans = %d, want exactly one (target resolution) more than %d", after, before)
+	}
+}
+
 func TestGroupsKillReportsAnUnknownGroupAsNotFound(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -44,9 +44,9 @@ type Runtime struct {
 // (group source `start`); internal/daemon/runsreg installs the implementation
 // from its own OnStart hook, so this package never imports it (contract §8).
 type RunRegistry interface {
-	// Run reports the group and name of the run that owns a port, matching
-	// groups.Registry so the resolver can take it as-is.
-	Run(p state.Port) (group, name string, ok bool)
+	// Run reports the run that owns a port, matching groups.Registry so the
+	// resolver can take it as-is.
+	Run(p state.Port) (run state.Run, ok bool)
 	// Prune drops runs whose process is gone.
 	Prune()
 }
@@ -55,8 +55,8 @@ type RunRegistry interface {
 // have to nil-check.
 type noRuns struct{}
 
-func (noRuns) Run(state.Port) (string, string, bool) { return "", "", false }
-func (noRuns) Prune()                                {}
+func (noRuns) Run(state.Port) (state.Run, bool) { return state.Run{}, false }
+func (noRuns) Prune()                           {}
 
 // SetRuns installs the run registry. Called once, from an OnStart hook.
 func (r *Runtime) SetRuns(reg RunRegistry) {

--- a/internal/daemon/listen_windows.go
+++ b/internal/daemon/listen_windows.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -11,15 +12,43 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// pipeBindTimeout bounds the retry below. It is generous on purpose: a restart
+// is already waiting on the outgoing daemon's lock, so the only cost of an
+// extra second here is a restart that succeeds instead of one that does not.
+const pipeBindTimeout = 5 * time.Second
+
 // listen binds the named pipe with a security descriptor that grants full
 // access to the current user and to SYSTEM, and to nobody else — the Windows
 // equivalent of the 0600 unix socket (spec, "Transport details").
+//
+// A pipe instance outlives the process that created it by the moment it takes
+// Windows to tear the last instance down, so the daemon that replaces another
+// one can meet "Access is denied" on a name that is about to be free. That is
+// a race, not a refusal: retry it for a few seconds before giving up.
 func listen(path string) (net.Listener, error) {
 	sddl, err := userOnlySDDL()
 	if err != nil {
 		return nil, err
 	}
-	return winio.ListenPipe(path, &winio.PipeConfig{SecurityDescriptor: sddl})
+	cfg := &winio.PipeConfig{SecurityDescriptor: sddl}
+	deadline := time.Now().Add(pipeBindTimeout)
+	for {
+		ln, err := winio.ListenPipe(path, cfg)
+		if err == nil {
+			return ln, nil
+		}
+		if !pipeNameStillBusy(err) || !time.Now().Before(deadline) {
+			return nil, err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// pipeNameStillBusy reports whether creating the pipe failed because the
+// previous owner has not finished letting go of the name.
+func pipeNameStillBusy(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_PIPE_BUSY)
 }
 
 // dial connects to the named pipe. The short timeout matters because a pipe

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -32,9 +32,13 @@ func IsAlreadyRunning(err error) bool {
 	return errors.As(err, &e)
 }
 
-// Lock is the single-instance lock. It is an advisory whole-file lock (flock on
-// Unix, LockFileEx on Windows) on <socket dir>/daemon.lock whose contents are
-// the holder's pid, so a second `sonar serve` can name the process it lost to.
+// Lock is the single-instance lock: an advisory lock (flock on Unix,
+// LockFileEx on Windows) on <socket dir>/daemon.lock, whose contents are the
+// holder's pid so a second `sonar serve` can name the process it lost to.
+//
+// Unix locks the whole file; Windows locks one byte far past the end of it,
+// because a Windows lock also blocks reads of the range it covers and the pid
+// has to stay readable while the lock is held (see lock_windows.go).
 type Lock struct {
 	path string
 	f    *os.File

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -120,6 +120,13 @@ func (l *Lock) Path() string { return l.path }
 // ErrAlreadyRunning, so they are retried here instead of aborting the restart.
 func WaitForLockRelease(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
+	// Asking whether the holder is alive costs a `tasklist` process on Windows,
+	// so it is rate-limited well below the poll: the lock itself is the fast
+	// answer, and a recorded holder that is already gone can wait half a second
+	// to be noticed.
+	const livenessEvery = 500 * time.Millisecond
+	checkLivenessAt := time.Now()
+
 	var last error
 	for {
 		lock, err := AcquireLock(path)
@@ -134,8 +141,11 @@ func WaitForLockRelease(path string, timeout time.Duration) error {
 		}
 		last = err
 		var already *ErrAlreadyRunning
-		if errors.As(err, &already) && already.PID > 0 && !runs.PIDAlive(already.PID) {
-			return nil
+		if errors.As(err, &already) && already.PID > 0 && !time.Now().Before(checkLivenessAt) {
+			checkLivenessAt = time.Now().Add(livenessEvery)
+			if !runs.PIDAlive(already.PID) {
+				return nil
+			}
 		}
 		if !time.Now().Before(deadline) {
 			return fmt.Errorf("the previous daemon still holds %s after %s: %w", path, timeout, last)

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -52,6 +52,14 @@ func AcquireLock(path string) (*Lock, error) {
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
+		if isLockedOpenError(err) {
+			// Windows can refuse the open itself while another process has the
+			// file locked or opened without sharing, where Unix would let us
+			// open it and only refuse the lock. It is the same answer —
+			// somebody else has it — so it gets the same error, and callers
+			// that retry (WaitForLockRelease) keep retrying.
+			return nil, &ErrAlreadyRunning{PID: LockHolderPID(path), Path: path}
+		}
 		return nil, fmt.Errorf("opening lock file: %w", err)
 	}
 	if err := lockFile(f); err != nil {
@@ -99,6 +107,11 @@ func (l *Lock) Path() string { return l.path }
 // The lock is taken and immediately released, which is the only honest test
 // that it is free. A lock whose recorded holder is gone is also treated as
 // free, so a stale lock file cannot make restart hang for the whole timeout.
+//
+// On Windows the wait has to survive one more failure mode: opening a file the
+// outgoing daemon still holds fails outright (ERROR_LOCK_VIOLATION or
+// ERROR_SHARING_VIOLATION) rather than blocking. AcquireLock reports those as
+// ErrAlreadyRunning, so they are retried here instead of aborting the restart.
 func WaitForLockRelease(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var last error

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -62,6 +62,12 @@ func AcquireLock(path string) (*Lock, error) {
 		}
 		return nil, fmt.Errorf("opening lock file: %w", err)
 	}
+	// A daemon spawns children (`sonar start`, `sonar up`, autostart). None of
+	// them may inherit the lock handle: an inherited handle keeps the lock —
+	// and, on Windows, the file itself — alive after the daemon that took it
+	// has exited.
+	markNotInheritable(f)
+
 	if err := lockFile(f); err != nil {
 		pid := readLockPID(f)
 		f.Close()

--- a/internal/daemon/lock_unix.go
+++ b/internal/daemon/lock_unix.go
@@ -23,3 +23,8 @@ func lockFile(f *os.File) error {
 func unlockFile(f *os.File) error {
 	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 }
+
+// isLockedOpenError reports whether opening the lock file failed because
+// somebody else holds it. Unix always opens the file and refuses the lock
+// instead, so nothing lands here.
+func isLockedOpenError(error) bool { return false }

--- a/internal/daemon/lock_unix.go
+++ b/internal/daemon/lock_unix.go
@@ -28,3 +28,7 @@ func unlockFile(f *os.File) error {
 // somebody else holds it. Unix always opens the file and refuses the lock
 // instead, so nothing lands here.
 func isLockedOpenError(error) bool { return false }
+
+// markNotInheritable is a no-op on Unix: Go opens every file with O_CLOEXEC,
+// so no child of a fork/exec inherits the lock's descriptor.
+func markNotInheritable(*os.File) {}

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -50,3 +50,12 @@ func unlockFile(f *os.File) error {
 	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0,
 		lockBytesLow, lockBytesHigh, lockRange())
 }
+
+// isLockedOpenError reports whether opening the lock file failed because
+// another process has it locked or open without sharing. Windows refuses the
+// open where Unix would refuse only the lock, and a restart has to read that
+// as "still held, try again" rather than as a broken lock directory.
+func isLockedOpenError(err error) bool {
+	return errors.Is(err, windows.ERROR_LOCK_VIOLATION) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -59,3 +59,13 @@ func isLockedOpenError(err error) bool {
 	return errors.Is(err, windows.ERROR_LOCK_VIOLATION) ||
 		errors.Is(err, windows.ERROR_SHARING_VIOLATION)
 }
+
+// markNotInheritable clears the handle's inherit flag, so a child started by
+// the daemon cannot keep the lock (or the lock file) alive after the daemon
+// exits. Go already opens files with O_CLOEXEC on Windows; saying it again
+// here costs one syscall and makes the requirement explicit, because a
+// spawned child holding this handle is exactly how a daemon that has exited
+// goes on looking like it is running.
+func markNotInheritable(f *os.File) {
+	_ = windows.SetHandleInformation(windows.Handle(f.Fd()), windows.HANDLE_FLAG_INHERIT, 0)
+}

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -13,14 +13,33 @@ import (
 // turn it into ErrAlreadyRunning.
 var errLockBusy = errors.New("lock held by another process")
 
-// lockWholeFile locks a range large enough to cover any lock file we write.
-const lockLow, lockHigh = ^uint32(0), ^uint32(0)
+// The lock is a single byte at offset 1<<62, past any byte the lock file will
+// ever hold.
+//
+// LockFileEx makes the range it locks unreadable to every other process, so
+// locking the whole file hid the one thing the file exists to publish: with a
+// daemon running, LockHolderPID and ErrAlreadyRunning.PID both came back 0 and
+// os.ReadFile failed with "another process has locked a portion of the file".
+// A range that cannot overlap the pid keeps the semantics we want from flock —
+// the lock lives on the open handle and dies with it — and leaves offset 0
+// readable to anyone who wants to know whose daemon is running.
+const (
+	lockOffsetLow  = 0
+	lockOffsetHigh = 1 << 30 // (1<<30)<<32 == byte 1<<62 of the file
+	lockBytesLow   = 1
+	lockBytesHigh  = 0
+)
+
+// lockRange is the region LockFileEx and UnlockFileEx both address. The offset
+// travels in the OVERLAPPED, the length in the byte-count arguments.
+func lockRange() *windows.Overlapped {
+	return &windows.Overlapped{Offset: lockOffsetLow, OffsetHigh: lockOffsetHigh}
+}
 
 func lockFile(f *os.File) error {
-	var overlapped windows.Overlapped
 	err := windows.LockFileEx(windows.Handle(f.Fd()),
 		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
-		0, lockLow, lockHigh, &overlapped)
+		0, lockBytesLow, lockBytesHigh, lockRange())
 	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
 		return errLockBusy
 	}
@@ -28,6 +47,6 @@ func lockFile(f *os.File) error {
 }
 
 func unlockFile(f *os.File) error {
-	var overlapped windows.Overlapped
-	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, lockLow, lockHigh, &overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0,
+		lockBytesLow, lockBytesHigh, lockRange())
 }

--- a/internal/daemon/ports_test.go
+++ b/internal/daemon/ports_test.go
@@ -474,12 +474,18 @@ func TestReadsAreFreeWhileSomeoneIsSubscribed(t *testing.T) {
 		t.Fatalf("state.subscribe: %v", e)
 	}
 
+	// state.subscribe replies from the cache and wakes the scanner (contract
+	// §25), so the subscriber's first tick lands asynchronously. A baseline
+	// taken before it finishes counts that tick against the reads that follow,
+	// which is how this test failed on the slower Windows runner.
+	settleScans(t, h)
+
 	reader := h.dial(ctx)
 	var res listResult
 	if e := reader.call("ports.list", rpc.PortsListParams{}, &res); e != nil {
 		t.Fatalf("ports.list: %v", e)
 	}
-	before := h.loop.Status().Scans
+	before := settleScans(t, h)
 
 	// The loop keeps scanning on its own cadence; what must not happen is a
 	// read adding scans of its own. Give the reads no time to be "stale".
@@ -494,6 +500,33 @@ func TestReadsAreFreeWhileSomeoneIsSubscribed(t *testing.T) {
 	if got := h.loop.Status().Scans; got != before {
 		t.Fatalf("forty reads alongside a subscriber cost %d scans, want 0", got-before)
 	}
+}
+
+// settleScans waits until the scan counter has stopped moving and returns it.
+// The loop's own cadence is seconds apart (scanner.BaseInterval), so a counter
+// that has held still for a fifth of a second is between ticks, and the caller
+// has the rest of the interval to do its work in.
+func settleScans(t *testing.T, h *testHarness) int64 {
+	t.Helper()
+	const (
+		poll   = 20 * time.Millisecond
+		stable = 10
+	)
+	deadline := time.Now().Add(10 * time.Second)
+	last, held := h.loop.Status().Scans, 0
+	for time.Now().Before(deadline) {
+		time.Sleep(poll)
+		switch now := h.loop.Status().Scans; {
+		case now != last:
+			last, held = now, 0
+		case held == stable:
+			return now
+		default:
+			held++
+		}
+	}
+	t.Fatalf("the scan counter never settled: still moving at %d", last)
+	return 0
 }
 
 func TestDaemonStatusReportsTheScanCounter(t *testing.T) {

--- a/internal/daemon/ports_test.go
+++ b/internal/daemon/ports_test.go
@@ -489,6 +489,7 @@ func TestReadsAreFreeWhileSomeoneIsSubscribed(t *testing.T) {
 
 	// The loop keeps scanning on its own cadence; what must not happen is a
 	// read adding scans of its own. Give the reads no time to be "stale".
+	burstStart := time.Now()
 	for range 20 {
 		if e := reader.call("ports.list", rpc.PortsListParams{}, &res); e != nil {
 			t.Fatalf("ports.list: %v", e)
@@ -498,21 +499,39 @@ func TestReadsAreFreeWhileSomeoneIsSubscribed(t *testing.T) {
 		}
 	}
 	if got := h.loop.Status().Scans; got != before {
-		t.Fatalf("forty reads alongside a subscriber cost %d scans, want 0", got-before)
+		st := h.loop.Status()
+		t.Fatalf("forty reads alongside a subscriber cost %d scans, want 0 (interval %dms, last scan %s, burst took %s)",
+			got-before, st.IntervalMs, time.Since(st.LastScanAt), time.Since(burstStart))
 	}
 }
 
-// settleScans waits until the scan counter has stopped moving and returns it.
-// The loop's own cadence is seconds apart (scanner.BaseInterval), so a counter
-// that has held still for a fifth of a second is between ticks, and the caller
-// has the rest of the interval to do its work in.
+// settleScans leaves the scan loop with nothing left to do and returns the scan
+// counter, which is the baseline a "reads cost no scans" assertion needs.
+//
+// Waiting for the counter to go quiet is not enough on its own. A wake queued
+// but not yet served — state.subscribe queues one (contract §25) — is
+// invisible in the counter, and a loop goroutine that has not been scheduled
+// for a while looks exactly like a loop with nothing to do. So the loop is
+// woken and the scan that wake causes is waited for: a wake is coalesced onto
+// the one already queued, so when the counter moves the queue is empty and the
+// goroutine is demonstrably running. Only then is quiet meaningful.
 func settleScans(t *testing.T, h *testHarness) int64 {
 	t.Helper()
 	const (
 		poll   = 20 * time.Millisecond
 		stable = 10
 	)
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
+
+	started := h.loop.Status().Scans
+	h.loop.Wake()
+	for h.loop.Status().Scans == started {
+		if !time.Now().Before(deadline) {
+			t.Fatalf("the scan loop never served a wake: counter stuck at %d", started)
+		}
+		time.Sleep(poll)
+	}
+
 	last, held := h.loop.Status().Scans, 0
 	for time.Now().Before(deadline) {
 		time.Sleep(poll)

--- a/internal/daemon/rpc/schema_test.go
+++ b/internal/daemon/rpc/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/raskrebs/sonar/internal/state"
@@ -112,10 +113,17 @@ func TestCheckedInSchemaIsUpToDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v (run `go generate ./...`)", err)
 	}
-	if string(onDisk) != string(Marshal()) {
+	if unixEOL(string(onDisk)) != unixEOL(string(Marshal())) {
 		t.Fatalf("%s is stale; run `go generate ./...`", path)
 	}
 }
+
+// unixEOL folds CRLF to LF. .gitattributes pins the checked-in schema to LF so
+// the file a Windows CI checkout compares is the file `go generate` wrote, but
+// a developer's checkout made before that (or with core.autocrlf forced on)
+// still has CRLF on disk, and the schema's content is what this test is about,
+// not its line endings.
+func unixEOL(s string) string { return strings.ReplaceAll(s, "\r\n", "\n") }
 
 // TestSchemaEnumsMatchGoEnums guards against the Go enum constants and the
 // struct-tag enums in the generated schema drifting apart.

--- a/internal/daemon/runs_integration_test.go
+++ b/internal/daemon/runs_integration_test.go
@@ -106,14 +106,15 @@ func TestStartAttributesItsPortToTheGroup(t *testing.T) {
 	start.Dir = e.home
 	var out safeBuffer
 	start.Stdout, start.Stderr = &out, &out
+	ownProcessGroup(start)
 	if err := start.Start(); err != nil {
 		t.Fatalf("sonar start: %v", err)
 	}
 	t.Cleanup(func() {
-		if start.Process != nil {
-			_ = start.Process.Kill()
-			_ = start.Wait()
-		}
+		// The listener is in a process group of its own and holds the pipe
+		// `out` reads from, so the whole tree has to go before Wait can
+		// return.
+		stopCommand(start)
 		if t.Failed() {
 			t.Logf("sonar start output:\n%s", out.String())
 		}

--- a/internal/daemon/runs_integration_test.go
+++ b/internal/daemon/runs_integration_test.go
@@ -119,9 +119,9 @@ func TestStartAttributesItsPortToTheGroup(t *testing.T) {
 		}
 	})
 
-	added, ok := waitForAddedPort(t, sub, port, 45*time.Second)
+	added, ok := waitForAttributedPort(t, sub, port, 45*time.Second)
 	if !ok {
-		t.Fatalf("no state.delta added port %d within 45s\n%s", port, out.String())
+		t.Fatalf("no state.delta carried port %d with its run within 45s\n%s", port, out.String())
 	}
 
 	if added.Group == nil || *added.Group != "itest" {
@@ -194,9 +194,16 @@ func interrupt(t *testing.T, cmd *exec.Cmd) {
 	}
 }
 
-// waitForAddedPort is waitForAdded, but it hands back the row so the test can
-// assert on the group the resolver put on it.
-func waitForAddedPort(t *testing.T, sub *client.Subscription, port int, timeout time.Duration) (state.Port, bool) {
+// waitForAttributedPort is waitForAdded, but it hands back the row so the test
+// can assert on the group and the run the resolver put on it.
+//
+// It waits for the delta that carries the run rather than the first delta that
+// mentions the port. The two are usually the same one, but they need not be:
+// the child binds its port before `sonar start` has had a chance to tell the
+// daemon who owns it, and a scan tick landing in that window publishes a real
+// listener that genuinely has no run yet. The daemon corrects it in the very
+// next delta, which is the row this test is about.
+func waitForAttributedPort(t *testing.T, sub *client.Subscription, port int, timeout time.Duration) (state.Port, bool) {
 	t.Helper()
 	deadline := time.After(timeout)
 	for {
@@ -205,14 +212,16 @@ func waitForAddedPort(t *testing.T, sub *client.Subscription, port int, timeout 
 			if !ok {
 				return state.Port{}, false
 			}
-			for _, p := range d.Ports.Added {
-				if p.Port == port {
-					return p, true
-				}
-			}
-			for _, p := range d.Ports.Updated {
-				if p.Port == port && p.Group != nil {
-					return p, true
+			for _, rows := range [][]state.Port{d.Ports.Added, d.Ports.Updated} {
+				for _, p := range rows {
+					if p.Port != port {
+						continue
+					}
+					if p.Run != nil {
+						return p, true
+					}
+					t.Logf("delta seq %d has port %d before its run was registered (group %v)",
+						d.Seq, port, p.Group)
 				}
 			}
 		case <-deadline:

--- a/internal/daemon/runsreg/registry.go
+++ b/internal/daemon/runsreg/registry.go
@@ -153,17 +153,21 @@ func (r *Registry) Prune() {
 // Run implements groups.Registry: it attributes a listening port to the run
 // that owns it by walking the port's PPID ancestry, so `npm run dev` -> vite ->
 // esbuild all resolve to the run that started them.
-func (r *Registry) Run(p state.Port) (group, name string, ok bool) {
+//
+// It answers with the whole run because the resolver stamps it onto the row:
+// this registry, not the runs.json mirror the scanner reads, is what a daemon
+// knows about its own runs, and it knows it the moment `runs.register` returns.
+func (r *Registry) Run(p state.Port) (state.Run, bool) {
 	if rec, found := r.ancestor(p.PID, p.PPID); found {
-		return rec.Group, rec.Name, rec.Group != "" || rec.Name != ""
+		return state.Run{ID: rec.ID, Group: rec.Group, Name: rec.Name, RootPID: rec.PID}, true
 	}
 	// The scanner already walked the ancestry against the mirrored file while
 	// enriching this port; trust that rather than walking a process table that
 	// has moved on since.
 	if p.Run != nil && (p.Run.Group != "" || p.Run.Name != "") {
-		return p.Run.Group, p.Run.Name, true
+		return *p.Run, true
 	}
-	return "", "", false
+	return state.Run{}, false
 }
 
 // ancestor walks up from pid looking for a registered run. hintPPID is the

--- a/internal/daemon/runsreg/registry_test.go
+++ b/internal/daemon/runsreg/registry_test.go
@@ -76,13 +76,48 @@ func TestRunAttributesAPortByItsPPIDAncestry(t *testing.T) {
 	// sonar start (100) -> npm (200) -> node (300) -> esbuild (400)
 	r.Parents = func() map[int]int { return map[int]int{400: 300, 300: 200, 200: 100} }
 
-	group, name, ok := r.Run(state.Port{PID: 400, PPID: 300})
-	if !ok || group != "itest" || name != "web" {
-		t.Fatalf("Run(descendant) = %q/%q/%v, want itest/web/true", group, name, ok)
+	run, ok := r.Run(state.Port{PID: 400, PPID: 300})
+	if !ok || run.Group != "itest" || run.Name != "web" || run.RootPID != 100 {
+		t.Fatalf("Run(descendant) = %+v/%v, want itest/web rooted at 100", run, ok)
 	}
 
-	if _, _, ok := r.Run(state.Port{PID: 777, PPID: 1}); ok {
+	if _, ok := r.Run(state.Port{PID: 777, PPID: 1}); ok {
 		t.Fatal("an unrelated listener was attributed to a run")
+	}
+}
+
+// TestRunAttributesTheLinuxScannerShape is the shape a Linux scan hands the
+// resolver: `ss -tlnp` reports the listening pid and nothing else, so the row
+// arrives with PPID 0 and no run of its own. Attribution then has only the
+// process table to work with, and it has to reach the `sonar start` that owns
+// the listener through it.
+func TestRunAttributesTheLinuxScannerShape(t *testing.T) {
+	r := testRegistry(100)
+	r.Register(Record{ID: "a", PID: 100, Group: "itest", Name: "web"})
+	// sonar start (100) -> the listener it spawned (300). ss gave no ppid.
+	r.Parents = func() map[int]int { return map[int]int{300: 100, 100: 42} }
+
+	run, ok := r.Run(state.Port{PID: 300, PPID: 0})
+	if !ok {
+		t.Fatal("a listener spawned by a run was not attributed to it")
+	}
+	if run.ID != "a" || run.Group != "itest" || run.Name != "web" || run.RootPID != 100 {
+		t.Fatalf("Run = %+v, want a/itest/web rooted at 100", run)
+	}
+}
+
+// TestRunAttributesTheRegisteredPIDItself covers `sonar start` in the
+// foreground: the run is registered under the pid of the child it spawned, and
+// that child is the process holding the socket, so no walk is needed and the
+// answer must not depend on a process table being readable at all.
+func TestRunAttributesTheRegisteredPIDItself(t *testing.T) {
+	r := testRegistry(300)
+	r.Register(Record{ID: "a", PID: 300, Group: "itest", Name: "web"})
+	r.Parents = func() map[int]int { t.Fatal("the process table should not be needed"); return nil }
+
+	run, ok := r.Run(state.Port{PID: 300})
+	if !ok || run.ID != "a" || run.Name != "web" || run.RootPID != 300 {
+		t.Fatalf("Run = %+v/%v, want the registered run", run, ok)
 	}
 }
 
@@ -91,19 +126,19 @@ func TestRunUsesTheDirectParentBeforeTheProcessTable(t *testing.T) {
 	r.Register(Record{ID: "a", PID: 100, Group: "itest", Name: "web"})
 	r.Parents = func() map[int]int { t.Fatal("the process table should not be needed"); return nil }
 
-	if group, _, ok := r.Run(state.Port{PID: 200, PPID: 100}); !ok || group != "itest" {
-		t.Fatalf("Run(child) = %q/%v", group, ok)
+	if run, ok := r.Run(state.Port{PID: 200, PPID: 100}); !ok || run.Group != "itest" {
+		t.Fatalf("Run(child) = %+v/%v", run, ok)
 	}
 }
 
 func TestRunFallsBackToTheScannersOwnAttribution(t *testing.T) {
 	r := testRegistry()
-	group, name, ok := r.Run(state.Port{
+	run, ok := r.Run(state.Port{
 		PID: 400,
 		Run: &state.Run{ID: "x", Group: "from-file", Name: "web", RootPID: 100},
 	})
-	if !ok || group != "from-file" || name != "web" {
-		t.Fatalf("Run = %q/%q/%v", group, name, ok)
+	if !ok || run.Group != "from-file" || run.Name != "web" {
+		t.Fatalf("Run = %+v/%v", run, ok)
 	}
 }
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io"
 	"net"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -65,19 +64,6 @@ func (h *testHarness) dial(ctx context.Context) *testClient {
 	return c
 }
 
-// rpcDeadline bounds one test request/response. It is a guard against a hung
-// dispatcher, not a performance assertion, so Windows gets a much longer one:
-// `ports.kill` resolves its targets through the killer's own OS scan (contract
-// §25 rescans before selecting), and that scan shells out to PowerShell and to
-// `docker`, which on a cold CI runner takes many seconds. Three seconds there
-// times out a working call.
-func rpcDeadline() time.Duration {
-	if runtime.GOOS == "windows" {
-		return 30 * time.Second
-	}
-	return 3 * time.Second
-}
-
 type testClient struct {
 	t    *testing.T
 	conn net.Conn
@@ -94,7 +80,7 @@ func (c *testClient) send(method string, params any) string {
 	if err != nil {
 		c.t.Fatalf("marshalling params: %v", err)
 	}
-	c.conn.SetWriteDeadline(time.Now().Add(rpcDeadline()))
+	c.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
 	if err := json.NewEncoder(c.conn).Encode(rpc.Request{
 		JSONRPC: rpc.Version, ID: id, Method: method, Params: raw,
 	}); err != nil {
@@ -106,7 +92,7 @@ func (c *testClient) send(method string, params any) string {
 // read returns the next message from the daemon.
 func (c *testClient) read() rpc.Message {
 	c.t.Helper()
-	c.conn.SetReadDeadline(time.Now().Add(rpcDeadline()))
+	c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
 	line, err := c.r.ReadBytes('\n')
 	if err != nil {
 		c.t.Fatalf("reading from daemon: %v", err)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -64,6 +65,19 @@ func (h *testHarness) dial(ctx context.Context) *testClient {
 	return c
 }
 
+// rpcDeadline bounds one test request/response. It is a guard against a hung
+// dispatcher, not a performance assertion, so Windows gets a much longer one:
+// `ports.kill` resolves its targets through the killer's own OS scan (contract
+// §25 rescans before selecting), and that scan shells out to PowerShell and to
+// `docker`, which on a cold CI runner takes many seconds. Three seconds there
+// times out a working call.
+func rpcDeadline() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 30 * time.Second
+	}
+	return 3 * time.Second
+}
+
 type testClient struct {
 	t    *testing.T
 	conn net.Conn
@@ -80,7 +94,7 @@ func (c *testClient) send(method string, params any) string {
 	if err != nil {
 		c.t.Fatalf("marshalling params: %v", err)
 	}
-	c.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	c.conn.SetWriteDeadline(time.Now().Add(rpcDeadline()))
 	if err := json.NewEncoder(c.conn).Encode(rpc.Request{
 		JSONRPC: rpc.Version, ID: id, Method: method, Params: raw,
 	}); err != nil {
@@ -92,7 +106,7 @@ func (c *testClient) send(method string, params any) string {
 // read returns the next message from the daemon.
 func (c *testClient) read() rpc.Message {
 	c.t.Helper()
-	c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	c.conn.SetReadDeadline(time.Now().Add(rpcDeadline()))
 	line, err := c.r.ReadBytes('\n')
 	if err != nil {
 		c.t.Fatalf("reading from daemon: %v", err)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -25,15 +25,22 @@ type testHarness struct {
 	srv  *Server
 	loop *scanner.Loop
 
+	stopLoop context.CancelFunc
+	loopDone chan struct{}
+
 	mu   sync.Mutex
 	rows []ports.ListeningPort
 }
 
 // newHarness builds a server whose scan loop is already running, so a change to
 // the fake scan result reaches subscribers the way it does in production.
+//
+// A harness that opens a database must be built *after* the t.TempDir() that
+// holds it: cleanups run last-registered-first, and the harness has to stop
+// before the directory it writes into is removed.
 func newHarness(t *testing.T, ctx context.Context) *testHarness {
 	t.Helper()
-	h := &testHarness{t: t}
+	h := &testHarness{t: t, loopDone: make(chan struct{})}
 	h.loop = scanner.New(scanner.Options{
 		DaemonVersion: "test",
 		Scan: func(scanner.Include) ([]ports.ListeningPort, error) {
@@ -43,8 +50,33 @@ func newHarness(t *testing.T, ctx context.Context) *testHarness {
 		},
 	})
 	h.srv = New(Options{Socket: "/test/sonar.sock", Version: "test", Scanner: h.loop})
-	go h.loop.Run(ctx)
+
+	runCtx, stop := context.WithCancel(ctx)
+	h.stopLoop = stop
+	go func() {
+		defer close(h.loopDone)
+		h.loop.Run(runCtx)
+	}()
+	t.Cleanup(h.shutdown)
 	return h
+}
+
+// shutdown stops everything the harness started, in order, and returns only
+// once it has stopped.
+//
+// Cancelling the test's context asks the loop to stop; it does not wait for it
+// to have stopped, and a scan already in flight goes on publishing — which
+// records history through the store, into the temp directory t.TempDir is
+// removing at that very moment. That race failed as "TempDir RemoveAll
+// cleanup: directory not empty", pointing at a SQLite -wal file recreated
+// behind the delete. Connections first (their handlers write too), then the
+// loop, then the database.
+func (h *testHarness) shutdown() {
+	h.srv.closeAllConns("test over")
+	h.srv.wg.Wait()
+	h.stopLoop()
+	<-h.loopDone
+	h.srv.closeStore()
 }
 
 // setRows replaces what the fake scanner returns.

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -89,9 +90,16 @@ func (errNoHome) Error() string { return "no home" }
 // socket on a per-boot tmpfs takes its lock with it, and that a named pipe
 // (which has no directory) falls back to the config directory.
 func TestLockPathFollowsSocket(t *testing.T) {
-	if got, want := lockPathFor("/run/user/1000/sonar/daemon.sock"),
-		"/run/user/1000/sonar/daemon.lock"; got != want {
-		t.Errorf("lockPathFor(unix socket) = %q, want %q", got, want)
+	// The "beside the socket" branch is a unix-socket branch: on Windows the
+	// address is always a named pipe (the default, or a SONAR_SOCKET pointing
+	// at another pipe), which has no directory and takes the config-dir branch
+	// below. Asserting a unix path there would only assert what filepath does
+	// to slashes.
+	if runtime.GOOS != "windows" {
+		if got, want := lockPathFor("/run/user/1000/sonar/daemon.sock"),
+			"/run/user/1000/sonar/daemon.lock"; got != want {
+			t.Errorf("lockPathFor(unix socket) = %q, want %q", got, want)
+		}
 	}
 	got := lockPathFor(WindowsPipe)
 	if want := filepath.Join(ConfigDir(), "daemon.lock"); got != want {

--- a/internal/daemon/store_test.go
+++ b/internal/daemon/store_test.go
@@ -13,12 +13,13 @@ import (
 	"github.com/raskrebs/sonar/internal/store"
 )
 
-// withStore opens a database for the harness the way Serve does.
+// withStore opens the daemon's database at path the way Serve does. Closing it is the harness's
+// job (see testHarness.shutdown): the store must outlive the scan loop that
+// writes history into it, and a cleanup registered here would run first.
 func (h *testHarness) withStore(path string) *store.Store {
 	h.t.Helper()
 	h.srv.opts.DBPath = path
 	h.srv.openStore()
-	h.t.Cleanup(h.srv.closeStore)
 	if h.srv.runtime.Store == nil {
 		h.t.Fatalf("no store opened at %s", path)
 	}
@@ -28,6 +29,9 @@ func (h *testHarness) withStore(path string) *store.Store {
 func TestStatusReportsTheDatabasePath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// The database's directory is claimed before the harness exists, so the
+	// harness stops before the directory is removed.
+	path := filepath.Join(t.TempDir(), "sonar.db")
 	h := newHarness(t, ctx)
 	c := h.dial(ctx)
 
@@ -39,7 +43,6 @@ func TestStatusReportsTheDatabasePath(t *testing.T) {
 		t.Errorf("db_path = %q before the store is open, want empty", before.DBPath)
 	}
 
-	path := filepath.Join(t.TempDir(), "sonar.db")
 	h.withStore(path)
 
 	var after rpc.DaemonStatusResult

--- a/internal/daemon/treekill_test.go
+++ b/internal/daemon/treekill_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package daemon_test
+
+import (
+	"os/exec"
+
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+// stopCommand takes a `sonar` invocation down for good and reaps it.
+//
+// Killing only the process the test started is not enough: `sonar start` puts
+// the command it supervises in a process group of its own (daemon spec), so
+// the child survives its parent and keeps holding the stdout pipe it
+// inherited. Wait then blocks forever copying from a pipe nobody will close,
+// which is how a failed assertion turned into a ten-minute CI timeout. The
+// whole tree goes, and env.command's WaitDelay is the backstop for anything
+// that still escapes.
+func stopCommand(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	killTree(cmd)
+	_ = cmd.Wait()
+}
+
+// descendants lists every process below pid in the process table, deepest
+// first, so children are signalled before the parent that could respawn them.
+func descendants(pid int) []int {
+	children := map[int][]int{}
+	for child, parent := range ports.ParentTable() {
+		if child != parent && child > 1 {
+			children[parent] = append(children[parent], child)
+		}
+	}
+	var out []int
+	var walk func(int, int)
+	walk = func(p, depth int) {
+		if depth > 32 {
+			return
+		}
+		for _, c := range children[p] {
+			walk(c, depth+1)
+			out = append(out, c)
+		}
+	}
+	walk(pid, 0)
+	return out
+}

--- a/internal/daemon/treekill_unix_test.go
+++ b/internal/daemon/treekill_unix_test.go
@@ -1,0 +1,32 @@
+//go:build integration && !windows
+
+package daemon_test
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// ownProcessGroup puts a command in a process group of its own so the test can
+// signal it separately from the `go test` process it was started from.
+func ownProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killTree SIGKILLs a command, everything below it in the process table and
+// its process group. All three: a `sonar start` child gets a process group of
+// its own, so the group kill alone would miss it, and the process table can be
+// a scan behind.
+func killTree(cmd *exec.Cmd) {
+	pid := cmd.Process.Pid
+	for _, p := range descendants(pid) {
+		_ = syscall.Kill(p, syscall.SIGKILL)
+	}
+	if pgid, err := syscall.Getpgid(pid); err == nil && pgid > 1 {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+}

--- a/internal/daemon/treekill_windows_test.go
+++ b/internal/daemon/treekill_windows_test.go
@@ -1,0 +1,13 @@
+//go:build integration && windows
+
+package daemon_test
+
+import "os/exec"
+
+// ownProcessGroup is a no-op on Windows: spawn already puts a started command
+// in a Job Object, which is what makes the tree die with it.
+func ownProcessGroup(*exec.Cmd) {}
+
+// killTree kills the command, and the Job Object takes the rest of the tree
+// with it.
+func killTree(cmd *exec.Cmd) { _ = cmd.Process.Kill() }

--- a/internal/daemon/up_integration_test.go
+++ b/internal/daemon/up_integration_test.go
@@ -123,7 +123,7 @@ services:
 
 	// api only started once db was listening, so by now all three are up and
 	// the group is running.
-	waitForGroupStatus(t, e, "demo", "running", 45*time.Second)
+	waitForGroupStatus(t, e, project, "demo", "running", 45*time.Second)
 
 	tree := e.command("list", "--tree")
 	tree.Dir = project
@@ -247,15 +247,25 @@ func keys(m map[int]bool) []int {
 	return out
 }
 
-// waitForGroupStatus polls `sonar groups --json` until the named group reaches
-// a status.
-func waitForGroupStatus(t *testing.T, e *env, name, want string, timeout time.Duration) {
+// waitForGroupStatus polls `sonar groups --json` from inside the project until
+// the named group reaches the wanted status.
+//
+// It runs in the project directory on purpose: `sonar groups` is a direct-scan
+// command, and the only directories it indexes are the caller's own and the
+// working directories of the processes it scanned. The second half does not
+// exist on Windows — there is no per-process cwd the scanner can read — so
+// asking from somewhere else is asking a question the command cannot answer
+// there.
+func waitForGroupStatus(t *testing.T, e *env, dir, name, want string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
-	var last string
+	var last, lastOut string
+	var lastErr error
 	for time.Now().Before(deadline) {
 		cmd := e.command("groups", "--json")
+		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
+		lastOut, lastErr = string(out), err
 		if err == nil {
 			var rows []struct {
 				Name   string `json:"name"`
@@ -274,7 +284,32 @@ func waitForGroupStatus(t *testing.T, e *env, name, want string, timeout time.Du
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	reportGroupDiagnostics(t, e, dir, lastOut, lastErr)
 	t.Fatalf("group %s never reached status %q (last saw %q)", name, want, last)
+}
+
+// reportGroupDiagnostics dumps everything that decides a group before the test
+// fails on it: what `sonar groups` last said, the runs the daemon registered,
+// the mirrored registry the direct scan reads, and the ports with the three
+// fields attribution turns on. A group missing on one platform is either a
+// missing cwd, a missing run record or a missing config, and this says which.
+func reportGroupDiagnostics(t *testing.T, e *env, dir, lastOut string, lastErr error) {
+	t.Helper()
+	t.Logf("last `sonar groups --json` (err %v):\n%s", lastErr, lastOut)
+
+	for _, args := range [][]string{{"runs", "--json"}, {"list", "--json"}} {
+		cmd := e.command(args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		t.Logf("`sonar %s` (err %v):\n%s", strings.Join(args, " "), err, out)
+	}
+
+	registry := filepath.Join(e.home, ".config", "sonar", "runs.json")
+	if data, err := os.ReadFile(registry); err == nil {
+		t.Logf("%s:\n%s", registry, data)
+	} else {
+		t.Logf("%s could not be read: %v", registry, err)
+	}
 }
 
 // unusedPort is freePort plus the check freePort cannot make: that nothing is

--- a/internal/daemon/up_integration_test.go
+++ b/internal/daemon/up_integration_test.go
@@ -12,7 +12,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -297,12 +299,22 @@ func reportGroupDiagnostics(t *testing.T, e *env, dir, lastOut string, lastErr e
 	t.Helper()
 	t.Logf("last `sonar groups --json` (err %v):\n%s", lastErr, lastOut)
 
-	for _, args := range [][]string{{"runs", "--json"}, {"list", "--json"}} {
+	for _, args := range [][]string{{"runs", "--json"}, {"list", "--json"}, {"list", "-a", "--json"}} {
 		cmd := e.command(args...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		t.Logf("`sonar %s` (err %v):\n%s", strings.Join(args, " "), err, out)
 	}
+
+	// `list` hides desktop apps and `list -a` does not, so a scan that reaches
+	// the daemon and still shows nothing is either an empty scan or a
+	// classification that hid it. The raw OS output says which.
+	scan := exec.Command("netstat", "-ano")
+	if runtime.GOOS != "windows" {
+		scan = exec.Command("lsof", "-iTCP", "-sTCP:LISTEN", "-n", "-P")
+	}
+	out, err := scan.CombinedOutput()
+	t.Logf("`%s` (err %v):\n%s", strings.Join(scan.Args, " "), err, out)
 
 	registry := filepath.Join(e.home, ".config", "sonar", "runs.json")
 	if data, err := os.ReadFile(registry); err == nil {

--- a/internal/groups/attribute.go
+++ b/internal/groups/attribute.go
@@ -55,6 +55,8 @@ func AttributeWith(pp []ports.ListeningPort, pins Pins, runs Registry, index *In
 		}
 	}
 
+	stampRuns(pp, runs)
+
 	resolved := Resolve(state.FromListeningAll(pp), pins, runs, index)
 	for i := range resolved {
 		pp[i].ProjectRoot = deref(resolved[i].ProjectRoot)
@@ -72,4 +74,34 @@ func deref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// stampRuns writes the registry's run attribution onto the scan rows before
+// they are converted, so `run`, `display_name` and `group` are all derived
+// from the same lookup at the same instant.
+//
+// Without this the daemon read the run twice from two places: the scanner
+// walked the mirrored runs.json while enriching (which is what fills `run` and
+// the name `display_name` shows), and the resolver asked the live in-memory
+// registry afterwards (which is what sets `group_source: start`). A run
+// registered in between the two published a port with the group but a null
+// run — the window is milliseconds wide, and on Linux the whole enrich pass is
+// milliseconds long, so a `sonar start` racing the scan tick landed in it.
+//
+// PortRuns, the direct-scan registry, hands back what the row already carries,
+// so this is a no-op without a daemon.
+func stampRuns(pp []ports.ListeningPort, runs Registry) {
+	if runs == nil {
+		return
+	}
+	for i := range pp {
+		if pp[i].PID <= 0 {
+			continue
+		}
+		run, ok := runs.Run(state.FromListening(pp[i]))
+		if !ok || (run.ID == "" && run.Group == "" && run.Name == "") {
+			continue
+		}
+		pp[i].RunID, pp[i].RunGroup, pp[i].Tag, pp[i].RunRootPID = run.ID, run.Group, run.Name, run.RootPID
+	}
 }

--- a/internal/groups/attribute_test.go
+++ b/internal/groups/attribute_test.go
@@ -22,15 +22,16 @@ func (p pinSet) Group(port state.Port) (string, bool) {
 // runSet is a Registry that answers for one port number.
 type runSet struct {
 	port  int
+	id    string
 	group string
 	name  string
 }
 
-func (r runSet) Run(p state.Port) (string, string, bool) {
+func (r runSet) Run(p state.Port) (state.Run, bool) {
 	if p.Port != r.port {
-		return "", "", false
+		return state.Run{}, false
 	}
-	return r.group, r.name, true
+	return state.Run{ID: r.id, Group: r.group, Name: r.name, RootPID: p.PID}, true
 }
 
 func TestAttributeWithAppliesPinsAndRuns(t *testing.T) {
@@ -41,7 +42,7 @@ func TestAttributeWithAppliesPinsAndRuns(t *testing.T) {
 
 	resolved, index := AttributeWith(pp,
 		pinSet{"port:3000": "storefront"},
-		runSet{port: 4000, group: "itest", name: "web"},
+		runSet{port: 4000, id: "r1", group: "itest", name: "web"},
 		nil)
 
 	if index == nil {
@@ -63,6 +64,51 @@ func TestAttributeWithAppliesPinsAndRuns(t *testing.T) {
 	// same attribution.
 	if pp[0].Group != "storefront" || pp[0].GroupSource != "manual" {
 		t.Errorf("scanner row = %q/%q, want storefront/manual", pp[0].Group, pp[0].GroupSource)
+	}
+}
+
+// TestAttributeWithPublishesTheRegistrysRun pins the invariant the daemon
+// broke: whatever the registry says owns a port has to reach the published row
+// as `run` and as the name clients render, not only as the group. A registry
+// answer that set `group_source: start` next to a null `run` is what a
+// `sonar start` racing a scan tick used to publish.
+func TestAttributeWithPublishesTheRegistrysRun(t *testing.T) {
+	pp := []ports.ListeningPort{
+		{Port: 4000, PID: 12, Process: "listener", Command: "/tmp/listener 4000"},
+	}
+
+	resolved, _ := AttributeWith(pp, nil, runSet{port: 4000, id: "r1", group: "itest", name: "web"}, nil)
+
+	if resolved[0].Run == nil {
+		t.Fatal("run is null; the registry's attribution never reached the row")
+	}
+	want := state.Run{ID: "r1", Group: "itest", Name: "web", RootPID: 12}
+	if *resolved[0].Run != want {
+		t.Errorf("run = %+v, want %+v", *resolved[0].Run, want)
+	}
+	if resolved[0].DisplayName != "web" {
+		t.Errorf("display_name = %q, want the name the run gave it", resolved[0].DisplayName)
+	}
+	if resolved[0].GroupSource == nil || *resolved[0].GroupSource != state.SourceStart {
+		t.Errorf("group_source = %v, want start", resolved[0].GroupSource)
+	}
+}
+
+// TestAttributeWithLeavesTheScannersOwnRunAlone is the no-daemon path: there is
+// no registry to ask, so whatever the scanner attributed from runs.json while
+// enriching has to survive.
+func TestAttributeWithLeavesTheScannersOwnRunAlone(t *testing.T) {
+	pp := []ports.ListeningPort{
+		{Port: 4000, PID: 12, Process: "listener", Tag: "web", RunGroup: "itest", RunID: "r1", RunRootPID: 9},
+	}
+
+	resolved, _ := AttributeWith(pp, nil, PortRuns{}, nil)
+
+	if resolved[0].Run == nil || resolved[0].Run.Name != "web" || resolved[0].Run.RootPID != 9 {
+		t.Fatalf("run = %+v, want the scanner's own attribution", resolved[0].Run)
+	}
+	if got := deref(resolved[0].Group); got != "itest" {
+		t.Errorf("group = %q, want itest", got)
 	}
 }
 

--- a/internal/groups/index.go
+++ b/internal/groups/index.go
@@ -192,26 +192,57 @@ func (x *Index) Invalid() []InvalidConfig {
 // MatchPort finds the config that claims a port: one whose `ports:` list
 // contains it, or one of whose services declares it, with the process cwd
 // under the file's directory. The deepest matching config wins.
+//
+// A port with no cwd is not out of reach. Windows has no per-process working
+// directory the scanner can read (see ports.batchGetCwds), so requiring one
+// left every `.sonar.yaml` unable to claim the ports it declares there — the
+// group existed in the index and no listener ever joined it. When the cwd is
+// missing the question that remains is still answerable: is there exactly one
+// known config claiming this port? One is an answer. Two is a guess, and a
+// guess is worse than no group at all.
 func (x *Index) MatchPort(p state.Port) (*Config, string, bool) {
-	if p.Cwd == "" {
+	if p.Cwd != "" {
+		for _, cfg := range x.Configs() {
+			if !under(p.Cwd, cfg.Dir) {
+				continue
+			}
+			if svc, ok := claims(cfg, p.Port); ok {
+				return cfg, svc, true
+			}
+		}
 		return nil, "", false
 	}
+
+	var (
+		match *Config
+		name  string
+		found int
+	)
 	for _, cfg := range x.Configs() {
-		if !under(p.Cwd, cfg.Dir) {
-			continue
-		}
-		for _, svc := range cfg.Services {
-			if svc.Port != 0 && svc.Port == p.Port {
-				return cfg, svc.Name, true
-			}
-		}
-		for _, port := range cfg.Ports {
-			if port == p.Port {
-				return cfg, "", true
-			}
+		if svc, ok := claims(cfg, p.Port); ok {
+			match, name, found = cfg, svc, found+1
 		}
 	}
+	if found == 1 {
+		return match, name, true
+	}
 	return nil, "", false
+}
+
+// claims reports whether cfg declares this port, and under which service name
+// ("" when the port comes from the file's own `ports:` list).
+func claims(cfg *Config, port int) (string, bool) {
+	for _, svc := range cfg.Services {
+		if svc.Port != 0 && svc.Port == port {
+			return svc.Name, true
+		}
+	}
+	for _, p := range cfg.Ports {
+		if p == port {
+			return "", true
+		}
+	}
+	return "", false
 }
 
 // under reports whether path is dir or lives inside it.

--- a/internal/groups/index_test.go
+++ b/internal/groups/index_test.go
@@ -64,11 +64,76 @@ func TestIndexDeepestConfigWins(t *testing.T) {
 	if !ok || cfg.Name != "outer" || svc != "api" {
 		t.Fatalf("MatchPort from the repo root = (%v, %q, %v)", cfg, svc, ok)
 	}
+	// Two configs claim 8000, and with no cwd there is nothing to tell them
+	// apart: an ambiguous claim is not a group.
 	if _, _, ok := x.MatchPort(state.Port{Port: 8000}); ok {
-		t.Error("a port with no cwd must not match a config")
+		t.Error("a port with no cwd must not pick between two configs that both claim it")
 	}
 	if _, _, ok := x.MatchPort(state.Port{Port: 9999, Cwd: inner}); ok {
 		t.Error("an unclaimed port must not match a config")
+	}
+}
+
+// TestIndexMatchesADeclaredPortWithoutACwd is the Windows gap: the scanner has
+// no per-process working directory there, so a listener arrives with Cwd
+// empty. A `.sonar.yaml` that declares the port is still the only claim on it,
+// and the group has to form — otherwise `sonar up` starts a group nothing ever
+// joins.
+func TestIndexMatchesADeclaredPortWithoutACwd(t *testing.T) {
+	base := tempTree(t)
+	repo := mkdir(t, base, "repo")
+	mkdir(t, repo, ".git")
+	writeFile(t, filepath.Join(repo, ConfigName),
+		"name: demo\nservices:\n  - name: api\n    port: 8000\nports: [8100]\n")
+
+	x := NewIndex()
+	x.Observe(repo)
+
+	cfg, svc, ok := x.MatchPort(state.Port{Port: 8000})
+	if !ok || cfg.Name != "demo" || svc != "api" {
+		t.Fatalf("MatchPort(service port, no cwd) = (%v, %q, %v), want the demo config's api", cfg, svc, ok)
+	}
+	cfg, svc, ok = x.MatchPort(state.Port{Port: 8100})
+	if !ok || cfg.Name != "demo" || svc != "" {
+		t.Fatalf("MatchPort(file port, no cwd) = (%v, %q, %v), want the demo config", cfg, svc, ok)
+	}
+	if _, _, ok := x.MatchPort(state.Port{Port: 9999}); ok {
+		t.Error("a port no config declares must not match")
+	}
+
+	// The resolver has to reach the same conclusion, since that is what puts
+	// the port in the group.
+	got := Resolve([]state.Port{{Port: 8000}}, NoPins{}, NoRuns{}, x)[0]
+	if deref(got.Group) != "demo" {
+		t.Errorf("resolved group = %q, want demo", deref(got.Group))
+	}
+	if got.GroupSource == nil || *got.GroupSource != state.SourceFile {
+		t.Errorf("group source = %v, want file", got.GroupSource)
+	}
+}
+
+// TestIndexWillNotGuessBetweenTwoConfigsClaimingAPort: without a cwd, two
+// projects declaring the same port are indistinguishable, and a wrong group is
+// worse than none.
+func TestIndexWillNotGuessBetweenTwoConfigsClaimingAPort(t *testing.T) {
+	base := tempTree(t)
+	one := mkdir(t, base, "one")
+	mkdir(t, one, ".git")
+	two := mkdir(t, base, "two")
+	mkdir(t, two, ".git")
+	writeFile(t, filepath.Join(one, ConfigName), "name: one\nservices:\n  - name: api\n    port: 8000\n")
+	writeFile(t, filepath.Join(two, ConfigName), "name: two\nservices:\n  - name: api\n    port: 8000\n")
+
+	x := NewIndex()
+	x.Observe(one)
+	x.Observe(two)
+
+	if cfg, _, ok := x.MatchPort(state.Port{Port: 8000}); ok {
+		t.Errorf("MatchPort with no cwd chose %q; two configs claim 8000", cfg.Name)
+	}
+	// With a cwd the answer is unambiguous again.
+	if cfg, _, ok := x.MatchPort(state.Port{Port: 8000, Cwd: two}); !ok || cfg.Name != "two" {
+		t.Errorf("MatchPort(cwd two) = (%v, %v), want the two config", cfg, ok)
 	}
 }
 

--- a/internal/groups/resolve.go
+++ b/internal/groups/resolve.go
@@ -21,32 +21,36 @@ type NoPins struct{}
 // Group never matches.
 func (NoPins) Group(state.Port) (string, bool) { return "", false }
 
-// Registry attributes a port to a process sonar started. The scanner has
-// already walked the PPID ancestry against `runs.json`, so the default
-// implementation just reads what it recorded.
+// Registry attributes a port to a process sonar started. It answers with the
+// whole run, not just its group, because `run`, `display_name` and
+// `group_source: start` all have to come out of one lookup: a daemon that
+// resolved the group from its live registry but the run from the runs.json
+// mirror could publish `group_source: "start"` next to a null `run`.
 type Registry interface {
-	// Run returns the group and name of the run that owns this port.
-	Run(p state.Port) (group, name string, ok bool)
+	// Run returns the run that owns this port.
+	Run(p state.Port) (run state.Run, ok bool)
 }
 
-// PortRuns reads the run attribution the scanner put on the port itself.
+// PortRuns reads the run attribution the scanner put on the port itself. It is
+// the direct-scan path: no daemon, so `runs.json` is the only registry there is.
 type PortRuns struct{}
 
-// Run returns the run's group and name. Until `sonar start` records a group
-// (step 1A.5, contract §11.3) run.group is empty, so this reports ok only for
-// the name; the resolver then falls through to the file and git-root rules.
-func (PortRuns) Run(p state.Port) (group, name string, ok bool) {
+// Run returns the run the scanner already attributed. Until `sonar start`
+// records a group (step 1A.5, contract §11.3) run.group is empty, so this
+// reports ok with only the name; the resolver then falls through to the file
+// and git-root rules.
+func (PortRuns) Run(p state.Port) (state.Run, bool) {
 	if p.Run == nil {
-		return "", "", false
+		return state.Run{}, false
 	}
-	return p.Run.Group, p.Run.Name, true
+	return *p.Run, true
 }
 
 // NoRuns is the empty run registry.
 type NoRuns struct{}
 
 // Run never matches.
-func (NoRuns) Run(state.Port) (string, string, bool) { return "", "", false }
+func (NoRuns) Run(state.Port) (state.Run, bool) { return state.Run{}, false }
 
 // MatchKeys returns the keys a rename or a pin can be stored under for this
 // port, most stable first. The store step matches a stored key against all of
@@ -116,8 +120,8 @@ func resolveOne(p *state.Port, pins Pins, runs Registry, index *Index) {
 		}
 	}
 	if runs != nil {
-		if g, _, ok := runs.Run(*p); ok && g != "" {
-			assign(p, g, state.SourceStart)
+		if run, ok := runs.Run(*p); ok && run.Group != "" {
+			assign(p, run.Group, state.SourceStart)
 			return
 		}
 	}

--- a/internal/groups/resolve_test.go
+++ b/internal/groups/resolve_test.go
@@ -17,9 +17,9 @@ func (f fakePins) Group(p state.Port) (string, bool) {
 type fakeRun struct{ group, name string }
 type fakeRuns map[int]fakeRun
 
-func (f fakeRuns) Run(p state.Port) (string, string, bool) {
+func (f fakeRuns) Run(p state.Port) (state.Run, bool) {
 	r, ok := f[p.Port]
-	return r.group, r.name, ok
+	return state.Run{Group: r.group, Name: r.name}, ok
 }
 
 // resolveFixture builds a repo, a linked worktree, a Compose project inside the

--- a/internal/ports/displayname_darwin.go
+++ b/internal/ports/displayname_darwin.go
@@ -9,43 +9,17 @@ import (
 )
 
 // batchGetCwds returns pid -> cwd for the given PIDs using a single lsof call.
-// lsof -a -p PID,PID,... -d cwd -Fpn produces records like:
-//
-//	p1234
-//	n/Users/me/project
-//	p5678
-//	n/var/empty
+// A non-zero exit is not a failure: see cwdsFromLsof.
 func batchGetCwds(pids []int) map[int]string {
-	result := make(map[int]string)
 	if len(pids) == 0 {
-		return result
+		return map[int]string{}
 	}
 	pidStrs := make([]string, len(pids))
 	for i, p := range pids {
 		pidStrs[i] = strconv.Itoa(p)
 	}
 	out, err := exec.Command("lsof", "-a", "-p", strings.Join(pidStrs, ","), "-d", "cwd", "-Fpn").Output()
-	if err != nil {
-		return result
-	}
-	var current int
-	for _, line := range strings.Split(string(out), "\n") {
-		if line == "" {
-			continue
-		}
-		switch line[0] {
-		case 'p':
-			pid, err := strconv.Atoi(line[1:])
-			if err == nil {
-				current = pid
-			}
-		case 'n':
-			if current != 0 {
-				result[current] = line[1:]
-			}
-		}
-	}
-	return result
+	return cwdsFromLsof(out, err)
 }
 
 // batchGetServiceUnits returns pid -> launchd label using one launchctl list call.

--- a/internal/ports/enrich.go
+++ b/internal/ports/enrich.go
@@ -2,7 +2,9 @@ package ports
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -14,6 +16,14 @@ import (
 func Enrich(pp []ListeningPort) {
 	// Batch all PIDs into a single ps call for commands
 	commands := batchGetCommands(pp)
+
+	// netstat reports no process name, so on Windows a row whose command line
+	// the CIM query did not answer for has no identity at all — and identity
+	// is what decides whether a port is shown and which group it joins. One
+	// tasklist call fills in the names, per pid, for exactly those rows.
+	if runtime.GOOS == "windows" {
+		fillProcessNamesWindows(pp, commands)
+	}
 
 	for i := range pp {
 		if info, ok := commands[pp[i].PID]; ok {
@@ -160,6 +170,70 @@ func restAfterFields(line string, n int) string {
 		rest = rest[idx:]
 	}
 	return strings.TrimLeft(rest, " \t")
+}
+
+// fillProcessNamesWindows names the rows the CIM query left blank. tasklist
+// needs no WMI service and no elevation, so it answers when Get-CimInstance
+// does not, and a pid it cannot name simply stays unnamed: one process failing
+// to resolve must not cost the others their identity.
+func fillProcessNamesWindows(pp []ListeningPort, commands map[int]procInfo) {
+	missing := false
+	for i := range pp {
+		if pp[i].Process == "" && commands[pp[i].PID].command == "" {
+			missing = true
+			break
+		}
+	}
+	if !missing {
+		return
+	}
+
+	out, err := exec.Command("tasklist", "/NH", "/FO", "CSV").Output()
+	if err != nil {
+		return
+	}
+	names := parseTasklist(string(out))
+	for i := range pp {
+		if pp[i].Process != "" {
+			continue
+		}
+		if name, ok := names[pp[i].PID]; ok {
+			pp[i].Process = name
+		}
+	}
+}
+
+// parseTasklist reads `tasklist /NH /FO CSV` into pid -> image name. Rows it
+// cannot parse are skipped; the ones it can are still returned.
+func parseTasklist(out string) map[int]string {
+	names := make(map[int]string)
+	r := csv.NewReader(strings.NewReader(strings.TrimSpace(out)))
+	r.FieldsPerRecord = -1
+	for {
+		rec, err := r.Read()
+		if errors.Is(err, io.EOF) {
+			return names
+		}
+		if err != nil {
+			// One unreadable line is one process we cannot name, not a reason
+			// to forget the ones already read.
+			var parseErr *csv.ParseError
+			if errors.As(err, &parseErr) {
+				continue
+			}
+			return names
+		}
+		if len(rec) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(rec[1]))
+		if err != nil {
+			continue
+		}
+		if name := strings.TrimSpace(rec[0]); name != "" {
+			names[pid] = name
+		}
+	}
 }
 
 // batchGetCommandsWindows fetches command lines and start times via PowerShell
@@ -347,6 +421,11 @@ func isDesktopApp(command string, process string, pid int) bool {
 
 // isWindowsDesktopApp detects Windows desktop apps and system services.
 // PID 0 (System Idle) and PID 4 (System) own ports like 135, 139, 445.
+//
+// Everything this reports is hidden from `sonar list` unless --all is passed,
+// and hidden rows never join a group, so the two guesses here are not
+// symmetric: showing a system service is noise, hiding a dev server is a
+// broken tool. Both rules below are written to err towards showing.
 func isWindowsDesktopApp(command string, process string, pid int) bool {
 	if pid == 0 || pid == 4 {
 		return true
@@ -357,16 +436,23 @@ func isWindowsDesktopApp(command string, process string, pid int) bool {
 		lower = strings.ToLower(process)
 	}
 	if lower == "" {
-		// No command or process name — system service not visible without elevation
-		return true
+		// Nothing is known about this process. That is not evidence of a
+		// system service: on Windows the identity comes from one CIM query,
+		// and when it answers for nothing — no PowerShell, no WMI, a policy in
+		// the way — reading its silence as "everything is a desktop app" hid
+		// every port on the machine, dev servers included.
+		return false
 	}
 
 	// Windows system services
 	if strings.Contains(lower, `\windows\`) {
 		return true
 	}
-	// User-installed desktop apps (AppData\Local houses Discord, Cursor, Slack, etc.)
-	if strings.Contains(lower, `\appdata\`) {
+	// User-installed desktop apps (AppData\Local houses Discord, Cursor, Slack,
+	// etc.), except the temp directory: %LOCALAPPDATA%\Temp is where every
+	// scratch build and one-off binary runs from, and none of them is an
+	// installed application.
+	if strings.Contains(lower, `\appdata\`) && !strings.Contains(lower, `\appdata\local\temp\`) {
 		return true
 	}
 	// Microsoft Store apps

--- a/internal/ports/enrich_test.go
+++ b/internal/ports/enrich_test.go
@@ -121,3 +121,58 @@ func TestUptimeOfAnUnparseableStartIsEmpty(t *testing.T) {
 		t.Fatalf("uptime of garbage = %q, want empty", got)
 	}
 }
+
+// TestIsWindowsDesktopApp is the classification that decides whether a Windows
+// port is visible at all: an app is hidden from `sonar list` and never joins a
+// group. Two rules used to hide everything on a CI runner — a binary in
+// %LOCALAPPDATA%\Temp is not an installed app, and an unidentified process is
+// not evidence of one.
+func TestIsWindowsDesktopApp(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		process string
+		pid     int
+		want    bool
+	}{
+		{"system idle", "", "", 0, true},
+		{"system", "", "", 4, true},
+		{"unknown process", "", "", 7276, false},
+		{"temp build", `C:\Users\RUNNER~1\AppData\Local\Temp\sonar-itest-listener123\listener.exe 5000`, "listener.exe", 7276, false},
+		{"installed app", `C:\Users\dev\AppData\Local\Programs\cursor\Cursor.exe`, "Cursor.exe", 900, true},
+		{"roaming app", `C:\Users\dev\AppData\Roaming\Spotify\Spotify.exe`, "Spotify.exe", 901, true},
+		{"windows service", `C:\Windows\System32\svchost.exe -k RPCSS`, "svchost.exe", 1064, true},
+		{"store app", `C:\Program Files\WindowsApps\Something\app.exe`, "app.exe", 902, true},
+		{"dev server", `C:\Program Files\nodejs\node.exe server.js`, "node.exe", 903, false},
+		{"known app by name only", "", "chrome.exe", 904, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWindowsDesktopApp(tc.command, tc.process, tc.pid); got != tc.want {
+				t.Errorf("isWindowsDesktopApp(%q, %q, %d) = %v, want %v",
+					tc.command, tc.process, tc.pid, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseTasklist: the fallback that names a process when the CIM query does
+// not. A row it cannot read costs that row only.
+func TestParseTasklist(t *testing.T) {
+	out := "\"System Idle Process\",\"0\",\"Services\",\"0\",\"8 K\"\r\n" +
+		"\"listener.exe\",\"7276\",\"Console\",\"1\",\"5,120 K\"\r\n" +
+		"\"not a row\"\r\n" +
+		"\"svchost.exe\",\"nope\",\"Services\",\"0\",\"9,000 K\"\r\n" +
+		"\"node.exe\",\"3812\",\"Console\",\"1\",\"42,000 K\"\r\n"
+
+	got := parseTasklist(out)
+	want := map[int]string{0: "System Idle Process", 7276: "listener.exe", 3812: "node.exe"}
+	if len(got) != len(want) {
+		t.Fatalf("parseTasklist = %v, want %v", got, want)
+	}
+	for pid, name := range want {
+		if got[pid] != name {
+			t.Errorf("pid %d = %q, want %q", pid, got[pid], name)
+		}
+	}
+}

--- a/internal/ports/lsof.go
+++ b/internal/ports/lsof.go
@@ -1,0 +1,58 @@
+package ports
+
+import "strconv"
+
+// cwdsFromLsof turns one `lsof -a -p <pids> -d cwd -Fpn` run into pid -> cwd.
+// The field output is a record per line, `p<pid>` introducing a process and
+// `n<path>` its working directory:
+//
+//	p1234
+//	n/Users/me/project
+//	p5678
+//	n/var/empty
+//
+// The error is honoured only when lsof printed nothing at all — the same rule
+// scanLsof already applies. lsof exits non-zero as soon as one pid it was
+// asked about has gone away, which is routine when the caller is asking about
+// every listener on the machine, and it still prints every record it did
+// resolve. Dropping the whole batch on that error left *every* process without
+// a cwd for that scan, and a process with no cwd has no git root, so its group
+// and its display name silently fell back to something else for one tick and
+// then changed back.
+//
+// It lives outside the darwin-only file so the parsing is tested everywhere,
+// not only on the platform that runs lsof.
+func cwdsFromLsof(out []byte, err error) map[int]string {
+	result := make(map[int]string)
+	if err != nil && len(out) == 0 {
+		return result
+	}
+
+	current := 0
+	start := 0
+	text := string(out)
+	for i := 0; i <= len(text); i++ {
+		if i < len(text) && text[i] != '\n' {
+			continue
+		}
+		line := text[start:i]
+		start = i + 1
+		if line == "" {
+			continue
+		}
+		switch line[0] {
+		case 'p':
+			pid, convErr := strconv.Atoi(line[1:])
+			if convErr == nil && pid > 0 {
+				current = pid
+			} else {
+				current = 0
+			}
+		case 'n':
+			if current != 0 {
+				result[current] = line[1:]
+			}
+		}
+	}
+	return result
+}

--- a/internal/ports/lsof_test.go
+++ b/internal/ports/lsof_test.go
@@ -1,0 +1,64 @@
+package ports
+
+import (
+	"errors"
+	"testing"
+)
+
+// capturedLsof is real `lsof -a -p … -d cwd -Fpn` output from a machine where
+// one of the pids asked about had already exited: lsof reported what it could
+// and exited non-zero.
+const capturedLsof = `p71204
+n/Users/me/src/storefront
+p71209
+n/Users/me/src/storefront/web
+p980
+n/
+`
+
+// nonZeroExit stands in for the *exec.ExitError that Output() returns when
+// lsof exits non-zero; cwdsFromLsof only ever tests it for nil.
+var nonZeroExit = errors.New("exit status 1")
+
+func TestCwdsFromLsofKeepsWhatLsofFoundDespiteANonZeroExit(t *testing.T) {
+	got := cwdsFromLsof([]byte(capturedLsof), nonZeroExit)
+
+	want := map[int]string{
+		71204: "/Users/me/src/storefront",
+		71209: "/Users/me/src/storefront/web",
+		980:   "/",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d cwds, want %d: %v", len(got), len(want), got)
+	}
+	for pid, cwd := range want {
+		if got[pid] != cwd {
+			t.Errorf("cwd of %d = %q, want %q", pid, got[pid], cwd)
+		}
+	}
+}
+
+func TestCwdsFromLsofParsesACleanRun(t *testing.T) {
+	got := cwdsFromLsof([]byte("p1\nn/tmp\n"), nil)
+	if got[1] != "/tmp" {
+		t.Errorf("cwd of 1 = %q, want /tmp", got[1])
+	}
+}
+
+func TestCwdsFromLsofGivesUpOnlyWhenLsofSaidNothing(t *testing.T) {
+	if got := cwdsFromLsof(nil, nonZeroExit); len(got) != 0 {
+		t.Errorf("got %v, want no cwds when lsof produced no output", got)
+	}
+	if got := cwdsFromLsof(nil, errors.New(`exec: "lsof": executable file not found`)); len(got) != 0 {
+		t.Errorf("got %v, want no cwds when lsof is missing", got)
+	}
+}
+
+func TestCwdsFromLsofIgnoresPathsWithNoProcess(t *testing.T) {
+	// A path record before any process record, and a process record that is
+	// not a number, must not attribute a cwd to pid 0 or to the pid before it.
+	got := cwdsFromLsof([]byte("n/orphan\np12\nn/good\npNaN\nn/lost\n"), nil)
+	if len(got) != 1 || got[12] != "/good" {
+		t.Errorf("got %v, want only pid 12 -> /good", got)
+	}
+}

--- a/internal/ports/parents.go
+++ b/internal/ports/parents.go
@@ -1,14 +1,53 @@
 package ports
 
+import (
+	"strconv"
+	"strings"
+)
+
 // ParentTable returns a pid -> ppid map for every process this user can see.
 // It is the same table the scanner builds while enriching listeners, exported
 // so the daemon's runs registry can walk a listener's ancestry back to the
 // `sonar start` that owns it without scanning ports first.
+//
+// On Linux the table comes straight from /proc: no exec, no output parsing,
+// and — unlike `ps` — nothing to install. procps is absent from plenty of
+// container images, and a missing `ps` used to mean every ancestry walk came
+// back empty, so a listener a run had spawned was never attributed to it.
+// Everywhere else, and if /proc is unreadable, one `ps -A` call still answers.
 func ParentTable() map[int]int {
+	if table := nativeParentTable(); len(table) > 0 {
+		return table
+	}
 	info := batchGetPPIDsAndCommands()
 	out := make(map[int]int, len(info))
 	for pid, e := range info {
 		out[pid] = e.ppid
 	}
 	return out
+}
+
+// parseProcStatPPID reads the parent pid out of one /proc/<pid>/stat line.
+//
+// Field 2 is the executable name in parentheses and it may contain spaces and
+// parentheses of its own — Next.js sets its process title to
+// "next-server (v15.0.1)", so the line reads `42 (next-server (v15.0.1)) S 7
+// …`. Splitting on whitespace from the left therefore mis-reads the state and
+// the ppid; the scan starts after the *last* ')' instead, which is where the
+// kernel's own documentation says the fixed-width fields resume: state, then
+// ppid.
+func parseProcStatPPID(stat string) (int, bool) {
+	end := strings.LastIndexByte(stat, ')')
+	if end < 0 {
+		return 0, false
+	}
+	fields := strings.Fields(stat[end+1:])
+	if len(fields) < 2 {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil || ppid < 0 {
+		return 0, false
+	}
+	return ppid, true
 }

--- a/internal/ports/parents_linux.go
+++ b/internal/ports/parents_linux.go
@@ -1,0 +1,31 @@
+package ports
+
+import (
+	"os"
+	"strconv"
+)
+
+// nativeParentTable reads pid -> ppid from /proc, the authoritative source on
+// Linux. Every numeric directory under /proc is a process; its stat file
+// carries the parent. Processes that exit mid-walk are skipped.
+func nativeParentTable() map[int]int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	out := make(map[int]int, len(entries))
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		stat, err := os.ReadFile("/proc/" + e.Name() + "/stat")
+		if err != nil {
+			continue
+		}
+		if ppid, ok := parseProcStatPPID(string(stat)); ok {
+			out[pid] = ppid
+		}
+	}
+	return out
+}

--- a/internal/ports/parents_other.go
+++ b/internal/ports/parents_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package ports
+
+// nativeParentTable has no kernel-provided process table to read outside
+// Linux; ParentTable falls back to `ps`.
+func nativeParentTable() map[int]int { return nil }

--- a/internal/ports/parents_test.go
+++ b/internal/ports/parents_test.go
@@ -1,0 +1,97 @@
+package ports
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// TestParseProcStatPPID covers the Linux shape ParentTable reads: field 2 of
+// /proc/<pid>/stat is the executable name in parentheses, and it may contain
+// both spaces and parentheses of its own, so the ppid can only be found from
+// the last ')' onwards.
+func TestParseProcStatPPID(t *testing.T) {
+	cases := []struct {
+		name string
+		stat string
+		want int
+		ok   bool
+	}{
+		{
+			name: "a plain process",
+			stat: "4242 (listener) S 4200 4200 4200 0 -1 4194304 285 0 0 0 0 0 0 0 20 0 5 0 91234 0 0\n",
+			want: 4200,
+			ok:   true,
+		},
+		{
+			name: "a comm with spaces and parentheses",
+			// Next.js sets process.title to "next-server (v15.0.1)"; the
+			// kernel truncates comm to 15 bytes but keeps what fits verbatim.
+			stat: "812 (next-server (v) S 799 799 640 0 -1 4194560 9021 0 3 0 41 12 0 0 20 0 11 0 5512",
+			want: 799,
+			ok:   true,
+		},
+		{
+			name: "a comm that itself looks like a stat line",
+			stat: "77 (evil) 1 (x) R 5 5 5 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 42",
+			want: 5,
+			ok:   true,
+		},
+		{
+			name: "init, whose parent is the kernel",
+			stat: "1 (systemd) S 0 1 1 0 -1 4194560 30112 0 0 0 90 250 0 0 20 0 1 0 12",
+			want: 0,
+			ok:   true,
+		},
+		{
+			name: "a truncated read",
+			stat: "4242 (listener) S",
+			ok:   false,
+		},
+		{
+			name: "no comm at all",
+			stat: "not a stat line",
+			ok:   false,
+		},
+		{
+			name: "a non-numeric ppid",
+			stat: "4242 (listener) S parent 4200 4200",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseProcStatPPID(tc.stat)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Errorf("ppid = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParentTableFindsThisProcess is the end-to-end check that whichever
+// implementation the platform uses reports a table containing this test and
+// the parent it actually has.
+func TestParentTableFindsThisProcess(t *testing.T) {
+	table := ParentTable()
+	if len(table) == 0 {
+		t.Skip("no process table on this machine")
+	}
+	ppid, ok := table[os.Getpid()]
+	if !ok {
+		t.Fatalf("the table has no entry for this process (pid %d)", os.Getpid())
+	}
+	if ppid != os.Getppid() {
+		t.Errorf("ppid = %d, want %d", ppid, os.Getppid())
+	}
+	if runtime.GOOS == "linux" {
+		// /proc answered, so `ps` was never needed.
+		if native := nativeParentTable(); len(native) == 0 {
+			t.Error("/proc yielded no parent table on Linux")
+		}
+	}
+}

--- a/internal/ports/scan_test.go
+++ b/internal/ports/scan_test.go
@@ -302,3 +302,61 @@ func TestParseNetstat_DualStackWildcard(t *testing.T) {
 		t.Errorf(":: reported %q, want IPv6", byBind["::"])
 	}
 }
+
+// TestParseNetstat_RealCapture runs the parser over a verbatim `netstat -ano`
+// capture: the two header lines, IPv4 and IPv6 listeners, established
+// connections that must be ignored, a LISTENING row owned by pid 0 and a dev
+// server. The Windows daemon sees no ports at all when this parser is wrong,
+// so it is pinned against real output rather than a hand-shaped sample.
+func TestParseNetstat_RealCapture(t *testing.T) {
+	output := "\r\nActive Connections\r\n\r\n" +
+		"  Proto  Local Address          Foreign Address        State           PID\r\n" +
+		"  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1064\r\n" +
+		"  TCP    0.0.0.0:445            0.0.0.0:0              LISTENING       4\r\n" +
+		"  TCP    0.0.0.0:5040           0.0.0.0:0              LISTENING       0\r\n" +
+		"  TCP    127.0.0.1:49670        127.0.0.1:49671        ESTABLISHED     7276\r\n" +
+		"  TCP    127.0.0.1:52341        0.0.0.0:0              LISTENING       7276\r\n" +
+		"  TCP    10.1.0.4:49675         20.209.14.65:443       ESTABLISHED     3812\r\n" +
+		"  TCP    [::]:135               [::]:0                 LISTENING       1064\r\n" +
+		"  TCP    [::1]:52341            [::]:0                 LISTENING       7276\r\n" +
+		"  TCP    [::]:445               [::]:0                 TIME_WAIT       0\r\n" +
+		"  UDP    0.0.0.0:5353           *:*                                    2648\r\n"
+
+	got := parseNetstat(output)
+	if len(got) != 6 {
+		t.Fatalf("parsed %d rows, want the 6 LISTENING ones: %+v", len(got), got)
+	}
+
+	type row struct {
+		pid     int
+		bind    string
+		version string
+	}
+	byKey := map[string]row{}
+	for _, r := range got {
+		byKey[r.PortKey()] = row{r.PID, r.BindAddress, r.IPVersion}
+	}
+	want := map[string]row{
+		"135:0.0.0.0":     {1064, "0.0.0.0", "IPv4"},
+		"445:0.0.0.0":     {4, "0.0.0.0", "IPv4"},
+		"5040:0.0.0.0":    {0, "0.0.0.0", "IPv4"},
+		"52341:127.0.0.1": {7276, "127.0.0.1", "IPv4"},
+		"135:::":          {1064, "::", "IPv6"},
+		"52341:::1":       {7276, "::1", "IPv6"},
+	}
+	for key, w := range want {
+		g, ok := byKey[key]
+		if !ok {
+			t.Errorf("%s missing from the parse: %+v", key, byKey)
+			continue
+		}
+		if g != w {
+			t.Errorf("%s = %+v, want %+v", key, g, w)
+		}
+	}
+	for _, unwanted := range []string{"49670:127.0.0.1", "49675:10.1.0.4", "445:::", "5353:0.0.0.0"} {
+		if _, ok := byKey[unwanted]; ok {
+			t.Errorf("%s was parsed; only TCP LISTENING rows belong in a scan", unwanted)
+		}
+	}
+}

--- a/internal/spawn/name_test.go
+++ b/internal/spawn/name_test.go
@@ -49,14 +49,57 @@ func TestSplitCmd(t *testing.T) {
 		{"", nil},
 	}
 	for _, tc := range cases {
-		got := SplitCmd(tc.in)
-		if len(got) != len(tc.want) {
-			t.Fatalf("SplitCmd(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-		for i := range got {
-			if got[i] != tc.want[i] {
-				t.Fatalf("SplitCmd(%q) = %q, want %q", tc.in, got, tc.want)
-			}
+		assertSplit(t, SplitCmd(tc.in), tc.want, tc.in)
+	}
+}
+
+// TestSplitCmdUnixEscapes pins the POSIX reading: outside single quotes a
+// backslash escapes whatever follows it.
+func TestSplitCmdUnixEscapes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{`/tmp/a\ b/serve --port 3000`, []string{"/tmp/a b/serve", "--port", "3000"}},
+		{`echo "say \"hi\""`, []string{"echo", `say "hi"`}},
+		{`echo 'a\b'`, []string{"echo", `a\b`}},
+		{`echo \\`, []string{"echo", `\`}},
+	}
+	for _, tc := range cases {
+		assertSplit(t, splitCmdFor(tc.in, false), tc.want, tc.in)
+	}
+}
+
+// TestSplitCmdWindowsKeepsBackslashes is the Windows regression: `\` is a path
+// separator there, and treating it as an escape turned
+// `C:\Users\me\listener.exe` into `C:Usersmelistener.exe`, which no `sonar up`
+// could start. Only a quote inside double quotes is escapable, as
+// CommandLineToArgvW reads it.
+func TestSplitCmdWindowsKeepsBackslashes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{`C:\Users\me\listener.exe 3000`, []string{`C:\Users\me\listener.exe`, "3000"}},
+		{`"C:\Program Files\app\app.exe" --port 3000`, []string{`C:\Program Files\app\app.exe`, "--port", "3000"}},
+		{`'C:\Users\me\app.exe' serve`, []string{`C:\Users\me\app.exe`, "serve"}},
+		{`app.exe --dir "C:\logs\\" --port 80`, []string{"app.exe", "--dir", `C:\logs\`, "--port", "80"}},
+		{`echo "say \"hi\""`, []string{"echo", `say "hi"`}},
+		{`npm run dev`, []string{"npm", "run", "dev"}},
+	}
+	for _, tc := range cases {
+		assertSplit(t, splitCmdFor(tc.in, true), tc.want, tc.in)
+	}
+}
+
+func assertSplit(t *testing.T, got, want []string, in string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("split(%q) = %q, want %q", in, got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("split(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/internal/spawn/resolve.go
+++ b/internal/spawn/resolve.go
@@ -3,6 +3,7 @@ package spawn
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/raskrebs/sonar/internal/groups"
@@ -93,11 +94,21 @@ func matchService(cfg *groups.Config, cwd string, argv []string) (string, bool) 
 }
 
 // SplitCmd turns a `.sonar.yaml` `cmd:` string into argv with shell-style
-// quoting and no shell execution (contract §4). Backslash escapes are honoured
-// outside single quotes only, so a Windows path in double quotes survives.
+// quoting and no shell execution (contract §4).
+//
+// Backslashes follow the host's convention, because a `cmd:` is written for
+// the machine it runs on. On Unix a backslash escapes the character after it
+// (outside single quotes), so `/tmp/a\ b` is one argument. On Windows a
+// backslash is a path separator: `C:\srv\app.exe` has to survive verbatim, so
+// a backslash is literal except before a quote or another backslash inside
+// double quotes, which is how CommandLineToArgvW reads a command line.
 func SplitCmd(s string) []string { return splitCmd(s) }
 
-func splitCmd(s string) []string {
+func splitCmd(s string) []string { return splitCmdFor(s, runtime.GOOS == "windows") }
+
+// splitCmdFor is SplitCmd with the platform injected, so both conventions can
+// be tested on one host.
+func splitCmdFor(s string, windows bool) []string {
 	var (
 		out   []string
 		cur   strings.Builder
@@ -118,7 +129,7 @@ func splitCmd(s string) []string {
 			quote, have = c, true
 		case quote != 0 && c == quote:
 			quote = 0
-		case quote != '\'' && c == '\\' && i+1 < len(runes):
+		case c == '\\' && i+1 < len(runes) && escapesNext(quote, runes[i+1], windows):
 			i++
 			cur.WriteRune(runes[i])
 			have = true
@@ -131,4 +142,20 @@ func splitCmd(s string) []string {
 		out = append(out, cur.String())
 	}
 	return out
+}
+
+// escapesNext reports whether a backslash before next is an escape rather than
+// a character of its own, inside the given quote (0 for unquoted).
+func escapesNext(quote, next rune, windows bool) bool {
+	if quote == '\'' {
+		// Single quotes are literal on every platform.
+		return false
+	}
+	if !windows {
+		return true
+	}
+	// Windows: only a quote, or the backslash guarding one, is escapable, and
+	// only inside double quotes. Everywhere else a backslash is a path
+	// separator and stays one.
+	return quote == '"' && (next == '"' || next == '\\')
 }

--- a/internal/store/migrate_ext_test.go
+++ b/internal/store/migrate_ext_test.go
@@ -12,6 +12,14 @@ import (
 )
 
 func TestReservedMigrationFromAnotherPackage(t *testing.T) {
+	// The migration registry is global to the process and refuses a version
+	// twice — which is the last thing this test asserts. A second run in the
+	// same binary (`go test -count=2`) would therefore panic on the very first
+	// registration, so it stands aside once the slot is filled.
+	if store.LatestVersion() >= store.VersionTunnels {
+		t.Skip("migration 003 is already registered in this process")
+	}
+
 	before := store.LatestVersion()
 	if before < store.VersionIndexes {
 		t.Fatalf("LatestVersion = %d before registering, want at least %d", before, store.VersionIndexes)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,6 +9,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -228,10 +229,28 @@ func isCorruption(err error) bool {
 		strings.Contains(msg, "malformed database schema")
 }
 
-// Close releases the database.
+// Close releases the database, leaving one file behind rather than three.
+//
+// WAL keeps a `-wal` and a `-shm` beside the database, and they are written
+// again by whichever pooled connection closes last — after Close has returned,
+// as far as the caller can tell. A daemon that has stopped, or a test whose
+// temp directory is being removed, has no way to wait for that: the removal
+// fails with "directory not empty" against a `-wal` recreated behind it.
+// Checkpointing and leaving WAL mode deletes both sidecars while we still hold
+// the connection that owns them. A busy database refuses the switch; that is
+// the state we were already in, so the error is not worth reporting.
 func (s *Store) Close() error {
 	if s == nil || s.db == nil {
 		return nil
+	}
+	// Drop the idle pool: journal_mode can only change when one connection is
+	// left to change it.
+	s.db.SetMaxIdleConns(0)
+	s.db.SetMaxOpenConns(1)
+	if conn, err := s.db.Conn(context.Background()); err == nil {
+		_, _ = conn.ExecContext(context.Background(), `PRAGMA wal_checkpoint(TRUNCATE)`)
+		_, _ = conn.ExecContext(context.Background(), `PRAGMA journal_mode(DELETE)`)
+		_ = conn.Close()
 	}
 	return s.db.Close()
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -206,3 +206,45 @@ func TestIsCorruptionIgnoresOrdinaryErrors(t *testing.T) {
 		t.Error("sql.ErrNoRows counted as corruption")
 	}
 }
+
+// TestCloseLeavesNoWALSidecars: a closed database has to be one file. The WAL
+// and shared-memory sidecars are rewritten by whichever pooled connection
+// closes last, so a caller that closes the store and then removes the
+// directory — a stopping daemon, a test's t.TempDir cleanup — otherwise races
+// a `-wal` recreated behind the delete and fails with "directory not empty".
+func TestCloseLeavesNoWALSidecars(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sonar.db")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Write something, so there is a WAL to leave behind.
+	if err := s.SetRename("port:8123", "storefront"); err != nil {
+		t.Fatalf("SetRename: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), "-wal") || strings.HasSuffix(e.Name(), "-shm") {
+			t.Errorf("%s survived Close; the database should be a single file", e.Name())
+		}
+	}
+
+	// The data is still there: leaving WAL must checkpoint, not discard.
+	again, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopening: %v", err)
+	}
+	defer func() { _ = again.Close() }()
+	if name, _, err := again.GetRename("port:8123"); err != nil || name != "storefront" {
+		t.Errorf("rename after reopen = %q (%v), want storefront", name, err)
+	}
+}

--- a/scripts/readme-check.sh
+++ b/scripts/readme-check.sh
@@ -59,14 +59,18 @@ cd "$(cd "$project" && pwd -P)"
 # collected, and kept only if one of its lines is the `# check` marker.
 blocks=$work/blocks
 mkdir -p "$blocks"
-awk -v out="$blocks" '
-  /^```sh$/ && !inblock { inblock = 1; n = 0; checked = 0; next }
+awk -v out="$blocks" -v src="$readme" '
+  /^```sh$/ && !inblock { inblock = 1; n = 0; checked = 0; first = NR + 1; next }
   /^```/ && inblock {
     if (checked) {
       count++
       file = sprintf("%s/%03d.sh", out, count)
       for (i = 1; i <= n; i++) print body[i] > file
       close(file)
+      # Where the block lives, so a failure in CI names the lines to edit.
+      where = sprintf("%s/%03d.where", out, count)
+      printf "%s:%d-%d\n", src, first, NR - 1 > where
+      close(where)
     }
     inblock = 0
     next
@@ -90,8 +94,12 @@ for file in "${files[@]}"; do
   if output=$(bash -euo pipefail "$file" 2>&1); then
     printf 'ok   %s\n' "$name"
   else
+    status=$?
     failed=$((failed + 1))
-    printf 'FAIL %s\n' "$name"
+    printf 'FAIL %s (exit %d)\n' "$name" "$status"
+    # The block itself first, then what it printed: a CI log is the only thing
+    # anyone reads after a failure, and it has to be diagnosable on its own.
+    printf '     --- %s ---\n' "$(cat "${file%.sh}.where")"
     sed 's/^/     | /' "$file"
     printf '     --- output ---\n'
     printf '%s\n' "$output" | sed 's/^/     | /'


### PR DESCRIPTION
Fixes the Windows failures of the daemon integration job on main:

- lock a single far byte with LockFileEx so the lock file's pid stays readable by other processes (holder pid in errors and `daemon status`)
- treat lock/sharing violations on open as "still held" so `daemon restart` waits instead of aborting; retry named-pipe creation while the old daemon tears down
- tests stop the daemons they autostart and wait for the lock; per-env pipe names
- `SplitCmd` no longer treats a backslash as an escape on Windows (paths in `.sonar.yaml` commands survived only on unix)
- `.gitattributes` pins the schema and Go sources to LF; the freshness test compares line-ending-agnostically
- test hygiene: unix-socket lock-path case skipped on Windows, a Windows-sized RPC deadline around the kill rescan, scan baseline taken after the subscriber's first tick

The Ubuntu integration failure (run attribution + a hanging cleanup) is fixed on a separate branch; the two will be combined into one PR if branch protection keeps each from merging alone.