### PR TITLE
fix: attribute a port to its run from one lookup and never hang a failing integration test

### DIFF
--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -95,9 +95,16 @@ func newEnv(t *testing.T) *env {
 	return &env{t: t, bin: bin, home: home, socket: socket}
 }
 
+// waitDelay bounds how long Wait may block on a pipe after the process it was
+// waiting for has exited. A stray grandchild holding the inherited stdout
+// keeps that pipe open forever, so without this a test that has already failed
+// hangs until `go test -timeout` shoots it.
+const waitDelay = 5 * time.Second
+
 // command builds a `sonar` invocation pinned to this env.
 func (e *env) command(args ...string) *exec.Cmd {
 	cmd := exec.Command(e.bin, args...)
+	cmd.WaitDelay = waitDelay
 	cmd.Env = append(os.Environ(),
 		"HOME="+e.home,
 		"USERPROFILE="+e.home,
@@ -114,14 +121,12 @@ func (e *env) serve() *exec.Cmd {
 	cmd := e.command("serve")
 	var out strings.Builder
 	cmd.Stdout, cmd.Stderr = &out, &out
+	ownProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		e.t.Fatalf("starting sonar serve: %v", err)
 	}
 	e.t.Cleanup(func() {
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-		}
+		stopCommand(cmd)
 		if e.t.Failed() && out.Len() > 0 {
 			e.t.Logf("daemon output:\n%s", out.String())
 		}

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -44,9 +44,9 @@ type Runtime struct {
 // (group source `start`); internal/daemon/runsreg installs the implementation
 // from its own OnStart hook, so this package never imports it (contract §8).
 type RunRegistry interface {
-	// Run reports the group and name of the run that owns a port, matching
-	// groups.Registry so the resolver can take it as-is.
-	Run(p state.Port) (group, name string, ok bool)
+	// Run reports the run that owns a port, matching groups.Registry so the
+	// resolver can take it as-is.
+	Run(p state.Port) (run state.Run, ok bool)
 	// Prune drops runs whose process is gone.
 	Prune()
 }
@@ -55,8 +55,8 @@ type RunRegistry interface {
 // have to nil-check.
 type noRuns struct{}
 
-func (noRuns) Run(state.Port) (string, string, bool) { return "", "", false }
-func (noRuns) Prune()                                {}
+func (noRuns) Run(state.Port) (state.Run, bool) { return state.Run{}, false }
+func (noRuns) Prune()                           {}
 
 // SetRuns installs the run registry. Called once, from an OnStart hook.
 func (r *Runtime) SetRuns(reg RunRegistry) {

--- a/internal/daemon/runs_integration_test.go
+++ b/internal/daemon/runs_integration_test.go
@@ -106,14 +106,15 @@ func TestStartAttributesItsPortToTheGroup(t *testing.T) {
 	start.Dir = e.home
 	var out safeBuffer
 	start.Stdout, start.Stderr = &out, &out
+	ownProcessGroup(start)
 	if err := start.Start(); err != nil {
 		t.Fatalf("sonar start: %v", err)
 	}
 	t.Cleanup(func() {
-		if start.Process != nil {
-			_ = start.Process.Kill()
-			_ = start.Wait()
-		}
+		// The listener is in a process group of its own and holds the pipe
+		// `out` reads from, so the whole tree has to go before Wait can
+		// return.
+		stopCommand(start)
 		if t.Failed() {
 			t.Logf("sonar start output:\n%s", out.String())
 		}

--- a/internal/daemon/runs_integration_test.go
+++ b/internal/daemon/runs_integration_test.go
@@ -119,9 +119,9 @@ func TestStartAttributesItsPortToTheGroup(t *testing.T) {
 		}
 	})
 
-	added, ok := waitForAddedPort(t, sub, port, 45*time.Second)
+	added, ok := waitForAttributedPort(t, sub, port, 45*time.Second)
 	if !ok {
-		t.Fatalf("no state.delta added port %d within 45s\n%s", port, out.String())
+		t.Fatalf("no state.delta carried port %d with its run within 45s\n%s", port, out.String())
 	}
 
 	if added.Group == nil || *added.Group != "itest" {
@@ -194,9 +194,16 @@ func interrupt(t *testing.T, cmd *exec.Cmd) {
 	}
 }
 
-// waitForAddedPort is waitForAdded, but it hands back the row so the test can
-// assert on the group the resolver put on it.
-func waitForAddedPort(t *testing.T, sub *client.Subscription, port int, timeout time.Duration) (state.Port, bool) {
+// waitForAttributedPort is waitForAdded, but it hands back the row so the test
+// can assert on the group and the run the resolver put on it.
+//
+// It waits for the delta that carries the run rather than the first delta that
+// mentions the port. The two are usually the same one, but they need not be:
+// the child binds its port before `sonar start` has had a chance to tell the
+// daemon who owns it, and a scan tick landing in that window publishes a real
+// listener that genuinely has no run yet. The daemon corrects it in the very
+// next delta, which is the row this test is about.
+func waitForAttributedPort(t *testing.T, sub *client.Subscription, port int, timeout time.Duration) (state.Port, bool) {
 	t.Helper()
 	deadline := time.After(timeout)
 	for {
@@ -205,14 +212,16 @@ func waitForAddedPort(t *testing.T, sub *client.Subscription, port int, timeout 
 			if !ok {
 				return state.Port{}, false
 			}
-			for _, p := range d.Ports.Added {
-				if p.Port == port {
-					return p, true
-				}
-			}
-			for _, p := range d.Ports.Updated {
-				if p.Port == port && p.Group != nil {
-					return p, true
+			for _, rows := range [][]state.Port{d.Ports.Added, d.Ports.Updated} {
+				for _, p := range rows {
+					if p.Port != port {
+						continue
+					}
+					if p.Run != nil {
+						return p, true
+					}
+					t.Logf("delta seq %d has port %d before its run was registered (group %v)",
+						d.Seq, port, p.Group)
 				}
 			}
 		case <-deadline:

--- a/internal/daemon/runsreg/registry.go
+++ b/internal/daemon/runsreg/registry.go
@@ -153,17 +153,21 @@ func (r *Registry) Prune() {
 // Run implements groups.Registry: it attributes a listening port to the run
 // that owns it by walking the port's PPID ancestry, so `npm run dev` -> vite ->
 // esbuild all resolve to the run that started them.
-func (r *Registry) Run(p state.Port) (group, name string, ok bool) {
+//
+// It answers with the whole run because the resolver stamps it onto the row:
+// this registry, not the runs.json mirror the scanner reads, is what a daemon
+// knows about its own runs, and it knows it the moment `runs.register` returns.
+func (r *Registry) Run(p state.Port) (state.Run, bool) {
 	if rec, found := r.ancestor(p.PID, p.PPID); found {
-		return rec.Group, rec.Name, rec.Group != "" || rec.Name != ""
+		return state.Run{ID: rec.ID, Group: rec.Group, Name: rec.Name, RootPID: rec.PID}, true
 	}
 	// The scanner already walked the ancestry against the mirrored file while
 	// enriching this port; trust that rather than walking a process table that
 	// has moved on since.
 	if p.Run != nil && (p.Run.Group != "" || p.Run.Name != "") {
-		return p.Run.Group, p.Run.Name, true
+		return *p.Run, true
 	}
-	return "", "", false
+	return state.Run{}, false
 }
 
 // ancestor walks up from pid looking for a registered run. hintPPID is the

--- a/internal/daemon/runsreg/registry_test.go
+++ b/internal/daemon/runsreg/registry_test.go
@@ -76,13 +76,48 @@ func TestRunAttributesAPortByItsPPIDAncestry(t *testing.T) {
 	// sonar start (100) -> npm (200) -> node (300) -> esbuild (400)
 	r.Parents = func() map[int]int { return map[int]int{400: 300, 300: 200, 200: 100} }
 
-	group, name, ok := r.Run(state.Port{PID: 400, PPID: 300})
-	if !ok || group != "itest" || name != "web" {
-		t.Fatalf("Run(descendant) = %q/%q/%v, want itest/web/true", group, name, ok)
+	run, ok := r.Run(state.Port{PID: 400, PPID: 300})
+	if !ok || run.Group != "itest" || run.Name != "web" || run.RootPID != 100 {
+		t.Fatalf("Run(descendant) = %+v/%v, want itest/web rooted at 100", run, ok)
 	}
 
-	if _, _, ok := r.Run(state.Port{PID: 777, PPID: 1}); ok {
+	if _, ok := r.Run(state.Port{PID: 777, PPID: 1}); ok {
 		t.Fatal("an unrelated listener was attributed to a run")
+	}
+}
+
+// TestRunAttributesTheLinuxScannerShape is the shape a Linux scan hands the
+// resolver: `ss -tlnp` reports the listening pid and nothing else, so the row
+// arrives with PPID 0 and no run of its own. Attribution then has only the
+// process table to work with, and it has to reach the `sonar start` that owns
+// the listener through it.
+func TestRunAttributesTheLinuxScannerShape(t *testing.T) {
+	r := testRegistry(100)
+	r.Register(Record{ID: "a", PID: 100, Group: "itest", Name: "web"})
+	// sonar start (100) -> the listener it spawned (300). ss gave no ppid.
+	r.Parents = func() map[int]int { return map[int]int{300: 100, 100: 42} }
+
+	run, ok := r.Run(state.Port{PID: 300, PPID: 0})
+	if !ok {
+		t.Fatal("a listener spawned by a run was not attributed to it")
+	}
+	if run.ID != "a" || run.Group != "itest" || run.Name != "web" || run.RootPID != 100 {
+		t.Fatalf("Run = %+v, want a/itest/web rooted at 100", run)
+	}
+}
+
+// TestRunAttributesTheRegisteredPIDItself covers `sonar start` in the
+// foreground: the run is registered under the pid of the child it spawned, and
+// that child is the process holding the socket, so no walk is needed and the
+// answer must not depend on a process table being readable at all.
+func TestRunAttributesTheRegisteredPIDItself(t *testing.T) {
+	r := testRegistry(300)
+	r.Register(Record{ID: "a", PID: 300, Group: "itest", Name: "web"})
+	r.Parents = func() map[int]int { t.Fatal("the process table should not be needed"); return nil }
+
+	run, ok := r.Run(state.Port{PID: 300})
+	if !ok || run.ID != "a" || run.Name != "web" || run.RootPID != 300 {
+		t.Fatalf("Run = %+v/%v, want the registered run", run, ok)
 	}
 }
 
@@ -91,19 +126,19 @@ func TestRunUsesTheDirectParentBeforeTheProcessTable(t *testing.T) {
 	r.Register(Record{ID: "a", PID: 100, Group: "itest", Name: "web"})
 	r.Parents = func() map[int]int { t.Fatal("the process table should not be needed"); return nil }
 
-	if group, _, ok := r.Run(state.Port{PID: 200, PPID: 100}); !ok || group != "itest" {
-		t.Fatalf("Run(child) = %q/%v", group, ok)
+	if run, ok := r.Run(state.Port{PID: 200, PPID: 100}); !ok || run.Group != "itest" {
+		t.Fatalf("Run(child) = %+v/%v", run, ok)
 	}
 }
 
 func TestRunFallsBackToTheScannersOwnAttribution(t *testing.T) {
 	r := testRegistry()
-	group, name, ok := r.Run(state.Port{
+	run, ok := r.Run(state.Port{
 		PID: 400,
 		Run: &state.Run{ID: "x", Group: "from-file", Name: "web", RootPID: 100},
 	})
-	if !ok || group != "from-file" || name != "web" {
-		t.Fatalf("Run = %q/%q/%v", group, name, ok)
+	if !ok || run.Group != "from-file" || run.Name != "web" {
+		t.Fatalf("Run = %+v/%v", run, ok)
 	}
 }
 

--- a/internal/daemon/treekill_test.go
+++ b/internal/daemon/treekill_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package daemon_test
+
+import (
+	"os/exec"
+
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+// stopCommand takes a `sonar` invocation down for good and reaps it.
+//
+// Killing only the process the test started is not enough: `sonar start` puts
+// the command it supervises in a process group of its own (daemon spec), so
+// the child survives its parent and keeps holding the stdout pipe it
+// inherited. Wait then blocks forever copying from a pipe nobody will close,
+// which is how a failed assertion turned into a ten-minute CI timeout. The
+// whole tree goes, and env.command's WaitDelay is the backstop for anything
+// that still escapes.
+func stopCommand(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	killTree(cmd)
+	_ = cmd.Wait()
+}
+
+// descendants lists every process below pid in the process table, deepest
+// first, so children are signalled before the parent that could respawn them.
+func descendants(pid int) []int {
+	children := map[int][]int{}
+	for child, parent := range ports.ParentTable() {
+		if child != parent && child > 1 {
+			children[parent] = append(children[parent], child)
+		}
+	}
+	var out []int
+	var walk func(int, int)
+	walk = func(p, depth int) {
+		if depth > 32 {
+			return
+		}
+		for _, c := range children[p] {
+			walk(c, depth+1)
+			out = append(out, c)
+		}
+	}
+	walk(pid, 0)
+	return out
+}

--- a/internal/daemon/treekill_unix_test.go
+++ b/internal/daemon/treekill_unix_test.go
@@ -1,0 +1,32 @@
+//go:build integration && !windows
+
+package daemon_test
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// ownProcessGroup puts a command in a process group of its own so the test can
+// signal it separately from the `go test` process it was started from.
+func ownProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killTree SIGKILLs a command, everything below it in the process table and
+// its process group. All three: a `sonar start` child gets a process group of
+// its own, so the group kill alone would miss it, and the process table can be
+// a scan behind.
+func killTree(cmd *exec.Cmd) {
+	pid := cmd.Process.Pid
+	for _, p := range descendants(pid) {
+		_ = syscall.Kill(p, syscall.SIGKILL)
+	}
+	if pgid, err := syscall.Getpgid(pid); err == nil && pgid > 1 {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+}

--- a/internal/daemon/treekill_windows_test.go
+++ b/internal/daemon/treekill_windows_test.go
@@ -1,0 +1,13 @@
+//go:build integration && windows
+
+package daemon_test
+
+import "os/exec"
+
+// ownProcessGroup is a no-op on Windows: spawn already puts a started command
+// in a Job Object, which is what makes the tree die with it.
+func ownProcessGroup(*exec.Cmd) {}
+
+// killTree kills the command, and the Job Object takes the rest of the tree
+// with it.
+func killTree(cmd *exec.Cmd) { _ = cmd.Process.Kill() }

--- a/internal/groups/attribute.go
+++ b/internal/groups/attribute.go
@@ -55,6 +55,8 @@ func AttributeWith(pp []ports.ListeningPort, pins Pins, runs Registry, index *In
 		}
 	}
 
+	stampRuns(pp, runs)
+
 	resolved := Resolve(state.FromListeningAll(pp), pins, runs, index)
 	for i := range resolved {
 		pp[i].ProjectRoot = deref(resolved[i].ProjectRoot)
@@ -72,4 +74,34 @@ func deref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// stampRuns writes the registry's run attribution onto the scan rows before
+// they are converted, so `run`, `display_name` and `group` are all derived
+// from the same lookup at the same instant.
+//
+// Without this the daemon read the run twice from two places: the scanner
+// walked the mirrored runs.json while enriching (which is what fills `run` and
+// the name `display_name` shows), and the resolver asked the live in-memory
+// registry afterwards (which is what sets `group_source: start`). A run
+// registered in between the two published a port with the group but a null
+// run — the window is milliseconds wide, and on Linux the whole enrich pass is
+// milliseconds long, so a `sonar start` racing the scan tick landed in it.
+//
+// PortRuns, the direct-scan registry, hands back what the row already carries,
+// so this is a no-op without a daemon.
+func stampRuns(pp []ports.ListeningPort, runs Registry) {
+	if runs == nil {
+		return
+	}
+	for i := range pp {
+		if pp[i].PID <= 0 {
+			continue
+		}
+		run, ok := runs.Run(state.FromListening(pp[i]))
+		if !ok || (run.ID == "" && run.Group == "" && run.Name == "") {
+			continue
+		}
+		pp[i].RunID, pp[i].RunGroup, pp[i].Tag, pp[i].RunRootPID = run.ID, run.Group, run.Name, run.RootPID
+	}
 }

--- a/internal/groups/attribute_test.go
+++ b/internal/groups/attribute_test.go
@@ -22,15 +22,16 @@ func (p pinSet) Group(port state.Port) (string, bool) {
 // runSet is a Registry that answers for one port number.
 type runSet struct {
 	port  int
+	id    string
 	group string
 	name  string
 }
 
-func (r runSet) Run(p state.Port) (string, string, bool) {
+func (r runSet) Run(p state.Port) (state.Run, bool) {
 	if p.Port != r.port {
-		return "", "", false
+		return state.Run{}, false
 	}
-	return r.group, r.name, true
+	return state.Run{ID: r.id, Group: r.group, Name: r.name, RootPID: p.PID}, true
 }
 
 func TestAttributeWithAppliesPinsAndRuns(t *testing.T) {
@@ -41,7 +42,7 @@ func TestAttributeWithAppliesPinsAndRuns(t *testing.T) {
 
 	resolved, index := AttributeWith(pp,
 		pinSet{"port:3000": "storefront"},
-		runSet{port: 4000, group: "itest", name: "web"},
+		runSet{port: 4000, id: "r1", group: "itest", name: "web"},
 		nil)
 
 	if index == nil {
@@ -63,6 +64,51 @@ func TestAttributeWithAppliesPinsAndRuns(t *testing.T) {
 	// same attribution.
 	if pp[0].Group != "storefront" || pp[0].GroupSource != "manual" {
 		t.Errorf("scanner row = %q/%q, want storefront/manual", pp[0].Group, pp[0].GroupSource)
+	}
+}
+
+// TestAttributeWithPublishesTheRegistrysRun pins the invariant the daemon
+// broke: whatever the registry says owns a port has to reach the published row
+// as `run` and as the name clients render, not only as the group. A registry
+// answer that set `group_source: start` next to a null `run` is what a
+// `sonar start` racing a scan tick used to publish.
+func TestAttributeWithPublishesTheRegistrysRun(t *testing.T) {
+	pp := []ports.ListeningPort{
+		{Port: 4000, PID: 12, Process: "listener", Command: "/tmp/listener 4000"},
+	}
+
+	resolved, _ := AttributeWith(pp, nil, runSet{port: 4000, id: "r1", group: "itest", name: "web"}, nil)
+
+	if resolved[0].Run == nil {
+		t.Fatal("run is null; the registry's attribution never reached the row")
+	}
+	want := state.Run{ID: "r1", Group: "itest", Name: "web", RootPID: 12}
+	if *resolved[0].Run != want {
+		t.Errorf("run = %+v, want %+v", *resolved[0].Run, want)
+	}
+	if resolved[0].DisplayName != "web" {
+		t.Errorf("display_name = %q, want the name the run gave it", resolved[0].DisplayName)
+	}
+	if resolved[0].GroupSource == nil || *resolved[0].GroupSource != state.SourceStart {
+		t.Errorf("group_source = %v, want start", resolved[0].GroupSource)
+	}
+}
+
+// TestAttributeWithLeavesTheScannersOwnRunAlone is the no-daemon path: there is
+// no registry to ask, so whatever the scanner attributed from runs.json while
+// enriching has to survive.
+func TestAttributeWithLeavesTheScannersOwnRunAlone(t *testing.T) {
+	pp := []ports.ListeningPort{
+		{Port: 4000, PID: 12, Process: "listener", Tag: "web", RunGroup: "itest", RunID: "r1", RunRootPID: 9},
+	}
+
+	resolved, _ := AttributeWith(pp, nil, PortRuns{}, nil)
+
+	if resolved[0].Run == nil || resolved[0].Run.Name != "web" || resolved[0].Run.RootPID != 9 {
+		t.Fatalf("run = %+v, want the scanner's own attribution", resolved[0].Run)
+	}
+	if got := deref(resolved[0].Group); got != "itest" {
+		t.Errorf("group = %q, want itest", got)
 	}
 }
 

--- a/internal/groups/resolve.go
+++ b/internal/groups/resolve.go
@@ -21,32 +21,36 @@ type NoPins struct{}
 // Group never matches.
 func (NoPins) Group(state.Port) (string, bool) { return "", false }
 
-// Registry attributes a port to a process sonar started. The scanner has
-// already walked the PPID ancestry against `runs.json`, so the default
-// implementation just reads what it recorded.
+// Registry attributes a port to a process sonar started. It answers with the
+// whole run, not just its group, because `run`, `display_name` and
+// `group_source: start` all have to come out of one lookup: a daemon that
+// resolved the group from its live registry but the run from the runs.json
+// mirror could publish `group_source: "start"` next to a null `run`.
 type Registry interface {
-	// Run returns the group and name of the run that owns this port.
-	Run(p state.Port) (group, name string, ok bool)
+	// Run returns the run that owns this port.
+	Run(p state.Port) (run state.Run, ok bool)
 }
 
-// PortRuns reads the run attribution the scanner put on the port itself.
+// PortRuns reads the run attribution the scanner put on the port itself. It is
+// the direct-scan path: no daemon, so `runs.json` is the only registry there is.
 type PortRuns struct{}
 
-// Run returns the run's group and name. Until `sonar start` records a group
-// (step 1A.5, contract §11.3) run.group is empty, so this reports ok only for
-// the name; the resolver then falls through to the file and git-root rules.
-func (PortRuns) Run(p state.Port) (group, name string, ok bool) {
+// Run returns the run the scanner already attributed. Until `sonar start`
+// records a group (step 1A.5, contract §11.3) run.group is empty, so this
+// reports ok with only the name; the resolver then falls through to the file
+// and git-root rules.
+func (PortRuns) Run(p state.Port) (state.Run, bool) {
 	if p.Run == nil {
-		return "", "", false
+		return state.Run{}, false
 	}
-	return p.Run.Group, p.Run.Name, true
+	return *p.Run, true
 }
 
 // NoRuns is the empty run registry.
 type NoRuns struct{}
 
 // Run never matches.
-func (NoRuns) Run(state.Port) (string, string, bool) { return "", "", false }
+func (NoRuns) Run(state.Port) (state.Run, bool) { return state.Run{}, false }
 
 // MatchKeys returns the keys a rename or a pin can be stored under for this
 // port, most stable first. The store step matches a stored key against all of
@@ -116,8 +120,8 @@ func resolveOne(p *state.Port, pins Pins, runs Registry, index *Index) {
 		}
 	}
 	if runs != nil {
-		if g, _, ok := runs.Run(*p); ok && g != "" {
-			assign(p, g, state.SourceStart)
+		if run, ok := runs.Run(*p); ok && run.Group != "" {
+			assign(p, run.Group, state.SourceStart)
 			return
 		}
 	}

--- a/internal/groups/resolve_test.go
+++ b/internal/groups/resolve_test.go
@@ -17,9 +17,9 @@ func (f fakePins) Group(p state.Port) (string, bool) {
 type fakeRun struct{ group, name string }
 type fakeRuns map[int]fakeRun
 
-func (f fakeRuns) Run(p state.Port) (string, string, bool) {
+func (f fakeRuns) Run(p state.Port) (state.Run, bool) {
 	r, ok := f[p.Port]
-	return r.group, r.name, ok
+	return state.Run{Group: r.group, Name: r.name}, ok
 }
 
 // resolveFixture builds a repo, a linked worktree, a Compose project inside the

--- a/internal/ports/displayname_darwin.go
+++ b/internal/ports/displayname_darwin.go
@@ -9,43 +9,17 @@ import (
 )
 
 // batchGetCwds returns pid -> cwd for the given PIDs using a single lsof call.
-// lsof -a -p PID,PID,... -d cwd -Fpn produces records like:
-//
-//	p1234
-//	n/Users/me/project
-//	p5678
-//	n/var/empty
+// A non-zero exit is not a failure: see cwdsFromLsof.
 func batchGetCwds(pids []int) map[int]string {
-	result := make(map[int]string)
 	if len(pids) == 0 {
-		return result
+		return map[int]string{}
 	}
 	pidStrs := make([]string, len(pids))
 	for i, p := range pids {
 		pidStrs[i] = strconv.Itoa(p)
 	}
 	out, err := exec.Command("lsof", "-a", "-p", strings.Join(pidStrs, ","), "-d", "cwd", "-Fpn").Output()
-	if err != nil {
-		return result
-	}
-	var current int
-	for _, line := range strings.Split(string(out), "\n") {
-		if line == "" {
-			continue
-		}
-		switch line[0] {
-		case 'p':
-			pid, err := strconv.Atoi(line[1:])
-			if err == nil {
-				current = pid
-			}
-		case 'n':
-			if current != 0 {
-				result[current] = line[1:]
-			}
-		}
-	}
-	return result
+	return cwdsFromLsof(out, err)
 }
 
 // batchGetServiceUnits returns pid -> launchd label using one launchctl list call.

--- a/internal/ports/lsof.go
+++ b/internal/ports/lsof.go
@@ -1,0 +1,58 @@
+package ports
+
+import "strconv"
+
+// cwdsFromLsof turns one `lsof -a -p <pids> -d cwd -Fpn` run into pid -> cwd.
+// The field output is a record per line, `p<pid>` introducing a process and
+// `n<path>` its working directory:
+//
+//	p1234
+//	n/Users/me/project
+//	p5678
+//	n/var/empty
+//
+// The error is honoured only when lsof printed nothing at all — the same rule
+// scanLsof already applies. lsof exits non-zero as soon as one pid it was
+// asked about has gone away, which is routine when the caller is asking about
+// every listener on the machine, and it still prints every record it did
+// resolve. Dropping the whole batch on that error left *every* process without
+// a cwd for that scan, and a process with no cwd has no git root, so its group
+// and its display name silently fell back to something else for one tick and
+// then changed back.
+//
+// It lives outside the darwin-only file so the parsing is tested everywhere,
+// not only on the platform that runs lsof.
+func cwdsFromLsof(out []byte, err error) map[int]string {
+	result := make(map[int]string)
+	if err != nil && len(out) == 0 {
+		return result
+	}
+
+	current := 0
+	start := 0
+	text := string(out)
+	for i := 0; i <= len(text); i++ {
+		if i < len(text) && text[i] != '\n' {
+			continue
+		}
+		line := text[start:i]
+		start = i + 1
+		if line == "" {
+			continue
+		}
+		switch line[0] {
+		case 'p':
+			pid, convErr := strconv.Atoi(line[1:])
+			if convErr == nil && pid > 0 {
+				current = pid
+			} else {
+				current = 0
+			}
+		case 'n':
+			if current != 0 {
+				result[current] = line[1:]
+			}
+		}
+	}
+	return result
+}

--- a/internal/ports/lsof_test.go
+++ b/internal/ports/lsof_test.go
@@ -1,0 +1,64 @@
+package ports
+
+import (
+	"errors"
+	"testing"
+)
+
+// capturedLsof is real `lsof -a -p … -d cwd -Fpn` output from a machine where
+// one of the pids asked about had already exited: lsof reported what it could
+// and exited non-zero.
+const capturedLsof = `p71204
+n/Users/me/src/storefront
+p71209
+n/Users/me/src/storefront/web
+p980
+n/
+`
+
+// nonZeroExit stands in for the *exec.ExitError that Output() returns when
+// lsof exits non-zero; cwdsFromLsof only ever tests it for nil.
+var nonZeroExit = errors.New("exit status 1")
+
+func TestCwdsFromLsofKeepsWhatLsofFoundDespiteANonZeroExit(t *testing.T) {
+	got := cwdsFromLsof([]byte(capturedLsof), nonZeroExit)
+
+	want := map[int]string{
+		71204: "/Users/me/src/storefront",
+		71209: "/Users/me/src/storefront/web",
+		980:   "/",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d cwds, want %d: %v", len(got), len(want), got)
+	}
+	for pid, cwd := range want {
+		if got[pid] != cwd {
+			t.Errorf("cwd of %d = %q, want %q", pid, got[pid], cwd)
+		}
+	}
+}
+
+func TestCwdsFromLsofParsesACleanRun(t *testing.T) {
+	got := cwdsFromLsof([]byte("p1\nn/tmp\n"), nil)
+	if got[1] != "/tmp" {
+		t.Errorf("cwd of 1 = %q, want /tmp", got[1])
+	}
+}
+
+func TestCwdsFromLsofGivesUpOnlyWhenLsofSaidNothing(t *testing.T) {
+	if got := cwdsFromLsof(nil, nonZeroExit); len(got) != 0 {
+		t.Errorf("got %v, want no cwds when lsof produced no output", got)
+	}
+	if got := cwdsFromLsof(nil, errors.New(`exec: "lsof": executable file not found`)); len(got) != 0 {
+		t.Errorf("got %v, want no cwds when lsof is missing", got)
+	}
+}
+
+func TestCwdsFromLsofIgnoresPathsWithNoProcess(t *testing.T) {
+	// A path record before any process record, and a process record that is
+	// not a number, must not attribute a cwd to pid 0 or to the pid before it.
+	got := cwdsFromLsof([]byte("n/orphan\np12\nn/good\npNaN\nn/lost\n"), nil)
+	if len(got) != 1 || got[12] != "/good" {
+		t.Errorf("got %v, want only pid 12 -> /good", got)
+	}
+}

--- a/internal/ports/parents.go
+++ b/internal/ports/parents.go
@@ -1,14 +1,53 @@
 package ports
 
+import (
+	"strconv"
+	"strings"
+)
+
 // ParentTable returns a pid -> ppid map for every process this user can see.
 // It is the same table the scanner builds while enriching listeners, exported
 // so the daemon's runs registry can walk a listener's ancestry back to the
 // `sonar start` that owns it without scanning ports first.
+//
+// On Linux the table comes straight from /proc: no exec, no output parsing,
+// and — unlike `ps` — nothing to install. procps is absent from plenty of
+// container images, and a missing `ps` used to mean every ancestry walk came
+// back empty, so a listener a run had spawned was never attributed to it.
+// Everywhere else, and if /proc is unreadable, one `ps -A` call still answers.
 func ParentTable() map[int]int {
+	if table := nativeParentTable(); len(table) > 0 {
+		return table
+	}
 	info := batchGetPPIDsAndCommands()
 	out := make(map[int]int, len(info))
 	for pid, e := range info {
 		out[pid] = e.ppid
 	}
 	return out
+}
+
+// parseProcStatPPID reads the parent pid out of one /proc/<pid>/stat line.
+//
+// Field 2 is the executable name in parentheses and it may contain spaces and
+// parentheses of its own — Next.js sets its process title to
+// "next-server (v15.0.1)", so the line reads `42 (next-server (v15.0.1)) S 7
+// …`. Splitting on whitespace from the left therefore mis-reads the state and
+// the ppid; the scan starts after the *last* ')' instead, which is where the
+// kernel's own documentation says the fixed-width fields resume: state, then
+// ppid.
+func parseProcStatPPID(stat string) (int, bool) {
+	end := strings.LastIndexByte(stat, ')')
+	if end < 0 {
+		return 0, false
+	}
+	fields := strings.Fields(stat[end+1:])
+	if len(fields) < 2 {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil || ppid < 0 {
+		return 0, false
+	}
+	return ppid, true
 }

--- a/internal/ports/parents_linux.go
+++ b/internal/ports/parents_linux.go
@@ -1,0 +1,31 @@
+package ports
+
+import (
+	"os"
+	"strconv"
+)
+
+// nativeParentTable reads pid -> ppid from /proc, the authoritative source on
+// Linux. Every numeric directory under /proc is a process; its stat file
+// carries the parent. Processes that exit mid-walk are skipped.
+func nativeParentTable() map[int]int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	out := make(map[int]int, len(entries))
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		stat, err := os.ReadFile("/proc/" + e.Name() + "/stat")
+		if err != nil {
+			continue
+		}
+		if ppid, ok := parseProcStatPPID(string(stat)); ok {
+			out[pid] = ppid
+		}
+	}
+	return out
+}

--- a/internal/ports/parents_other.go
+++ b/internal/ports/parents_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package ports
+
+// nativeParentTable has no kernel-provided process table to read outside
+// Linux; ParentTable falls back to `ps`.
+func nativeParentTable() map[int]int { return nil }

--- a/internal/ports/parents_test.go
+++ b/internal/ports/parents_test.go
@@ -1,0 +1,97 @@
+package ports
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// TestParseProcStatPPID covers the Linux shape ParentTable reads: field 2 of
+// /proc/<pid>/stat is the executable name in parentheses, and it may contain
+// both spaces and parentheses of its own, so the ppid can only be found from
+// the last ')' onwards.
+func TestParseProcStatPPID(t *testing.T) {
+	cases := []struct {
+		name string
+		stat string
+		want int
+		ok   bool
+	}{
+		{
+			name: "a plain process",
+			stat: "4242 (listener) S 4200 4200 4200 0 -1 4194304 285 0 0 0 0 0 0 0 20 0 5 0 91234 0 0\n",
+			want: 4200,
+			ok:   true,
+		},
+		{
+			name: "a comm with spaces and parentheses",
+			// Next.js sets process.title to "next-server (v15.0.1)"; the
+			// kernel truncates comm to 15 bytes but keeps what fits verbatim.
+			stat: "812 (next-server (v) S 799 799 640 0 -1 4194560 9021 0 3 0 41 12 0 0 20 0 11 0 5512",
+			want: 799,
+			ok:   true,
+		},
+		{
+			name: "a comm that itself looks like a stat line",
+			stat: "77 (evil) 1 (x) R 5 5 5 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 42",
+			want: 5,
+			ok:   true,
+		},
+		{
+			name: "init, whose parent is the kernel",
+			stat: "1 (systemd) S 0 1 1 0 -1 4194560 30112 0 0 0 90 250 0 0 20 0 1 0 12",
+			want: 0,
+			ok:   true,
+		},
+		{
+			name: "a truncated read",
+			stat: "4242 (listener) S",
+			ok:   false,
+		},
+		{
+			name: "no comm at all",
+			stat: "not a stat line",
+			ok:   false,
+		},
+		{
+			name: "a non-numeric ppid",
+			stat: "4242 (listener) S parent 4200 4200",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseProcStatPPID(tc.stat)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Errorf("ppid = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParentTableFindsThisProcess is the end-to-end check that whichever
+// implementation the platform uses reports a table containing this test and
+// the parent it actually has.
+func TestParentTableFindsThisProcess(t *testing.T) {
+	table := ParentTable()
+	if len(table) == 0 {
+		t.Skip("no process table on this machine")
+	}
+	ppid, ok := table[os.Getpid()]
+	if !ok {
+		t.Fatalf("the table has no entry for this process (pid %d)", os.Getpid())
+	}
+	if ppid != os.Getppid() {
+		t.Errorf("ppid = %d, want %d", ppid, os.Getppid())
+	}
+	if runtime.GOOS == "linux" {
+		// /proc answered, so `ps` was never needed.
+		if native := nativeParentTable(); len(native) == 0 {
+			t.Error("/proc yielded no parent table on Linux")
+		}
+	}
+}


### PR DESCRIPTION
Fixes the Ubuntu daemon integration failure on main (`TestStartAttributesItsPortToTheGroup`: `run is null`, then a 10-minute hang in cleanup). Reproduced in a golang:1.25 container by widening the race.

- `sonar start` forks first and registers the run afterwards, so a scan tick in that window publishes a genuinely unattributed listener; on Linux the scan is fast enough to land there. `group_source` came from the live registry while `run`/`display_name` came from the scanner's re-read of `runs.json`, so a registration between those reads produced `group_source: start` next to `run: null`. `groups.Registry.Run` now returns the whole `state.Run` and it is stamped onto the row before conversion, one lookup for all three fields.
- `ports.ParentTable()` reads `/proc` on Linux and falls back to `ps` elsewhere; a missing procps previously emptied every ancestry walk.
- Integration tests kill the whole process tree of what they start and set `WaitDelay`, so a failure takes seconds instead of the job timeout.
- macOS: `batchGetCwds` no longer discards every cwd when `lsof` exits non-zero because one scanned pid has gone; it parses what lsof printed. This also removes an intermittent display-name difference in the kill JSON parity test.

The Windows integration failures are fixed on #55; the README check on #54.