### PR TITLE
feat: read the per-process working directory from the PEB on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,19 @@ sonar daemon status
 - Linux (uses `ss`)
 - Windows (uses `netstat`)
 
+Grouping needs each process's working directory, and every platform now has
+one: `/proc` on Linux, `lsof` on macOS, and on Windows a read of the process's
+own PEB. So git-root groups, `project_root` and cwd-based names work the same
+everywhere, and `sonar init` can propose a `.sonar.yaml` from what is listening
+on any of the three.
+
+The one gap is a 32-bit `sonar.exe` on 64-bit Windows: it cannot read a 64-bit
+process's memory, so those ports come back without a working directory and fall
+out of their git-root group. Use the 64-bit build — it reads 64-bit and 32-bit
+processes alike. Elsewhere, a port whose process denies access (a service
+running as another user, a protected system process) is simply left without a
+working directory; the rest of the scan is unaffected.
+
 ## Contributors
 
 Thanks to everyone who has contributed to sonar!

--- a/internal/daemon/cwd_integration_test.go
+++ b/internal/daemon/cwd_integration_test.go
@@ -130,12 +130,48 @@ func TestCwdGroupsPortsUnderTheGitRoot(t *testing.T) {
 	t.Logf("sonar list --tree:\n%s", treeOut)
 	section := treeSection(string(treeOut), repoName)
 	if section == nil {
+		// The rows are in the daemon — waitForCwds proved it — so a group
+		// missing from the tree is the display filter, not the scan. `list`
+		// hides desktop apps and `list -a` does not, and is_app is the field
+		// that decides it, so print the rows the filter judged.
+		reportPortRows(t, e, repo, rootPort, nestedPort)
+		reportGroupDiagnostics(t, e, repo, "", nil)
 		t.Fatalf("no %q group in the tree:\n%s", repoName, treeOut)
 	}
 	for _, port := range []int{rootPort, nestedPort} {
 		if !sectionHasPort(section, port) {
 			t.Errorf("port %d is not under the %q group:\n%s", port, repoName, treeOut)
 		}
+	}
+}
+
+// reportPortRows prints everything about the spawned listeners that decides
+// whether they are displayed: their identity, what the OS said about them, and
+// the is_app verdict that follows from it.
+func reportPortRows(t *testing.T, e *env, dir string, wanted ...int) {
+	t.Helper()
+	cmd := e.command("list", "-a", "--json")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("`sonar list -a --json` failed: %v\n%s", err, out)
+		return
+	}
+	var rows []state.Port
+	if err := json.Unmarshal(out, &rows); err != nil {
+		t.Logf("decoding `sonar list -a --json`: %v\n%s", err, out)
+		return
+	}
+	want := map[int]bool{}
+	for _, p := range wanted {
+		want[p] = true
+	}
+	for _, p := range rows {
+		if !want[p.Port] {
+			continue
+		}
+		t.Logf("port %d: is_app=%v process=%q command=%q cwd=%q project_root=%v group=%v type=%s",
+			p.Port, p.IsApp, p.Process, p.Command, p.Cwd, deref(p.ProjectRoot), deref(p.Group), p.Type)
 	}
 }
 

--- a/internal/daemon/cwd_integration_test.go
+++ b/internal/daemon/cwd_integration_test.go
@@ -1,0 +1,275 @@
+//go:build integration
+
+// Roadmap step 1A.10's acceptance path: a listener started inside a git
+// checkout is grouped under the repository, on every platform, with no
+// `.sonar.yaml` anywhere near it.
+//
+// Nothing here is guarded by OS, and that is the whole point. Until the PEB
+// reader landed, `batchGetCwds` was a no-op on Windows, so every row there had
+// an empty cwd, no project_root and no git-root group — and no test said so,
+// because the ones that could have were written to skip. Run with
+// `go test -tags integration ./internal/daemon/...`.
+package daemon_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// TestCwdGroupsPortsUnderTheGitRoot is the demo for step 1A.10: two listeners
+// started inside one checkout — one at its root, one in a subdirectory — carry
+// the working directory they were started in, resolve a project_root at the
+// checkout, and land in the same `<repo>` group in `sonar list --tree` without
+// any config file claiming them.
+func TestCwdGroupsPortsUnderTheGitRoot(t *testing.T) {
+	listener, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newEnv(t)
+
+	// A checkout is a directory with a `.git` entry — groups.Find only ever
+	// Lstats it — so no git binary is needed to make one.
+	repoName := "sonar-cwd-demo"
+	repo := filepath.Join(e.home, repoName)
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repo, "services", "api")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately no .sonar.yaml: the group under test is the git-root one.
+	if _, err := os.Stat(filepath.Join(repo, groups.ConfigName)); err == nil {
+		t.Fatalf("%s exists; this test is about grouping without one", groups.ConfigName)
+	}
+
+	e.serve()
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	c := e.connect(ctx)
+	// A subscriber keeps the daemon's scan loop running: with nobody listening
+	// it parks between requests.
+	sub, err := c.Subscribe(ctx, client.SubscribeOptions{Buffer: 256})
+	if err != nil {
+		t.Fatalf("state.subscribe: %v", err)
+	}
+	go drain(ctx, sub)
+
+	rootPort, nestedPort := unusedPort(t), unusedPort(t)
+	startListener(t, listener, repo, rootPort)
+	startListener(t, listener, nested, nestedPort)
+
+	wantCwd := map[int]string{
+		rootPort:   groups.Canonical(repo),
+		nestedPort: groups.Canonical(nested),
+	}
+	wantRoot := groups.Canonical(repo)
+
+	rows := waitForCwds(t, ctx, c, wantCwd, 90*time.Second)
+
+	for port, want := range wantCwd {
+		p := rows[port]
+		if p.Cwd == "" {
+			t.Errorf("port %d has no cwd; the scanner cannot read this platform's per-process working directory", port)
+			continue
+		}
+		// The raw field is compared canonically because each platform spells
+		// the same directory its own way: /private/var on macOS, the long path
+		// on Windows, the resolved symlink on Linux.
+		if got := groups.Canonical(p.Cwd); got != want {
+			t.Errorf("port %d cwd = %q (canonical %q), want %q", port, p.Cwd, got, want)
+		}
+		// Spellings the rest of sonar must never see, whatever the platform.
+		if strings.HasPrefix(p.Cwd, `\\?\`) {
+			t.Errorf("port %d cwd = %q keeps the extended-length prefix", port, p.Cwd)
+		}
+		if len(p.Cwd) > 1 && strings.HasSuffix(p.Cwd, string(filepath.Separator)) {
+			t.Errorf("port %d cwd = %q keeps a trailing separator", port, p.Cwd)
+		}
+
+		if p.ProjectRoot == nil || *p.ProjectRoot == "" {
+			t.Errorf("port %d has no project_root even though its cwd is %q", port, p.Cwd)
+		} else if got := groups.Canonical(*p.ProjectRoot); got != wantRoot {
+			t.Errorf("port %d project_root = %q (canonical %q), want the checkout %q",
+				port, *p.ProjectRoot, got, wantRoot)
+		}
+
+		if p.Group == nil || *p.Group != repoName {
+			t.Errorf("port %d group = %v, want %q from the git root", port, deref(p.Group), repoName)
+		}
+		if p.GroupSource == nil || *p.GroupSource != state.SourceAuto {
+			t.Errorf("port %d group_source = %v, want %q (no .sonar.yaml claims it)",
+				port, deref((*string)(p.GroupSource)), state.SourceAuto)
+		}
+	}
+
+	// And the demo itself: the tree puts both under one heading named after the
+	// repository.
+	tree := e.command("list", "--tree")
+	tree.Dir = repo
+	treeOut, err := tree.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sonar list --tree: %v\n%s", err, treeOut)
+	}
+	t.Logf("sonar list --tree:\n%s", treeOut)
+	section := treeSection(string(treeOut), repoName)
+	if section == nil {
+		t.Fatalf("no %q group in the tree:\n%s", repoName, treeOut)
+	}
+	for _, port := range []int{rootPort, nestedPort} {
+		if !sectionHasPort(section, port) {
+			t.Errorf("port %d is not under the %q group:\n%s", port, repoName, treeOut)
+		}
+	}
+}
+
+// startListener spawns the helper in dir and registers its cleanup. dir, not
+// the test's own working directory, is what the scanner has to read back.
+func startListener(t *testing.T, listener, dir string, port int) {
+	t.Helper()
+	cmd := exec.Command(listener, strconv.Itoa(port))
+	cmd.Dir = dir
+	cmd.WaitDelay = waitDelay
+	var out safeBuffer
+	cmd.Stdout, cmd.Stderr = &out, &out
+	ownProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting the listener in %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		stopCommand(cmd)
+		if t.Failed() && out.String() != "" {
+			t.Logf("listener on %d:\n%s", port, out.String())
+		}
+	})
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if portOpen(port) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("the listener never came up on %d:\n%s", port, out.String())
+}
+
+// waitForCwds polls ports.list until every wanted port is present with a
+// non-empty cwd, then returns the rows. The scan that first sees a port can
+// race the process's own startup, so a row without a cwd is retried rather than
+// failed on; the timeout is the real assertion.
+func waitForCwds(t *testing.T, ctx context.Context, c *client.Client, want map[int]string, timeout time.Duration) map[int]state.Port {
+	t.Helper()
+	rows := map[int]state.Port{}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var res rpc.PortsListResult
+		if err := c.Call(ctx, "ports.list", rpc.PortsListParams{All: true}, &res); err != nil {
+			t.Fatalf("ports.list: %v", err)
+		}
+		found := 0
+		for _, p := range res.Ports {
+			if _, ok := want[p.Port]; !ok {
+				continue
+			}
+			rows[p.Port] = p
+			if p.Cwd != "" {
+				found++
+			}
+		}
+		if found == len(want) {
+			return rows
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	for port := range want {
+		if p, ok := rows[port]; !ok {
+			t.Errorf("the daemon never reported port %d at all", port)
+		} else {
+			t.Errorf("port %d never got a cwd; last row: %s", port, mustJSON(p))
+		}
+	}
+	t.Fatalf("no cwd on the spawned listeners within %s", timeout)
+	return rows
+}
+
+// drain keeps a subscription alive: a subscriber that stops reading is dropped,
+// and the scan loop parks again with it.
+func drain(ctx context.Context, sub *client.Subscription) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-sub.Deltas:
+			if !ok {
+				return
+			}
+		case _, ok := <-sub.Events:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+// treeSection returns the lines `sonar list --tree` printed under the heading
+// for name: the heading itself is the only line in a block that does not start
+// with a branch character.
+func treeSection(out, name string) []string {
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		if fields := strings.Fields(line); len(fields) == 0 || fields[0] != name {
+			continue
+		}
+		section := []string{lines[i]}
+		for _, next := range lines[i+1:] {
+			if !strings.HasPrefix(next, "├─") && !strings.HasPrefix(next, "└─") {
+				break
+			}
+			section = append(section, next)
+		}
+		return section
+	}
+	return nil
+}
+
+func sectionHasPort(section []string, port int) bool {
+	want := strconv.Itoa(port)
+	for _, line := range section[1:] {
+		for _, f := range strings.Fields(line) {
+			if f == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}
+
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%+v", v)
+	}
+	return string(b)
+}

--- a/internal/daemon/ports.go
+++ b/internal/daemon/ports.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
-	"github.com/raskrebs/sonar/internal/docker"
 	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/scanner"
 	"github.com/raskrebs/sonar/internal/state"
@@ -230,7 +229,7 @@ func handlePortsInspect(_ context.Context, req *Request) (any, error) {
 		return nil, err
 	}
 
-	probe := ports.ProbeHealth(row.BindAddress, row.Port, "/", scanner.HealthTimeout)
+	probe := req.Runtime.Scanner.Probe(row.BindAddress, row.Port, "/", scanner.HealthTimeout)
 	row.Health = &state.Health{
 		Status:    probe.Status,
 		Code:      probe.StatusCode,
@@ -249,14 +248,15 @@ func handlePortsInspect(_ context.Context, req *Request) (any, error) {
 	return rpc.PortsInspectResult{
 		Port:        row,
 		LogSources:  sources,
-		Connections: peersOf(row, rows),
+		Connections: peersOf(req.Runtime, row, rows),
 	}, nil
 }
 
 // peersOf lists the listening ports this one is connected to. It reuses the
-// same established-connection scan `sonar graph` runs.
-func peersOf(row state.Port, rows []state.Port) []rpc.Connection {
-	edges, err := ports.BuildGraph(state.ToListeningAll(rows))
+// same established-connection lookup `sonar graph` runs, through the scanner's
+// seam, and over the listeners the snapshot already gave us.
+func peersOf(rt *Runtime, row state.Port, rows []state.Port) []rpc.Connection {
+	edges, err := rt.Scanner.Graph(state.ToListeningAll(rows))
 	if err != nil {
 		return []rpc.Connection{}
 	}
@@ -367,7 +367,7 @@ func handlePortsHealth(_ context.Context, req *Request) (any, error) {
 		go func(i int) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			r := ports.ProbeHealth(targets[i].BindAddress, targets[i].Port, "/", scanner.HealthTimeout)
+			r := req.Runtime.Scanner.Probe(targets[i].BindAddress, targets[i].Port, "/", scanner.HealthTimeout)
 			// One health vocabulary on the wire: the probe's finer verdict
 			// travels as the reason (step 1A.7).
 			status, reason := state.NormalizeHealth(r.Status)
@@ -389,17 +389,14 @@ func handlePortsGraph(_ context.Context, req *Request) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The listeners come from the snapshot; only the connections between them
+	// are asked of the OS, and that goes through the scanner's seam.
 	listening := state.ToListeningAll(rows)
 
-	edges, err := ports.BuildGraph(listening)
+	edges, err := req.Runtime.Scanner.Graph(listening)
 	if err != nil {
 		return nil, rpc.NewError(rpc.CodeInternal, "building the connection graph: "+err.Error(), "")
 	}
-	containerEdges, err := docker.BuildDockerGraph(listening)
-	if err != nil {
-		return nil, rpc.NewError(rpc.CodeInternal, "building the container graph: "+err.Error(), "")
-	}
-	edges = append(edges, containerEdges...)
 
 	pidOf := map[int]int{}
 	for _, r := range rows {

--- a/internal/daemon/ports_test.go
+++ b/internal/daemon/ports_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
 )
 
 // fakeRows is the snapshot every read handler is exercised against: a user
@@ -44,12 +45,23 @@ func fakeRows() []ports.ListeningPort {
 	}
 }
 
-// newPortsHarness starts a server whose scanner returns fakeRows and returns a
-// connected test client.
+// fakeEdges is the connection graph that goes with fakeRows: the web server on
+// 3000 talks to the database on 5432. It is a fixture rather than a lookup so
+// the graph handler is measured on its own, without netstat, lsof, ss or
+// docker.
+func fakeEdges() []ports.Connection {
+	return []ports.Connection{
+		{FromPort: 3000, FromProcess: "node", ToPort: 5432, ToProcess: "com.docker.backend"},
+	}
+}
+
+// newPortsHarness starts a server whose scanner returns fakeRows and fakeEdges
+// and returns a connected test client.
 func newPortsHarness(t *testing.T, ctx context.Context) *testClient {
 	t.Helper()
 	h := newHarness(t, ctx)
 	h.setRows(fakeRows()...)
+	h.setEdges(fakeEdges()...)
 	return h.dial(ctx)
 }
 
@@ -276,23 +288,35 @@ func TestPortsNextSkipsListeningPorts(t *testing.T) {
 	}
 }
 
+// TestPortsGraphAndHealthShapes measures the two handlers, not the machine
+// underneath them: the connection graph and the health probe both come from
+// the harness's fixtures, so the assertions are exact and the same everywhere.
+// They used to reach the OS — netstat plus a docker inspect for the fake
+// container row, and a real TCP connect — which on the Windows runner overran
+// the harness's read deadline and failed as "read pipe: i/o timeout".
 func TestPortsGraphAndHealthShapes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c := newPortsHarness(t, ctx)
 
 	var graph rpc.PortsGraphResult
-	switch e := c.call("ports.graph", rpc.Empty{}, &graph); {
-	case e == nil:
-		if graph.Connections == nil {
-			t.Fatal("connections must always be an array")
-		}
-	case e.Code == rpc.CodeInternal:
-		// No lsof / ss / docker on this machine: the shape is all this test
-		// can check, and there is nothing to check it against.
-		t.Log("connection graph unavailable here:", e.Message)
-	default:
+	if e := c.call("ports.graph", rpc.Empty{}, &graph); e != nil {
 		t.Fatalf("ports.graph: %v", e)
+	}
+	if graph.Connections == nil {
+		t.Fatal("connections must always be an array")
+	}
+	if len(graph.Connections) != 1 {
+		t.Fatalf("ports.graph = %+v, want the one fixture edge", graph.Connections)
+	}
+	// The pids are the handler's own work: the edge carries ports, and the
+	// handler joins them against the snapshot it already had.
+	want := rpc.GraphEdge{
+		FromPort: 3000, FromPID: 100, FromProcess: "node",
+		ToPort: 5432, ToPID: 200, ToProcess: "com.docker.backend",
+	}
+	if graph.Connections[0] != want {
+		t.Fatalf("ports.graph edge = %+v, want %+v", graph.Connections[0], want)
 	}
 
 	// Probing a port nothing is listening on is the deterministic case: it is
@@ -304,8 +328,43 @@ func TestPortsGraphAndHealthShapes(t *testing.T) {
 	if len(health.Results) != 1 || health.Results[0].Port != 1 {
 		t.Fatalf("ports.health = %+v, want one row for port 1", health.Results)
 	}
-	if health.Results[0].Status == "" {
-		t.Fatal("ports.health returned an empty status")
+	if health.Results[0].Status != state.HealthFail {
+		t.Errorf("ports.health status = %q, want %q", health.Results[0].Status, state.HealthFail)
+	}
+	// The probe's finer verdict travels as the reason (step 1A.7).
+	if health.Results[0].Reason != "refused" {
+		t.Errorf("ports.health reason = %q, want %q", health.Results[0].Reason, "refused")
+	}
+}
+
+// TestPortsGraphAndHealthDoNotRescanListeners pins the other half of the fix:
+// both handlers answer from the snapshot the loop already published, so N
+// clients asking cost the machine no extra listener scan.
+func TestPortsGraphAndHealthDoNotRescanListeners(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+	h.setRows(fakeRows()...)
+	h.setEdges(fakeEdges()...)
+	c := h.dial(ctx)
+
+	// Prime the cache and take the scan counter from there.
+	var list listResult
+	if e := c.call("ports.list", rpc.PortsListParams{}, &list); e != nil {
+		t.Fatalf("ports.list: %v", e)
+	}
+	before := h.loop.Status().Scans
+
+	for i := 0; i < 3; i++ {
+		if e := c.call("ports.graph", rpc.Empty{}, &rpc.PortsGraphResult{}); e != nil {
+			t.Fatalf("ports.graph: %v", e)
+		}
+		if e := c.call("ports.health", rpc.PortsHealthParams{Ports: []int{1}}, &rpc.PortsHealthResult{}); e != nil {
+			t.Fatalf("ports.health: %v", e)
+		}
+	}
+	if got := h.loop.Status().Scans - before; got > 1 {
+		t.Errorf("six reads cost %d listener scans, want at most 1 (the cache TTL)", got)
 	}
 }
 
@@ -383,7 +442,7 @@ func TestPortsWaitTimesOut(t *testing.T) {
 		t.Fatalf("ports.wait: %v", e)
 	}
 
-	deadline := time.After(3 * time.Second)
+	deadline := time.After(settle)
 	done := make(chan rpc.PortsWaitEnd, 1)
 	go func() {
 		msg := c.nextNotification(rpc.MethodStreamEnd)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -17,9 +17,36 @@ import (
 	"github.com/raskrebs/sonar/internal/state"
 )
 
+// pipeWrite and pipeRead bound how long a test will wait on the in-memory
+// connection. They are hang-guards, not latency assertions: a handler that
+// never answers has to fail the test rather than hang it until `go test
+// -timeout` shoots the whole binary, but a handler that answers in 20 ms on a
+// laptop and 4 s on a contended two-core CI runner is not a bug, and a deadline
+// that calls it one produces exactly the flake this suite kept seeing — three
+// different tests, on three different branches, all failing as "read pipe: i/o
+// timeout" at the old 3 s.
+//
+// net.Pipe is synchronous and unbuffered, so the server's write blocks until
+// the test reads; the write deadline needs the same headroom as the read.
+const (
+	pipeWrite = 30 * time.Second
+	pipeRead  = 30 * time.Second
+	// settle is how long a test may wait for work the daemon does on its own
+	// clock — a scan tick, a delta, a stream ending. The scan loop's base
+	// interval is 2 s, so anything under a few of those is a race with the
+	// runner rather than a bound on the daemon.
+	settle = 30 * time.Second
+)
+
 // testHarness is a Server wired to an in-memory connection, so the dispatcher,
 // the codec, the subscription registry and the fan-out are exercised together
 // without touching the filesystem or the OS scanner.
+//
+// "Without touching the OS" is load-bearing and is enforced by the seams below:
+// Scan, Graph and Probe are all faked, so no unit test spawns netstat, lsof,
+// ss, ps, tasklist, powershell or docker, and none opens a real socket. A
+// handler that reaches the OS behind those seams is a bug — it makes the test
+// measure the runner instead of the handler.
 type testHarness struct {
 	t    *testing.T
 	srv  *Server
@@ -28,8 +55,10 @@ type testHarness struct {
 	stopLoop context.CancelFunc
 	loopDone chan struct{}
 
-	mu   sync.Mutex
-	rows []ports.ListeningPort
+	mu    sync.Mutex
+	rows  []ports.ListeningPort
+	edges []ports.Connection
+	probe scanner.Probe
 }
 
 // newHarness builds a server whose scan loop is already running, so a change to
@@ -41,12 +70,29 @@ type testHarness struct {
 func newHarness(t *testing.T, ctx context.Context) *testHarness {
 	t.Helper()
 	h := &testHarness{t: t, loopDone: make(chan struct{})}
+	h.probe = refusedProbe
 	h.loop = scanner.New(scanner.Options{
 		DaemonVersion: "test",
 		Scan: func(scanner.Include) ([]ports.ListeningPort, error) {
 			h.mu.Lock()
 			defer h.mu.Unlock()
 			return append([]ports.ListeningPort{}, h.rows...), nil
+		},
+		// Graph and Probe are faked for the same reason Scan is. A handler
+		// test that let them through would pay for `netstat`/`lsof`/`ss`, a
+		// `docker inspect` and a real TCP connect on whatever machine CI is —
+		// seconds on a Windows runner — and would then be measuring the runner
+		// rather than the handler. See scanner.Options.
+		Graph: func([]ports.ListeningPort) ([]ports.Connection, error) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			return append([]ports.Connection{}, h.edges...), nil
+		},
+		Probe: func(host string, port int, path string, timeout time.Duration) ports.HealthResult {
+			h.mu.Lock()
+			probe := h.probe
+			h.mu.Unlock()
+			return probe(host, port, path, timeout)
 		},
 	})
 	h.srv = New(Options{Socket: "/test/sonar.sock", Version: "test", Scanner: h.loop})
@@ -86,6 +132,26 @@ func (h *testHarness) setRows(rows ...ports.ListeningPort) {
 	h.mu.Unlock()
 }
 
+// setEdges replaces the connections the fake graph reports.
+func (h *testHarness) setEdges(edges ...ports.Connection) {
+	h.mu.Lock()
+	h.edges = edges
+	h.mu.Unlock()
+}
+
+// setProbe replaces the fake health probe.
+func (h *testHarness) setProbe(p scanner.Probe) {
+	h.mu.Lock()
+	h.probe = p
+	h.mu.Unlock()
+}
+
+// refusedProbe is the harness default: nothing is really listening behind the
+// fake rows, so every probe is refused, deterministically and instantly.
+func refusedProbe(_ string, _ int, _ string, _ time.Duration) ports.HealthResult {
+	return ports.HealthResult{Status: "refused"}
+}
+
 // dial attaches a client to the server over an in-memory pipe.
 func (h *testHarness) dial(ctx context.Context) *testClient {
 	h.t.Helper()
@@ -112,7 +178,7 @@ func (c *testClient) send(method string, params any) string {
 	if err != nil {
 		c.t.Fatalf("marshalling params: %v", err)
 	}
-	c.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	c.conn.SetWriteDeadline(time.Now().Add(pipeWrite))
 	if err := json.NewEncoder(c.conn).Encode(rpc.Request{
 		JSONRPC: rpc.Version, ID: id, Method: method, Params: raw,
 	}); err != nil {
@@ -124,7 +190,7 @@ func (c *testClient) send(method string, params any) string {
 // read returns the next message from the daemon.
 func (c *testClient) read() rpc.Message {
 	c.t.Helper()
-	c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	c.conn.SetReadDeadline(time.Now().Add(pipeRead))
 	line, err := c.r.ReadBytes('\n')
 	if err != nil {
 		c.t.Fatalf("reading from daemon: %v", err)
@@ -304,7 +370,7 @@ func TestSubscribeThenDelta(t *testing.T) {
 
 	var delta state.Delta
 	var event state.Event
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(settle)
 	for (len(delta.Ports.Added) == 0 || event.Kind == "") && time.Now().Before(deadline) {
 		m := c.read()
 		switch m.Method {
@@ -463,7 +529,7 @@ func TestOversizeMessageIsRejectedNotFatal(t *testing.T) {
 	c := newHarness(t, ctx).dial(ctx)
 
 	go func() {
-		c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		c.conn.SetWriteDeadline(time.Now().Add(pipeWrite))
 		io.WriteString(c.conn, `{"jsonrpc":"2.0","id":1,"method":"daemon.status","params":{"pad":"`)
 		chunk := strings.Repeat("x", 64<<10)
 		for written := 0; written < MaxMessageBytes+(1<<20); written += len(chunk) {

--- a/internal/daemon/up_integration_test.go
+++ b/internal/daemon/up_integration_test.go
@@ -254,10 +254,10 @@ func keys(m map[int]bool) []int {
 //
 // It runs in the project directory on purpose: `sonar groups` is a direct-scan
 // command, and the only directories it indexes are the caller's own and the
-// working directories of the processes it scanned. The second half does not
-// exist on Windows — there is no per-process cwd the scanner can read — so
-// asking from somewhere else is asking a question the command cannot answer
-// there.
+// working directories of the processes it scanned. The second half is best
+// effort — a process may refuse the scanner the handle it needs — so asking
+// from somewhere else is asking a question the command may not be able to
+// answer.
 func waitForGroupStatus(t *testing.T, e *env, dir, name, want string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)

--- a/internal/display/tree.go
+++ b/internal/display/tree.go
@@ -26,6 +26,7 @@ func RenderTree(w io.Writer, pp []ports.ListeningPort, gg []state.Group) {
 		fmt.Fprintln(w, "No listening ports found.")
 		return
 	}
+	pp = dedupeFamilies(pp)
 
 	byGroup := map[string][]ports.ListeningPort{}
 	for _, p := range pp {
@@ -89,6 +90,41 @@ func RenderTree(w io.Writer, pp []ports.ListeningPort, gg []state.Group) {
 	}
 
 	fmt.Fprintf(w, "\n%s\n", Dim(treeSummary(len(pp), len(names), byGroup)))
+}
+
+// dedupeFamilies collapses the rows one process contributes for one port.
+//
+// A service bound on both families is two rows — 127.0.0.1 and [::1] — and the
+// table view is right to show both: they are two sockets, and which one a
+// client reaches matters. The tree is a different question. It answers "what is
+// running, and which project does it belong to", and printing
+//
+//	├─ 49665  wininit.exe   http://localhost:49665
+//	├─ 49665  wininit.exe   http://localhost:49665
+//
+// answers it twice, inflates every group's port count, and is worst exactly
+// where the tree is most useful — a dual-stack dev server under its repo.
+//
+// The first row for a (port, pid) pair wins, so the ordering the scanner
+// produces decides which address is shown, and `--json` and the table keep
+// every row. A pid of 0 (an identity the scanner could not resolve) still
+// collapses per port: two families of one unknown listener are one listener.
+func dedupeFamilies(pp []ports.ListeningPort) []ports.ListeningPort {
+	type key struct {
+		port int
+		pid  int
+	}
+	seen := make(map[key]bool, len(pp))
+	out := make([]ports.ListeningPort, 0, len(pp))
+	for _, p := range pp {
+		k := key{port: p.Port, pid: p.PID}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, p)
+	}
+	return out
 }
 
 // groupHeader is the "name  (n ports, status)" line, with the group's root

--- a/internal/display/tree_test.go
+++ b/internal/display/tree_test.go
@@ -62,6 +62,50 @@ ungrouped  (1 port)
 	}
 }
 
+// TestRenderTreeCollapsesDualStackRows: a service listening on both families
+// is one entry in the tree, and the port count says one. Windows shows this
+// most — every listener there comes back as an IPv4 row and an IPv6 row — and
+// the tree printed each one twice, under a heading claiming twice the ports.
+func TestRenderTreeCollapsesDualStackRows(t *testing.T) {
+	NoColor = true
+	pp := []ports.ListeningPort{
+		{Port: 8000, BindAddress: "127.0.0.1", PID: 42, Process: "python3", Group: "api"},
+		{Port: 8000, BindAddress: "::1", PID: 42, Process: "python3", Group: "api"},
+		// Same port, a different process: two listeners, two rows.
+		{Port: 9000, BindAddress: "127.0.0.1", PID: 7, Process: "node", Group: "api"},
+		{Port: 9000, BindAddress: "127.0.0.2", PID: 8, Process: "node", Group: "api"},
+	}
+
+	var buf bytes.Buffer
+	RenderTree(&buf, pp, nil)
+	got := buf.String()
+
+	rows := 0
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "├─") || strings.HasPrefix(line, "└─") {
+			rows++
+		}
+	}
+	if rows != 3 {
+		t.Errorf("the tree printed %d rows, want 3:\n%s", rows, got)
+	}
+	if n := strings.Count(got, ":8000"); n != 1 {
+		t.Errorf("port 8000 appears %d times, want once:\n%s", n, got)
+	}
+	// Same port, two pids: two listeners, and collapsing them would hide a
+	// genuine conflict.
+	if n := strings.Count(got, ":9000"); n != 2 {
+		t.Errorf("port 9000 appears %d times, want twice (two pids):\n%s", n, got)
+	}
+	if !strings.Contains(got, "3 ports") {
+		t.Errorf("the summary does not count the rows it printed:\n%s", got)
+	}
+	// The first row for a pair wins, so the IPv4 address is the one shown.
+	if !strings.Contains(got, "http://127.0.0.1:8000") {
+		t.Errorf("the surviving row is not the first one:\n%s", got)
+	}
+}
+
 func TestRenderTreeEmpty(t *testing.T) {
 	NoColor = true
 	var buf bytes.Buffer

--- a/internal/groups/index.go
+++ b/internal/groups/index.go
@@ -193,13 +193,15 @@ func (x *Index) Invalid() []InvalidConfig {
 // contains it, or one of whose services declares it, with the process cwd
 // under the file's directory. The deepest matching config wins.
 //
-// A port with no cwd is not out of reach. Windows has no per-process working
-// directory the scanner can read (see ports.batchGetCwds), so requiring one
-// left every `.sonar.yaml` unable to claim the ports it declares there — the
-// group existed in the index and no listener ever joined it. When the cwd is
-// missing the question that remains is still answerable: is there exactly one
-// known config claiming this port? One is an answer. Two is a guess, and a
-// guess is worse than no group at all.
+// A port with no cwd is not out of reach. Every platform can read a working
+// directory now (see ports.batchGetCwds), but plenty of individual rows still
+// arrive without one: a Docker container has no cwd of its own, and a process
+// that denies the scanner access keeps its own. Requiring one left every
+// `.sonar.yaml` unable to claim the ports it declares — the group existed in
+// the index and no listener ever joined it. When the cwd is missing the
+// question that remains is still answerable: is there exactly one known config
+// claiming this port? One is an answer. Two is a guess, and a guess is worse
+// than no group at all.
 func (x *Index) MatchPort(p state.Port) (*Config, string, bool) {
 	if p.Cwd != "" {
 		for _, cfg := range x.Configs() {

--- a/internal/groups/windows_paths_test.go
+++ b/internal/groups/windows_paths_test.go
@@ -1,0 +1,161 @@
+package groups
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Until the PEB reader landed, no port on Windows had a cwd, so nothing in this
+// package was ever asked a question shaped like `C:\src\api`. These tests ask
+// it. The first two run everywhere — filepath is the platform's own separator,
+// so on the Windows runner they are the drive-letter case and on macOS they are
+// the regression guard — and the third is the literal backslash table, which
+// only means anything where backslash is the separator.
+
+// TestFindAcceptsEverySpellingOfTheSameCheckout: the scanner's cwd and a
+// caller's own directory reach Find spelled differently — with a trailing
+// separator, with a redundant `.`, through a nested subdirectory — and all of
+// them have to name one root, or one project becomes several groups.
+func TestFindAcceptsEverySpellingOfTheSameCheckout(t *testing.T) {
+	base := tempTree(t)
+	clone := mkdir(t, base, "api")
+	mkdir(t, clone, ".git")
+	deep := mkdir(t, clone, "services", "web")
+
+	spellings := []string{
+		clone,
+		clone + string(filepath.Separator),
+		filepath.Join(clone, "."),
+		deep,
+		deep + string(filepath.Separator),
+		filepath.Join(deep, "..", "..", "services", "web"),
+	}
+	for _, cwd := range spellings {
+		root, worktree, ok := Find(cwd)
+		if !ok {
+			t.Errorf("Find(%q) found no checkout", cwd)
+			continue
+		}
+		if root != clone {
+			t.Errorf("Find(%q) root = %q, want %q", cwd, root, clone)
+		}
+		if worktree != "" {
+			t.Errorf("Find(%q) worktree = %q, want none", cwd, worktree)
+		}
+		if got := GroupName(root, worktree); got != "api" {
+			t.Errorf("GroupName for %q = %q, want %q", cwd, got, "api")
+		}
+	}
+}
+
+// TestCanonicalCollapsesTheSpellingsToOneKey: the group index is a map keyed by
+// directory, so two spellings of one directory are two groups. Canonical is the
+// only thing standing between the PEB's spelling and that split.
+func TestCanonicalCollapsesTheSpellingsToOneKey(t *testing.T) {
+	base := tempTree(t)
+	dir := mkdir(t, base, "api", "services", "web")
+
+	want := Canonical(dir)
+	if want == "" {
+		t.Fatal("Canonical returned nothing for a directory that exists")
+	}
+	if strings.HasSuffix(want, string(filepath.Separator)) && filepath.Dir(want) != want {
+		t.Errorf("Canonical(%q) = %q, which keeps a trailing separator", dir, want)
+	}
+	for _, spelling := range []string{
+		dir + string(filepath.Separator),
+		filepath.Join(dir, "."),
+		filepath.Join(dir, "..", "web"),
+	} {
+		if got := Canonical(spelling); got != want {
+			t.Errorf("Canonical(%q) = %q, want %q", spelling, got, want)
+		}
+	}
+}
+
+// TestWindowsPathShapes is the drive-letter and backslash table. filepath's
+// behaviour for `C:\…` only exists on Windows — elsewhere a backslash is an
+// ordinary character in a file name — so this is the assertion the runner makes
+// and the developer machine cannot.
+func TestWindowsPathShapes(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("drive letters and backslashes are only path syntax on Windows")
+	}
+	base := tempTree(t)
+	clone := mkdir(t, base, "api")
+	mkdir(t, clone, ".git")
+	deep := mkdir(t, clone, "services", "web")
+
+	if !strings.Contains(clone, `\`) || filepath.VolumeName(clone) == "" {
+		t.Fatalf("the temp checkout %q is not a drive-letter path", clone)
+	}
+
+	// The PEB hands back a backslash path; a config or an env var may hand back
+	// the same directory with forward slashes, and Windows accepts both.
+	forward := strings.ReplaceAll(deep, `\`, `/`)
+	if got, want := Canonical(forward), Canonical(deep); got != want {
+		t.Errorf("Canonical(%q) = %q, want %q — forward slashes are a second key", forward, got, want)
+	}
+	if got := Canonical(deep); strings.Contains(got, "/") {
+		t.Errorf("Canonical(%q) = %q, which still contains a forward slash", deep, got)
+	}
+
+	// The drive letter's case is not a second project either.
+	lower := strings.ToLower(clone[:1]) + clone[1:]
+	upper := strings.ToUpper(clone[:1]) + clone[1:]
+	if got, want := Canonical(lower), Canonical(upper); got != want {
+		t.Errorf("Canonical(%q) = %q but Canonical(%q) = %q", lower, got, upper, want)
+	}
+
+	// Find walks up with filepath.Dir, which has to stop at the drive root
+	// rather than loop, and GroupName has to take the directory name off a
+	// backslash path.
+	root, worktree, ok := Find(forward)
+	if !ok || root != Canonical(clone) {
+		t.Errorf("Find(%q) = %q, %q, %v; want %q", forward, root, worktree, ok, Canonical(clone))
+	}
+	if got := GroupName(root, worktree); got != "api" {
+		t.Errorf("GroupName(%q) = %q, want %q", root, got, "api")
+	}
+
+	// A directory that is not in any checkout still terminates: the walk from a
+	// drive root has nowhere left to go.
+	outside := filepath.VolumeName(clone) + `\`
+	if _, _, ok := Find(outside); ok {
+		if _, err := os.Stat(filepath.Join(outside, ".git")); err != nil {
+			t.Errorf("Find(%q) claimed a checkout at the drive root", outside)
+		}
+	}
+}
+
+// TestWindowsWorktreeGitFile: a linked worktree's `.git` file holds a backslash
+// gitdir on Windows, and the `<repo>@<worktree>` name is parsed straight out of
+// it.
+func TestWindowsWorktreeGitFile(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("backslash gitdir lines only occur on Windows")
+	}
+	base := tempTree(t)
+	clone := mkdir(t, base, "sonar")
+	mkdir(t, clone, ".git")
+	wt := mkdir(t, base, "sonar-feature")
+	writeFile(t, filepath.Join(wt, ".git"),
+		"gitdir: "+filepath.Join(clone, ".git", "worktrees", "sonar-feature")+"\r\n")
+
+	root, worktree, ok := Find(wt)
+	if !ok {
+		t.Fatalf("Find(%q) found no checkout", wt)
+	}
+	if root != Canonical(wt) {
+		t.Errorf("root = %q, want %q", root, Canonical(wt))
+	}
+	if worktree != "sonar@sonar-feature" {
+		t.Errorf("worktree = %q, want %q", worktree, "sonar@sonar-feature")
+	}
+	if got := GroupName(root, worktree); got != "sonar@sonar-feature" {
+		t.Errorf("GroupName = %q, want %q", got, "sonar@sonar-feature")
+	}
+}

--- a/internal/ports/cwd_other.go
+++ b/internal/ports/cwd_other.go
@@ -1,0 +1,11 @@
+//go:build !linux && !darwin && !windows
+
+package ports
+
+// batchGetCwds is a no-op on platforms with no per-process cwd lookup of their
+// own. Linux reads /proc, macOS asks lsof and Windows reads the PEB; anything
+// else leaves Cwd empty, and the cwd-augmentation step in resolveProcessName is
+// simply skipped.
+func batchGetCwds(pids []int) map[int]string {
+	return nil
+}

--- a/internal/ports/cwd_peb.go
+++ b/internal/ports/cwd_peb.go
@@ -1,0 +1,205 @@
+package ports
+
+import (
+	"strings"
+	"unicode/utf16"
+	"unsafe"
+)
+
+// Windows keeps a process's current directory in its own address space, in the
+// PEB, not in any table the kernel will hand out. Reading it is therefore
+// pointer arithmetic over three hops of foreign memory:
+//
+//	PEB.ProcessParameters                     -> RTL_USER_PROCESS_PARAMETERS
+//	RTL_USER_PROCESS_PARAMETERS.CurrentDirectory.DosPath -> UNICODE_STRING
+//	UNICODE_STRING.Buffer                     -> the UTF-16 path itself
+//
+// None of that arithmetic needs Windows to be exercised, so the offsets and the
+// decoding live here, in a file that builds everywhere and is unit-tested on
+// the developer's machine. cwd_windows.go supplies the three reads.
+
+// pebLayout is the byte geometry of those structures for one pointer size.
+// Every field is an offset in bytes from the start of its structure.
+type pebLayout struct {
+	// ptrSize is the width of a pointer in the target process: 8 for a 64-bit
+	// process read from a 64-bit sonar, 4 for a 32-bit process read from a
+	// 32-bit sonar.
+	ptrSize int
+	// processParameters is PEB.ProcessParameters.
+	processParameters uintptr
+	// currentDirectory is RTL_USER_PROCESS_PARAMETERS.CurrentDirectory.DosPath,
+	// i.e. the UNICODE_STRING at the head of the CURDIR.
+	currentDirectory uintptr
+	// unicodeBuffer is UNICODE_STRING.Buffer; unicodeSize is sizeof(UNICODE_STRING).
+	unicodeBuffer uintptr
+	unicodeSize   int
+}
+
+// layout64 is the geometry for 64-bit targets, spelled out so a test can pin it
+// without trusting the same arithmetic it is checking. These are the numbers
+// every debugger prints for ntdll's structures on amd64/arm64.
+var layout64 = pebLayout{
+	ptrSize:           8,
+	processParameters: 0x20,
+	currentDirectory:  0x38,
+	unicodeBuffer:     0x08,
+	unicodeSize:       0x10,
+}
+
+// layout32 is the same geometry for 32-bit targets.
+var layout32 = pebLayout{
+	ptrSize:           4,
+	processParameters: 0x10,
+	currentDirectory:  0x24,
+	unicodeBuffer:     0x04,
+	unicodeSize:       0x08,
+}
+
+// The mirror structs below exist only so the layout can be *derived* rather
+// than asserted: Go lays them out with the same natural alignment the C
+// declarations get, so unsafe.Offsetof reproduces ntdll's offsets for whatever
+// word size this binary was built for. They are never allocated.
+
+type mirrorUnicodeString struct {
+	Length        uint16
+	MaximumLength uint16
+	Buffer        uintptr
+}
+
+type mirrorCurDir struct {
+	DosPath mirrorUnicodeString
+	Handle  uintptr
+}
+
+type mirrorProcessParameters struct {
+	MaximumLength    uint32
+	Length           uint32
+	Flags            uint32
+	DebugFlags       uint32
+	ConsoleHandle    uintptr
+	ConsoleFlags     uint32
+	StandardInput    uintptr
+	StandardOutput   uintptr
+	StandardError    uintptr
+	CurrentDirectory mirrorCurDir
+}
+
+type mirrorPEB struct {
+	InheritedAddressSpace    byte
+	ReadImageFileExecOptions byte
+	BeingDebugged            byte
+	BitField                 byte
+	Mutant                   uintptr
+	ImageBaseAddress         uintptr
+	Ldr                      uintptr
+	ProcessParameters        uintptr
+}
+
+// nativeLayout is the geometry of a process with this binary's own word size.
+// A 64-bit sonar reads 64-bit PEBs — including those of WOW64 processes, which
+// keep a populated 64-bit PEB alongside their 32-bit one.
+func nativeLayout() pebLayout {
+	return pebLayout{
+		ptrSize:           int(unsafe.Sizeof(uintptr(0))),
+		processParameters: unsafe.Offsetof(mirrorPEB{}.ProcessParameters),
+		currentDirectory:  unsafe.Offsetof(mirrorProcessParameters{}.CurrentDirectory),
+		unicodeBuffer:     unsafe.Offsetof(mirrorUnicodeString{}.Buffer),
+		unicodeSize:       int(unsafe.Sizeof(mirrorUnicodeString{})),
+	}
+}
+
+// pointerAt decodes the little-endian pointer stored at off. ok is false when
+// buf is too short, which is how a short or refused ReadProcessMemory surfaces.
+func (l pebLayout) pointerAt(buf []byte, off uintptr) (addr uint64, ok bool) {
+	end := off + uintptr(l.ptrSize)
+	if uintptr(len(buf)) < end {
+		return 0, false
+	}
+	for i := l.ptrSize - 1; i >= 0; i-- {
+		addr = addr<<8 | uint64(buf[off+uintptr(i)])
+	}
+	return addr, true
+}
+
+// unicodeStringAt decodes the UNICODE_STRING that starts at off: its Length (in
+// bytes, not characters — the field is famously not a count of runes) and the
+// address of its buffer. ok is false for a truncated read, an odd Length, an
+// empty Length or a null buffer. Length needs no upper bound of its own: it is
+// a uint16, so the worst a wrong offset can ask us to allocate is 64 KiB.
+func (l pebLayout) unicodeStringAt(buf []byte, off uintptr) (length int, addr uint64, ok bool) {
+	if uintptr(len(buf)) < off+uintptr(l.unicodeSize) {
+		return 0, 0, false
+	}
+	length = int(buf[off]) | int(buf[off+1])<<8
+	addr, ok = l.pointerAt(buf, off+l.unicodeBuffer)
+	if !ok || addr == 0 {
+		return 0, 0, false
+	}
+	if length <= 0 || length%2 != 0 {
+		return 0, 0, false
+	}
+	return length, addr, true
+}
+
+// decodeUTF16LE turns the raw bytes of a UNICODE_STRING buffer into a Go
+// string. A trailing NUL is dropped: the PEB's DosPath is usually NUL-padded
+// even though Length excludes the terminator, and a stray one would otherwise
+// travel all the way into a group name.
+func decodeUTF16LE(b []byte) string {
+	units := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		units = append(units, uint16(b[i])|uint16(b[i+1])<<8)
+	}
+	for len(units) > 0 && units[len(units)-1] == 0 {
+		units = units[:len(units)-1]
+	}
+	return string(utf16.Decode(units))
+}
+
+// normalizeWindowsCwd turns the PEB's spelling of a directory into the one the
+// rest of sonar uses as a map key.
+//
+// Two things have to go. The PEB always stores a trailing backslash
+// (`C:\src\api\`), and groups.Canonical — which is filepath.Clean plus
+// EvalSymlinks — never produces one, so an unstripped path is a second entry
+// for the same directory and the group silently splits in two. And the
+// extended-length `\\?\` prefix, which shows up for processes started with a
+// long path, is not a spelling any other tool prints: `\\?\C:\src` and
+// `C:\src` are the same directory and must not be two groups. `\\?\UNC\host\share`
+// is the same escape for a network path and unfolds back to `\\host\share`.
+//
+// A bare drive root keeps its backslash: `C:\` is the root of C:, while `C:`
+// on its own means "whatever directory that drive is parked at", which is a
+// different — and unstable — place.
+func normalizeWindowsCwd(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	if rest, found := strings.CutPrefix(s, `\\?\`); found {
+		if unc, isUNC := strings.CutPrefix(rest, `UNC\`); isUNC {
+			s = `\\` + unc
+		} else {
+			s = rest
+		}
+	}
+	for len(s) > 1 && (s[len(s)-1] == '\\' || s[len(s)-1] == '/') {
+		if isDriveRoot(s) {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// isDriveRoot reports whether s is exactly `X:\` or `X:/`.
+func isDriveRoot(s string) bool {
+	if len(s) != 3 || s[1] != ':' {
+		return false
+	}
+	if s[2] != '\\' && s[2] != '/' {
+		return false
+	}
+	c := s[0]
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}

--- a/internal/ports/cwd_peb_test.go
+++ b/internal/ports/cwd_peb_test.go
@@ -1,0 +1,245 @@
+package ports
+
+import (
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+// The PEB walk is pointer arithmetic over another process's memory: get an
+// offset wrong and ReadProcessMemory happily returns bytes that decode into a
+// plausible path from the wrong field. Nothing here needs Windows — the
+// geometry and the decoding are the same numbers on any host — so it is pinned
+// twice: against the offsets Go derives from the mirror structs, and against
+// the constants a debugger prints for ntdll on a 64-bit machine.
+
+func TestNativeLayoutMatchesTheHardCoded64BitGeometry(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Skip("the 64-bit table only describes a 64-bit host")
+	}
+	got := nativeLayout()
+	if got != layout64 {
+		t.Fatalf("nativeLayout() = %+v, want %+v", got, layout64)
+	}
+	// Spelled out again so a change to layout64 cannot quietly agree with a
+	// change to the mirror structs.
+	if got.processParameters != 0x20 {
+		t.Errorf("PEB.ProcessParameters = %#x, want 0x20", got.processParameters)
+	}
+	if got.currentDirectory != 0x38 {
+		t.Errorf("RTL_USER_PROCESS_PARAMETERS.CurrentDirectory = %#x, want 0x38", got.currentDirectory)
+	}
+	if got.unicodeBuffer != 0x08 || got.unicodeSize != 0x10 {
+		t.Errorf("UNICODE_STRING buffer/size = %#x/%#x, want 0x8/0x10", got.unicodeBuffer, got.unicodeSize)
+	}
+}
+
+func TestLayout32IsTheHalfWidthGeometry(t *testing.T) {
+	want := pebLayout{ptrSize: 4, processParameters: 0x10, currentDirectory: 0x24, unicodeBuffer: 0x04, unicodeSize: 0x08}
+	if layout32 != want {
+		t.Fatalf("layout32 = %+v, want %+v", layout32, want)
+	}
+}
+
+func TestPointerAtDecodesLittleEndianAndRefusesShortReads(t *testing.T) {
+	buf := []byte{
+		0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, // 0x00000000deadbeef
+		0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x00, // 0x0077665544332211
+	}
+	if got, ok := layout64.pointerAt(buf, 0); !ok || got != 0xdeadbeef {
+		t.Errorf("pointerAt(0) = %#x, %v; want 0xdeadbeef, true", got, ok)
+	}
+	if got, ok := layout64.pointerAt(buf, 8); !ok || got != 0x0077665544332211 {
+		t.Errorf("pointerAt(8) = %#x, %v; want 0x77665544332211, true", got, ok)
+	}
+	if got, ok := layout32.pointerAt(buf, 0); !ok || got != 0xdeadbeef {
+		t.Errorf("32-bit pointerAt(0) = %#x, %v; want 0xdeadbeef, true", got, ok)
+	}
+	// A refused or truncated ReadProcessMemory arrives as a short buffer, and
+	// half a pointer must never decode to a usable address.
+	if _, ok := layout64.pointerAt(buf[:7], 0); ok {
+		t.Error("pointerAt accepted a 7-byte buffer for a 64-bit pointer")
+	}
+	if _, ok := layout64.pointerAt(buf, 9); ok {
+		t.Error("pointerAt read past the end of the buffer")
+	}
+}
+
+// synthUnicodeString builds the 16 bytes a 64-bit UNICODE_STRING occupies.
+func synthUnicodeString(length, maxLength uint16, buffer uint64) []byte {
+	b := make([]byte, layout64.unicodeSize)
+	b[0], b[1] = byte(length), byte(length>>8)
+	b[2], b[3] = byte(maxLength), byte(maxLength>>8)
+	for i := 0; i < 8; i++ {
+		b[int(layout64.unicodeBuffer)+i] = byte(buffer >> (8 * i))
+	}
+	return b
+}
+
+func TestUnicodeStringAtReadsLengthAndBuffer(t *testing.T) {
+	// C:\src\api is 10 characters, so Length is 20 bytes — the field counts
+	// bytes, not characters, and reading it as characters would truncate the
+	// path in half.
+	us := synthUnicodeString(20, 22, 0x00007ffe12340000)
+	length, addr, ok := layout64.unicodeStringAt(us, 0)
+	if !ok {
+		t.Fatal("unicodeStringAt refused a well-formed UNICODE_STRING")
+	}
+	if length != 20 {
+		t.Errorf("length = %d, want 20 bytes", length)
+	}
+	if addr != 0x00007ffe12340000 {
+		t.Errorf("buffer = %#x, want 0x7ffe12340000", addr)
+	}
+}
+
+func TestUnicodeStringAtHonoursTheCurrentDirectoryOffset(t *testing.T) {
+	// The real read lands the whole RTL_USER_PROCESS_PARAMETERS prefix in the
+	// buffer, so the UNICODE_STRING is decoded at CurrentDirectory, not at 0.
+	params := make([]byte, int(layout64.currentDirectory)+layout64.unicodeSize)
+	copy(params[layout64.currentDirectory:], synthUnicodeString(8, 10, 0xCAFE0000))
+	length, addr, ok := layout64.unicodeStringAt(params, layout64.currentDirectory)
+	if !ok || length != 8 || addr != 0xCAFE0000 {
+		t.Fatalf("unicodeStringAt at CurrentDirectory = %d, %#x, %v; want 8, 0xcafe0000, true", length, addr, ok)
+	}
+	// Decoding at 0 instead reads MaximumLength/Flags as a length and a null
+	// pointer as a buffer: exactly the silent-garbage failure the offset
+	// prevents.
+	if _, _, ok := layout64.unicodeStringAt(params, 0); ok {
+		t.Error("a UNICODE_STRING decoded out of the zeroed header was accepted")
+	}
+}
+
+func TestUnicodeStringAtRejectsImplausibleValues(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{"truncated", synthUnicodeString(20, 22, 0x1000)[:8]},
+		{"null buffer", synthUnicodeString(20, 22, 0)},
+		{"zero length", synthUnicodeString(0, 22, 0x1000)},
+		{"odd length", synthUnicodeString(21, 22, 0x1000)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, ok := layout64.unicodeStringAt(tc.buf, 0); ok {
+				t.Error("unicodeStringAt accepted it")
+			}
+		})
+	}
+}
+
+func TestDecodeUTF16LE(t *testing.T) {
+	encode := func(s string, trailingNULs int) []byte {
+		var b []byte
+		for _, r := range []rune(s) {
+			if r > 0xFFFF {
+				r -= 0x10000
+				hi := 0xD800 + uint16(r>>10)
+				lo := 0xDC00 + uint16(r&0x3FF)
+				b = append(b, byte(hi), byte(hi>>8), byte(lo), byte(lo>>8))
+				continue
+			}
+			b = append(b, byte(r), byte(r>>8))
+		}
+		for i := 0; i < trailingNULs; i++ {
+			b = append(b, 0, 0)
+		}
+		return b
+	}
+	cases := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"ascii path", encode(`C:\src\api`, 0), `C:\src\api`},
+		{"NUL terminated", encode(`C:\src\api`, 1), `C:\src\api`},
+		{"non-ascii", encode(`C:\Users\Rasmus Krebs\Bürö`, 0), `C:\Users\Rasmus Krebs\Bürö`},
+		{"surrogate pair", encode("C:\\emoji\\🚀", 0), "C:\\emoji\\🚀"},
+		{"empty", nil, ""},
+		{"odd trailing byte is ignored", []byte{0x43, 0x00, 0x3A}, "C"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decodeUTF16LE(tc.in); got != tc.want {
+				t.Errorf("decodeUTF16LE = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeWindowsCwd(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// The PEB always stores the trailing backslash; groups.Canonical never
+		// does, so leaving it on splits one project into two groups.
+		{"trailing backslash", `C:\src\api\`, `C:\src\api`},
+		{"no trailing backslash", `C:\src\api`, `C:\src\api`},
+		{"drive root keeps its backslash", `C:\`, `C:\`},
+		{"lowercase drive root", `d:\`, `d:\`},
+		{"extended-length prefix", `\\?\C:\src\api\`, `C:\src\api`},
+		{"extended-length UNC", `\\?\UNC\build\share\api\`, `\\build\share\api`},
+		{"plain UNC", `\\build\share\api\`, `\\build\share\api`},
+		{"space padded", "  C:\\src\\api\\  ", `C:\src\api`},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeWindowsCwd(tc.in)
+			if got != tc.want {
+				t.Errorf("normalizeWindowsCwd(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.HasPrefix(got, `\\?\`) {
+				t.Errorf("normalizeWindowsCwd(%q) kept the \\\\?\\ prefix", tc.in)
+			}
+		})
+	}
+}
+
+// TestPEBWalkOverASyntheticProcessImage is the whole three-hop walk done over a
+// byte slice standing in for another process's address space: it proves the
+// offsets compose, not just that each one is right on its own.
+func TestPEBWalkOverASyntheticProcessImage(t *testing.T) {
+	const (
+		pebAddr    = uint64(0x00007FF700000000)
+		paramsAddr = uint64(0x00007FF700010000)
+		pathAddr   = uint64(0x00007FF700020000)
+		base       = pebAddr
+	)
+	l := layout64
+	mem := make([]byte, 0x30000)
+	read := func(addr uint64, n int) []byte {
+		off := addr - base
+		return mem[off : off+uint64(n)]
+	}
+	writePtr := func(addr, value uint64) {
+		b := read(addr, l.ptrSize)
+		for i := 0; i < l.ptrSize; i++ {
+			b[i] = byte(value >> (8 * i))
+		}
+	}
+
+	// PEB.ProcessParameters -> params, params.CurrentDirectory -> the string.
+	writePtr(pebAddr+uint64(l.processParameters), paramsAddr)
+	copy(read(paramsAddr+uint64(l.currentDirectory), l.unicodeSize),
+		synthUnicodeString(uint16(len(`C:\src\api`)*2), uint16(len(`C:\src\api`)*2+2), pathAddr))
+	pathBytes := read(pathAddr, len(`C:\src\api`)*2)
+	for i, r := range []rune(`C:\src\api`) {
+		pathBytes[i*2], pathBytes[i*2+1] = byte(r), byte(r>>8)
+	}
+
+	params, ok := l.pointerAt(read(pebAddr+uint64(l.processParameters), l.ptrSize), 0)
+	if !ok || params != paramsAddr {
+		t.Fatalf("ProcessParameters = %#x, %v; want %#x", params, ok, paramsAddr)
+	}
+	length, addr, ok := l.unicodeStringAt(read(params+uint64(l.currentDirectory), l.unicodeSize), 0)
+	if !ok || addr != pathAddr {
+		t.Fatalf("CurrentDirectory.DosPath = %d, %#x, %v; want %#x", length, addr, ok, pathAddr)
+	}
+	if got := normalizeWindowsCwd(decodeUTF16LE(read(addr, length))); got != `C:\src\api` {
+		t.Fatalf("the walk produced %q, want %q", got, `C:\src\api`)
+	}
+}

--- a/internal/ports/cwd_windows.go
+++ b/internal/ports/cwd_windows.go
@@ -1,0 +1,185 @@
+//go:build windows
+
+package ports
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// batchGetCwds returns pid -> working directory by reading each process's PEB.
+//
+// Windows has no lsof and no /proc: the current directory of another process is
+// only readable out of that process's own address space. For each pid the
+// sequence is
+//
+//	OpenProcess(PROCESS_QUERY_INFORMATION|PROCESS_VM_READ)
+//	NtQueryInformationProcess(ProcessBasicInformation)  -> PebBaseAddress
+//	ReadProcessMemory(peb + ProcessParameters)          -> params address
+//	ReadProcessMemory(params + CurrentDirectory)        -> UNICODE_STRING
+//	ReadProcessMemory(UNICODE_STRING.Buffer)            -> the UTF-16 path
+//
+// and every one of those steps is allowed to fail. System processes, services
+// running as another user and anything protected deny the handle outright, and
+// a process may exit between the scan and this call. Following the rule the
+// lsof path already lives by, a pid that refuses is skipped and the batch
+// carries on: partial results are results, and a scan that returned nothing
+// because one system process said no would be worse than one that named
+// nine listeners out of ten.
+//
+// Limitation: a 32-bit sonar cannot read a 64-bit process. Its
+// NtQueryInformationProcess is the WOW64 thunk, which reports the 32-bit view,
+// and the 64-bit target's structures live above the 4 GB its pointers can
+// address. Those pids are skipped and get "" — the same answer they had before
+// this file existed. A 64-bit sonar has no such gap: it reads 64-bit processes
+// and WOW64 32-bit ones alike, because a WOW64 process keeps a populated
+// 64-bit PEB next to its 32-bit one.
+func batchGetCwds(pids []int) map[int]string {
+	result := make(map[int]string, len(pids))
+	if len(pids) == 0 {
+		return result
+	}
+	layout := nativeLayout()
+	wow64 := selfIsWow64()
+	for _, pid := range pids {
+		if pid <= 0 {
+			continue
+		}
+		if cwd := processCwd(uint32(pid), layout, wow64); cwd != "" {
+			result[pid] = cwd
+		}
+	}
+	return result
+}
+
+// selfIsWow64 reports whether this sonar is a 32-bit binary running on 64-bit
+// Windows. A native 32-bit Windows has no 64-bit processes to fail on, and a
+// 64-bit sonar is never WOW64, so this is only ever true in the one build that
+// has the limitation documented above.
+func selfIsWow64() bool {
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		return false
+	}
+	var is bool
+	if err := windows.IsWow64Process(windows.CurrentProcess(), &is); err != nil {
+		return false
+	}
+	return is
+}
+
+// processCwd resolves one pid, returning "" for every failure.
+func processCwd(pid uint32, layout pebLayout, selfWow64 bool) string {
+	h, err := openForRead(pid)
+	if err != nil {
+		return ""
+	}
+	defer windows.CloseHandle(h)
+
+	if selfWow64 && !targetIsWow64(h) {
+		// A 32-bit sonar looking at a 64-bit process: unsupported, see above.
+		return ""
+	}
+
+	var pbi windows.PROCESS_BASIC_INFORMATION
+	var retLen uint32
+	if err := windows.NtQueryInformationProcess(h, windows.ProcessBasicInformation,
+		unsafe.Pointer(&pbi), uint32(unsafe.Sizeof(pbi)), &retLen); err != nil {
+		return ""
+	}
+	peb := uintptr(unsafe.Pointer(pbi.PebBaseAddress))
+	if peb == 0 {
+		return ""
+	}
+
+	// PEB.ProcessParameters
+	buf := make([]byte, layout.ptrSize)
+	if !readMemory(h, peb+layout.processParameters, buf) {
+		return ""
+	}
+	params, ok := layout.pointerAt(buf, 0)
+	if !ok || params == 0 {
+		return ""
+	}
+
+	// RTL_USER_PROCESS_PARAMETERS.CurrentDirectory.DosPath
+	us := make([]byte, layout.unicodeSize)
+	if !readMemory(h, uintptr(params)+layout.currentDirectory, us) {
+		return ""
+	}
+	length, addr, ok := layout.unicodeStringAt(us, 0)
+	if !ok {
+		return ""
+	}
+
+	// UNICODE_STRING.Buffer
+	path := make([]byte, length)
+	if !readMemory(h, uintptr(addr), path) {
+		return ""
+	}
+	raw := decodeUTF16LE(path)
+	if raw == "" {
+		return ""
+	}
+	return normalizeWindowsCwd(longPathName(raw))
+}
+
+// openForRead opens a process for the reads above. PROCESS_QUERY_INFORMATION
+// is what NtQueryInformationProcess documents; PROCESS_QUERY_LIMITED_INFORMATION
+// is enough on Vista and later and is granted in places the full right is not,
+// so it is worth a second attempt before giving up on a pid.
+func openForRead(pid uint32) (windows.Handle, error) {
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ, false, pid)
+	if err == nil {
+		return h, nil
+	}
+	return windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, pid)
+}
+
+// targetIsWow64 reports whether the process behind h is a 32-bit process on
+// 64-bit Windows. A handle that cannot answer is treated as 64-bit, i.e. as one
+// this build must not try to read.
+func targetIsWow64(h windows.Handle) bool {
+	var is bool
+	if err := windows.IsWow64Process(h, &is); err != nil {
+		return false
+	}
+	return is
+}
+
+// readMemory fills buf from the target's address space, insisting on a complete
+// read: a partial one means the address was wrong, and half a pointer decodes
+// to a plausible-looking lie.
+func readMemory(h windows.Handle, addr uintptr, buf []byte) bool {
+	if len(buf) == 0 {
+		return false
+	}
+	var read uintptr
+	if err := windows.ReadProcessMemory(h, addr, &buf[0], uintptr(len(buf)), &read); err != nil {
+		return false
+	}
+	return int(read) == len(buf)
+}
+
+// longPathName expands an 8.3 short name (`C:\PROGRA~1\api`) to its long
+// spelling. The PEB stores whatever the process was launched with, while
+// groups.Canonical runs filepath.EvalSymlinks, which on Windows always reports
+// the long form — so without this the same directory would key the group index
+// twice. A path that no longer exists, or one GetLongPathName refuses, is kept
+// as it was: a short-name group is still better than no group.
+func longPathName(path string) string {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return path
+	}
+	n, err := windows.GetLongPathName(p, nil, 0)
+	if err != nil || n == 0 {
+		return path
+	}
+	buf := make([]uint16, n)
+	n, err = windows.GetLongPathName(p, &buf[0], n)
+	if err != nil || n == 0 || int(n) > len(buf) {
+		return path
+	}
+	return windows.UTF16ToString(buf[:n])
+}

--- a/internal/ports/displayname_other.go
+++ b/internal/ports/displayname_other.go
@@ -2,12 +2,6 @@
 
 package ports
 
-// batchGetCwds is a no-op on platforms without a stable per-process cwd lookup.
-// On Windows, the cwd-augmentation step in resolveProcessName is simply skipped.
-func batchGetCwds(pids []int) map[int]string {
-	return nil
-}
-
 // batchGetServiceUnits is a no-op on platforms without systemd / launchd.
 func batchGetServiceUnits(pids []int) map[int]string {
 	return nil

--- a/internal/ports/enrich.go
+++ b/internal/ports/enrich.go
@@ -28,6 +28,13 @@ func Enrich(pp []ListeningPort) {
 	for i := range pp {
 		if info, ok := commands[pp[i].PID]; ok {
 			pp[i].Command = info.command
+			// Windows learns the parent from the same CIM query that fetched
+			// the command line, so the ancestry walk costs no second process
+			// table. Elsewhere this is 0 and enrichDisplayNameSignals fills
+			// PPID from the `ps -A` table it builds anyway.
+			if info.ppid > 0 {
+				pp[i].PPID = info.ppid
+			}
 			// started_at is never gated by --stats: the contract publishes it
 			// on every row (contract §21). EnrichStats refines the same field
 			// with the raw ps lstart it parses anyway.
@@ -100,6 +107,7 @@ type DockerStatsEntry struct {
 type procInfo struct {
 	command   string
 	startedAt string // RFC3339, "" when ps did not report a parsable time
+	ppid      int    // 0 when the source did not report a parent
 }
 
 // batchGetCommands fetches full command lines and start times for all PIDs in a
@@ -248,8 +256,12 @@ func batchGetCommandsWindows(pidStrs []string) map[int]procInfo {
 	}
 	filter := strings.Join(conditions, " or ")
 
+	// ParentProcessId rides along on the query that was already being made:
+	// Windows has no `ps -A` to build a process table from, and spawning a
+	// second PowerShell per scan to learn one parent pid would cost more than
+	// everything else the scan does put together.
 	psCmd := fmt.Sprintf(
-		"Get-CimInstance Win32_Process -Filter '%s' | Select-Object ProcessId,@{N='StartedAt';E={$_.CreationDate.ToString('o')}},CommandLine | ConvertTo-Csv -NoTypeInformation",
+		"Get-CimInstance Win32_Process -Filter '%s' | Select-Object ProcessId,ParentProcessId,@{N='StartedAt';E={$_.CreationDate.ToString('o')}},CommandLine | ConvertTo-Csv -NoTypeInformation",
 		filter,
 	)
 
@@ -264,22 +276,37 @@ func batchGetCommandsWindows(pidStrs []string) map[int]procInfo {
 		return result
 	}
 
-	// CSV columns: "ProcessId","StartedAt","CommandLine"
+	result = parseCIMProcesses(records)
+	rememberScanParents(result)
+	return result
+}
+
+// parseCIMProcesses reads the CSV Get-CimInstance produced. Columns:
+// "ProcessId","ParentProcessId","StartedAt","CommandLine".
+//
+// A row with no command line still counts: on Windows the command line is the
+// field most often withheld (another user's process, a protected one), and
+// dropping the row with it would throw away the parent pid and the start time
+// that did come back.
+func parseCIMProcesses(records [][]string) map[int]procInfo {
+	result := make(map[int]procInfo, len(records))
 	for i, record := range records {
 		if i == 0 {
 			continue // skip header
 		}
-		if len(record) < 3 {
+		if len(record) < 4 {
 			continue
 		}
 		pid, err := strconv.Atoi(strings.TrimSpace(record[0]))
 		if err != nil {
 			continue
 		}
-		cmd := strings.TrimSpace(record[2])
-		if cmd != "" {
-			result[pid] = procInfo{command: cmd, startedAt: parseStartTime(record[1])}
+		ppid, _ := strconv.Atoi(strings.TrimSpace(record[1]))
+		cmd := strings.TrimSpace(record[3])
+		if cmd == "" && ppid <= 0 {
+			continue
 		}
+		result[pid] = procInfo{command: cmd, startedAt: parseStartTime(record[2]), ppid: ppid}
 	}
 	return result
 }

--- a/internal/ports/enrich.go
+++ b/internal/ports/enrich.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -270,45 +271,111 @@ func batchGetCommandsWindows(pidStrs []string) map[int]procInfo {
 		return result
 	}
 
-	r := csv.NewReader(strings.NewReader(strings.TrimSpace(string(out))))
-	records, err := r.ReadAll()
-	if err != nil {
-		return result
-	}
-
-	result = parseCIMProcesses(records)
+	result = parseCIMProcesses(string(out))
 	rememberScanParents(result)
 	return result
 }
 
-// parseCIMProcesses reads the CSV Get-CimInstance produced. Columns:
-// "ProcessId","ParentProcessId","StartedAt","CommandLine".
+// parseCIMProcesses reads the CSV Get-CimInstance produced.
+//
+// It finds its columns by name from the header rather than by position. The
+// query asks for ProcessId, ParentProcessId, StartedAt and CommandLine, and
+// Select-Object emits them in that order — but a positional parser turns any
+// future edit to that Select-Object list, or a PowerShell that orders or names
+// things differently, into silently misread rows: a parent pid read as a start
+// time, a command line read from the wrong column. Reading the header is one
+// map and removes the entire class.
+//
+// It is also tolerant per row. The previous parser called ReadAll and returned
+// nothing at all when any single line failed to parse, so one process with an
+// odd command line cost every other process on the machine its identity — and
+// on Windows identity is what decides whether a port is shown and which group
+// it joins. A row that cannot be read is skipped; the ones that can are kept.
 //
 // A row with no command line still counts: on Windows the command line is the
 // field most often withheld (another user's process, a protected one), and
 // dropping the row with it would throw away the parent pid and the start time
 // that did come back.
-func parseCIMProcesses(records [][]string) map[int]procInfo {
-	result := make(map[int]procInfo, len(records))
-	for i, record := range records {
-		if i == 0 {
-			continue // skip header
+func parseCIMProcesses(out string) map[int]procInfo {
+	result := map[int]procInfo{}
+	text := strings.TrimSpace(strings.TrimPrefix(out, "\ufeff"))
+	if text == "" {
+		return result
+	}
+	r := csv.NewReader(strings.NewReader(text))
+	r.FieldsPerRecord = -1
+	r.LazyQuotes = true
+
+	var cols map[string]int
+	for {
+		rec, err := r.Read()
+		if errors.Is(err, io.EOF) {
+			return result
 		}
-		if len(record) < 4 {
-			continue
-		}
-		pid, err := strconv.Atoi(strings.TrimSpace(record[0]))
 		if err != nil {
+			var parseErr *csv.ParseError
+			if errors.As(err, &parseErr) {
+				continue // one unreadable line, not the end of the batch
+			}
+			return result
+		}
+		if len(rec) == 0 {
 			continue
 		}
-		ppid, _ := strconv.Atoi(strings.TrimSpace(record[1]))
-		cmd := strings.TrimSpace(record[3])
+		// PowerShell 5.1 emits a `#TYPE …` line unless -NoTypeInformation is
+		// passed. It is, but skipping the line costs nothing and a missing
+		// flag would otherwise be read as the header.
+		if strings.HasPrefix(strings.TrimSpace(rec[0]), "#TYPE") {
+			continue
+		}
+		if cols == nil {
+			cols = cimColumns(rec)
+			if _, ok := cols["processid"]; !ok {
+				return result // not a header we understand
+			}
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(field(rec, cols, "processid")))
+		if err != nil || pid <= 0 {
+			continue
+		}
+		ppid, _ := strconv.Atoi(strings.TrimSpace(field(rec, cols, "parentprocessid")))
+		cmd := strings.TrimSpace(field(rec, cols, "commandline"))
 		if cmd == "" && ppid <= 0 {
 			continue
 		}
-		result[pid] = procInfo{command: cmd, startedAt: parseStartTime(record[2]), ppid: ppid}
+		result[pid] = procInfo{
+			command:   cmd,
+			startedAt: parseStartTime(field(rec, cols, "startedat")),
+			ppid:      ppid,
+		}
 	}
-	return result
+}
+
+// cimColumns maps a CSV header to column indexes, lowercased and trimmed so
+// the lookup does not depend on PowerShell's capitalisation.
+func cimColumns(header []string) map[string]int {
+	cols := make(map[string]int, len(header))
+	for i, name := range header {
+		key := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(name, "\ufeff")))
+		if key == "" {
+			continue
+		}
+		if _, taken := cols[key]; !taken {
+			cols[key] = i
+		}
+	}
+	return cols
+}
+
+// field reads a named column, returning "" when the header did not have it or
+// the row is short.
+func field(rec []string, cols map[string]int, name string) string {
+	i, ok := cols[name]
+	if !ok || i >= len(rec) {
+		return ""
+	}
+	return rec[i]
 }
 
 // batchEnrichProcessStats fetches CPU, memory, state, uptime for all non-Docker
@@ -471,15 +538,25 @@ func isWindowsDesktopApp(command string, process string, pid int) bool {
 		return false
 	}
 
+	// A binary running out of a temp directory is a scratch build, a one-off
+	// download or a test fixture. None of them is an installed application,
+	// and this is checked first because every temp directory lives inside a
+	// directory one of the rules below would otherwise claim:
+	// %LOCALAPPDATA%\Temp is under \AppData\, C:\Windows\Temp is under
+	// \Windows\, and a runner's D:\a\_temp is neither. Getting the order
+	// wrong hides exactly the ports a developer just started — which is how a
+	// listener built into the CI runner's temp directory vanished from
+	// `sonar list` while wininit.exe stayed.
+	if isWindowsTempPath(lower) {
+		return false
+	}
 	// Windows system services
 	if strings.Contains(lower, `\windows\`) {
 		return true
 	}
-	// User-installed desktop apps (AppData\Local houses Discord, Cursor, Slack,
-	// etc.), except the temp directory: %LOCALAPPDATA%\Temp is where every
-	// scratch build and one-off binary runs from, and none of them is an
-	// installed application.
-	if strings.Contains(lower, `\appdata\`) && !strings.Contains(lower, `\appdata\local\temp\`) {
+	// User-installed desktop apps: AppData\Local houses Discord, Cursor,
+	// Slack and the rest.
+	if strings.Contains(lower, `\appdata\`) {
 		return true
 	}
 	// Microsoft Store apps
@@ -505,6 +582,32 @@ func isWindowsDesktopApp(command string, process string, pid int) bool {
 
 	for _, app := range knownApps {
 		if strings.Contains(baseName, app) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWindowsTempPath reports whether an already-lowercased command line runs out
+// of a temporary directory.
+//
+// Two ways in, because neither alone is enough. A path segment literally called
+// `temp` or `tmp` covers %LOCALAPPDATA%\Temp, C:\Windows\Temp and the
+// `\_temp` a CI runner uses, whatever drive they sit on. And this process's own
+// os.TempDir() covers a TMP pointed somewhere with no such name in it at all —
+// the daemon and the listeners it is looking at share a machine, so its idea of
+// "temporary" is theirs.
+func isWindowsTempPath(lower string) bool {
+	normalized := strings.ReplaceAll(lower, "/", `\`)
+	for _, seg := range strings.Split(normalized, `\`) {
+		// A runner's `_temp` counts; `template` and `tempo` do not.
+		seg = strings.TrimPrefix(seg, "_")
+		if seg == "temp" || seg == "tmp" {
+			return true
+		}
+	}
+	if dir := strings.ToLower(strings.ReplaceAll(os.TempDir(), "/", `\`)); dir != "" && dir != `\` {
+		if strings.Contains(normalized, strings.TrimSuffix(dir, `\`)+`\`) {
 			return true
 		}
 	}

--- a/internal/ports/enrich_test.go
+++ b/internal/ports/enrich_test.go
@@ -124,9 +124,10 @@ func TestUptimeOfAnUnparseableStartIsEmpty(t *testing.T) {
 
 // TestIsWindowsDesktopApp is the classification that decides whether a Windows
 // port is visible at all: an app is hidden from `sonar list` and never joins a
-// group. Two rules used to hide everything on a CI runner — a binary in
-// %LOCALAPPDATA%\Temp is not an installed app, and an unidentified process is
-// not evidence of one.
+// group. Three rules used to hide everything on a CI runner — a binary in any
+// temp directory is not an installed app, an unidentified process is not
+// evidence of one, and the temp rule has to be checked before the \Windows\
+// and \AppData\ rules that every temp directory lives inside.
 func TestIsWindowsDesktopApp(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -145,6 +146,23 @@ func TestIsWindowsDesktopApp(t *testing.T) {
 		{"store app", `C:\Program Files\WindowsApps\Something\app.exe`, "app.exe", 902, true},
 		{"dev server", `C:\Program Files\nodejs\node.exe server.js`, "node.exe", 903, false},
 		{"known app by name only", "", "chrome.exe", 904, true},
+		// The exact shape of the CI regression: the CIM query withheld the
+		// command line, tasklist supplied the image name, and the row has to
+		// stay visible on that alone (contract §27).
+		{"identity only from tasklist", "", "listener.exe", 905, false},
+
+		// Every temp directory, not just %LOCALAPPDATA%\Temp. A scratch
+		// binary under C:\Windows\Temp used to be classified as a Windows
+		// system service and hidden, and one under a runner's D:\a\_temp was
+		// only saved by not matching any rule at all.
+		{"windows temp", `C:\Windows\Temp\sonar-itest-listener1\listener.exe 59028`, "listener.exe", 7277, false},
+		{"runner temp", `D:\a\_temp\sonar-itest-listener1\listener.exe 59028`, "listener.exe", 7278, false},
+		{"quoted temp path", `"C:\Users\runneradmin\AppData\Local\Temp\x\listener.exe" 59028`, "listener.exe", 7279, false},
+		{"tmp directory", `C:\tmp\build\api.exe`, "api.exe", 7280, false},
+		{"forward slashes", `C:/Users/dev/AppData/Local/Temp/x/listener.exe`, "listener.exe", 7281, false},
+		// "temp" has to be a whole path segment: a real application does not
+		// stop being one because its name looks like the word.
+		{"template is not temp", `C:\Users\dev\AppData\Local\Templates\thing.exe`, "thing.exe", 7282, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ports/parents.go
+++ b/internal/ports/parents.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"strconv"
 	"strings"
+	"sync/atomic"
 )
 
 // ParentTable returns a pid -> ppid map for every process this user can see.
@@ -15,14 +16,58 @@ import (
 // container images, and a missing `ps` used to mean every ancestry walk came
 // back empty, so a listener a run had spawned was never attributed to it.
 // Everywhere else, and if /proc is unreadable, one `ps -A` call still answers.
+//
+// Windows has neither: no /proc, and no `ps -A` for batchGetPPIDsAndCommands
+// to call, so both of those come back empty and the table used to be empty with
+// them — every ancestry walk on Windows failed, and a listener a `sonar start`
+// had spawned was never attributed to its run. The fallback is the parents the
+// last scan already learned: Get-CimInstance returns ParentProcessId alongside
+// the command line it was being asked for anyway, so this costs no process and
+// no second query. It covers the pids that have been scanned, which is exactly
+// the population the walk starts from.
 func ParentTable() map[int]int {
 	if table := nativeParentTable(); len(table) > 0 {
 		return table
 	}
 	info := batchGetPPIDsAndCommands()
-	out := make(map[int]int, len(info))
+	if len(info) > 0 {
+		out := make(map[int]int, len(info))
+		for pid, e := range info {
+			out[pid] = e.ppid
+		}
+		return out
+	}
+	return scanParents()
+}
+
+// scanParentTable holds the pid -> ppid pairs the most recent scan learned, for
+// platforms with no process table of their own to read. It is replaced whole,
+// never mutated, so a reader always sees one consistent scan's worth.
+var scanParentTable atomic.Pointer[map[int]int]
+
+// rememberScanParents records the parents a scan reported.
+func rememberScanParents(info map[int]procInfo) {
+	table := make(map[int]int, len(info))
 	for pid, e := range info {
-		out[pid] = e.ppid
+		if pid > 0 && e.ppid > 0 {
+			table[pid] = e.ppid
+		}
+	}
+	if len(table) == 0 {
+		return
+	}
+	scanParentTable.Store(&table)
+}
+
+// scanParents returns a copy of what the last scan learned.
+func scanParents() map[int]int {
+	table := scanParentTable.Load()
+	if table == nil {
+		return map[int]int{}
+	}
+	out := make(map[int]int, len(*table))
+	for pid, ppid := range *table {
+		out[pid] = ppid
 	}
 	return out
 }

--- a/internal/ports/parents_scan_test.go
+++ b/internal/ports/parents_scan_test.go
@@ -1,33 +1,34 @@
 package ports
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Windows has no /proc and no `ps -A`, so ParentTable used to come back empty
 // there and every ancestry walk with it. The parents now ride along on the CIM
 // query the scan was making anyway. None of that needs Windows to test: the CSV
 // parsing and the table it feeds are ordinary Go.
 
-func TestParseCIMProcesses(t *testing.T) {
-	records := [][]string{
-		{"ProcessId", "ParentProcessId", "StartedAt", "CommandLine"},
-		{"1234", "1000", "2026-09-06T10:00:00.0000000+02:00", `"C:\src\api\node.exe" server.js`},
-		// A protected process: Windows withholds the command line but still
-		// names the parent, and the row has to survive for the walk's sake.
-		{"1235", "1000", "2026-09-06T10:00:01.0000000+02:00", ""},
-		// Neither a command line nor a parent is nothing worth keeping.
-		{"1236", "0", "", ""},
-		// Garbage in the pid column is skipped, not fatal.
-		{"nope", "1000", "", "x"},
-		// A short row (an older schema, a truncated read) is skipped.
-		{"1237", "1000"},
-	}
-	got := parseCIMProcesses(records)
+// cimSample is what `Get-CimInstance Win32_Process … | Select-Object
+// ProcessId,ParentProcessId,@{N='StartedAt';…},CommandLine | ConvertTo-Csv
+// -NoTypeInformation` prints on windows-latest, with the rows that matter:
+// a normal process, a protected one whose CommandLine comes back empty, and a
+// command line carrying the quotes, spaces and commas CSV has to survive.
+const cimSample = "\"ProcessId\",\"ParentProcessId\",\"StartedAt\",\"CommandLine\"\r\n" +
+	"\"1234\",\"1000\",\"2026-09-06T10:00:00.0000000+02:00\",\"\"\"C:\\Users\\runneradmin\\AppData\\Local\\Temp\\sonar-itest-listener1\\listener.exe\"\" 59028\"\r\n" +
+	"\"1235\",\"1000\",\"2026-09-06T10:00:01.0000000+02:00\",\"\"\r\n" +
+	"\"640\",\"512\",\"2026-09-06T09:59:00.0000000+02:00\",\"C:\\Windows\\system32\\svchost.exe -k RPCSS -p, -s RpcEptMapper\"\r\n"
 
-	if len(got) != 2 {
+func TestParseCIMProcessesReadsACapturedSample(t *testing.T) {
+	got := parseCIMProcesses(cimSample)
+
+	if len(got) != 3 {
 		t.Fatalf("parseCIMProcesses returned %d rows: %+v", len(got), got)
 	}
-	if got[1234].command != `"C:\src\api\node.exe" server.js` {
-		t.Errorf("command = %q", got[1234].command)
+	want := `"C:\Users\runneradmin\AppData\Local\Temp\sonar-itest-listener1\listener.exe" 59028`
+	if got[1234].command != want {
+		t.Errorf("command = %q, want %q", got[1234].command, want)
 	}
 	if got[1234].ppid != 1000 {
 		t.Errorf("ppid = %d, want 1000", got[1234].ppid)
@@ -35,14 +36,62 @@ func TestParseCIMProcesses(t *testing.T) {
 	if got[1234].startedAt == "" {
 		t.Error("startedAt was dropped")
 	}
-	if _, ok := got[1235]; !ok {
-		t.Error("a row with a parent but no command line was dropped")
+	// A protected process withholds its command line and still reports a
+	// parent. Dropping the row would cost the ancestry walk that parent.
+	if row, ok := got[1235]; !ok || row.ppid != 1000 || row.command != "" {
+		t.Errorf("the command-less row = %+v, ok=%v; want a kept row with ppid 1000", row, ok)
 	}
-	if got[1235].ppid != 1000 {
-		t.Errorf("ppid for the command-less row = %d, want 1000", got[1235].ppid)
+	// Commas inside a quoted command line are not column separators.
+	if !strings.Contains(got[640].command, "-k RPCSS -p, -s RpcEptMapper") {
+		t.Errorf("svchost command = %q, want the commas preserved", got[640].command)
+	}
+}
+
+// TestParseCIMProcessesFindsColumnsByName: the parser must not depend on the
+// order Select-Object happens to emit. A positional parser read a parent pid as
+// a start time the moment the query grew a column.
+func TestParseCIMProcessesFindsColumnsByName(t *testing.T) {
+	reordered := "\"CommandLine\",\"StartedAt\",\"ProcessId\",\"ParentProcessId\"\r\n" +
+		"\"node server.js\",\"2026-09-06T10:00:00.0000000+02:00\",\"1234\",\"1000\"\r\n"
+	got := parseCIMProcesses(reordered)
+	if len(got) != 1 {
+		t.Fatalf("parseCIMProcesses returned %d rows: %+v", len(got), got)
+	}
+	if got[1234].command != "node server.js" || got[1234].ppid != 1000 {
+		t.Errorf("row = %+v, want command %q and ppid 1000", got[1234], "node server.js")
+	}
+}
+
+// TestParseCIMProcessesSurvivesOneBadRow: one process with an unreadable
+// command line must not cost every other process on the machine its identity —
+// which is what ReadAll's all-or-nothing error did.
+func TestParseCIMProcessesSurvivesOneBadRow(t *testing.T) {
+	withGarbage := "\"ProcessId\",\"ParentProcessId\",\"StartedAt\",\"CommandLine\"\r\n" +
+		"\"1234\",\"1000\",\"\",\"node server.js\"\r\n" +
+		"\"nope\",\"x\",\"\",\"skipped: unparsable pid\"\r\n" +
+		"\"1236\",\"0\",\"\",\"\"\r\n" +
+		"\"1237\",\"1000\",\"\",\"python -m http.server\"\r\n"
+	got := parseCIMProcesses(withGarbage)
+	if _, ok := got[1234]; !ok {
+		t.Error("the row before the bad one was lost")
+	}
+	if _, ok := got[1237]; !ok {
+		t.Error("the row after the bad one was lost")
 	}
 	if _, ok := got[1236]; ok {
 		t.Error("a row with neither a command line nor a parent was kept")
+	}
+}
+
+func TestParseCIMProcessesHandlesNoOutput(t *testing.T) {
+	for _, in := range []string{"", "   \r\n", "\"ProcessId\",\"ParentProcessId\",\"StartedAt\",\"CommandLine\"\r\n"} {
+		if got := parseCIMProcesses(in); len(got) != 0 {
+			t.Errorf("parseCIMProcesses(%q) = %v, want empty", in, got)
+		}
+	}
+	// A header the parser does not recognise is not a licence to guess.
+	if got := parseCIMProcesses("\"Name\",\"Handle\"\r\n\"node\",\"1234\"\r\n"); len(got) != 0 {
+		t.Errorf("an unknown header produced %v, want empty", got)
 	}
 }
 

--- a/internal/ports/parents_scan_test.go
+++ b/internal/ports/parents_scan_test.go
@@ -1,0 +1,80 @@
+package ports
+
+import "testing"
+
+// Windows has no /proc and no `ps -A`, so ParentTable used to come back empty
+// there and every ancestry walk with it. The parents now ride along on the CIM
+// query the scan was making anyway. None of that needs Windows to test: the CSV
+// parsing and the table it feeds are ordinary Go.
+
+func TestParseCIMProcesses(t *testing.T) {
+	records := [][]string{
+		{"ProcessId", "ParentProcessId", "StartedAt", "CommandLine"},
+		{"1234", "1000", "2026-09-06T10:00:00.0000000+02:00", `"C:\src\api\node.exe" server.js`},
+		// A protected process: Windows withholds the command line but still
+		// names the parent, and the row has to survive for the walk's sake.
+		{"1235", "1000", "2026-09-06T10:00:01.0000000+02:00", ""},
+		// Neither a command line nor a parent is nothing worth keeping.
+		{"1236", "0", "", ""},
+		// Garbage in the pid column is skipped, not fatal.
+		{"nope", "1000", "", "x"},
+		// A short row (an older schema, a truncated read) is skipped.
+		{"1237", "1000"},
+	}
+	got := parseCIMProcesses(records)
+
+	if len(got) != 2 {
+		t.Fatalf("parseCIMProcesses returned %d rows: %+v", len(got), got)
+	}
+	if got[1234].command != `"C:\src\api\node.exe" server.js` {
+		t.Errorf("command = %q", got[1234].command)
+	}
+	if got[1234].ppid != 1000 {
+		t.Errorf("ppid = %d, want 1000", got[1234].ppid)
+	}
+	if got[1234].startedAt == "" {
+		t.Error("startedAt was dropped")
+	}
+	if _, ok := got[1235]; !ok {
+		t.Error("a row with a parent but no command line was dropped")
+	}
+	if got[1235].ppid != 1000 {
+		t.Errorf("ppid for the command-less row = %d, want 1000", got[1235].ppid)
+	}
+	if _, ok := got[1236]; ok {
+		t.Error("a row with neither a command line nor a parent was kept")
+	}
+}
+
+func TestRememberScanParentsFeedsTheTable(t *testing.T) {
+	restore := scanParentTable.Load()
+	t.Cleanup(func() { scanParentTable.Store(restore) })
+	scanParentTable.Store(nil)
+
+	if got := scanParents(); len(got) != 0 {
+		t.Fatalf("scanParents before any scan = %v, want empty", got)
+	}
+
+	rememberScanParents(map[int]procInfo{
+		1234: {command: "node", ppid: 1000},
+		1235: {command: "python", ppid: 1000},
+		1236: {command: "orphan"}, // no parent reported: nothing to record
+	})
+	got := scanParents()
+	if len(got) != 2 || got[1234] != 1000 || got[1235] != 1000 {
+		t.Fatalf("scanParents = %v, want {1234:1000, 1235:1000}", got)
+	}
+
+	// The caller gets a copy: mutating it must not poison the next reader.
+	got[1234] = 9999
+	if again := scanParents(); again[1234] != 1000 {
+		t.Errorf("the table was aliased: %v", again)
+	}
+
+	// A scan that learned nothing leaves the last good table in place rather
+	// than blanking it — an empty answer is worse than a slightly stale one.
+	rememberScanParents(map[int]procInfo{})
+	if again := scanParents(); len(again) != 2 {
+		t.Errorf("an empty scan cleared the table: %v", again)
+	}
+}

--- a/internal/scanner/health.go
+++ b/internal/scanner/health.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"sync"
+	"time"
 
 	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/state"
@@ -11,6 +12,10 @@ import (
 // same ceiling the opt-in probe uses.
 const maxHealthProbes = 10
 
+// Probe is one health check. Options.Probe replaces it for tests; production
+// is ports.ProbeHealth.
+type Probe func(host string, port int, path string, timeout time.Duration) ports.HealthResult
+
 // probeConfigured fills Port.health for every `.sonar.yaml` service that
 // declares a `health:` path and whose port is listening.
 //
@@ -19,7 +24,7 @@ const maxHealthProbes = 10
 // the service *is*, not a statistic a client may or may not want, so the
 // daemon polls it as part of state (step 1A.7). Everything else about it is the
 // same probe — one HTTP GET, HealthTimeout, ten in flight.
-func probeConfigured(rows []state.Port, gg []state.Group) {
+func probeConfigured(rows []state.Port, gg []state.Group, probe Probe) {
 	targets := healthTargets(rows, gg)
 	if len(targets) == 0 {
 		return
@@ -35,7 +40,7 @@ func probeConfigured(rows []state.Port, gg []state.Group) {
 			defer wg.Done()
 			defer func() { <-sem }()
 			t := targets[i]
-			r := ports.ProbeHealth(t.host, t.port, t.path, HealthTimeout)
+			r := probe(t.host, t.port, t.path, HealthTimeout)
 			status, reason := state.NormalizeHealth(r.Status)
 			results[i] = state.Health{
 				Status:     status,

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -6,6 +6,7 @@ package scanner
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -76,6 +77,26 @@ type Options struct {
 	// and gets ports.Scan + docker.EnrichPorts + ports.Enrich.
 	Scan func(include Include) ([]ports.ListeningPort, error)
 
+	// Graph overrides the OS lookup of established connections between
+	// listening ports. Tests inject a fake; production leaves it nil and gets
+	// ports.BuildGraph + docker.BuildDockerGraph.
+	//
+	// It is a seam for the same reason Scan is. `ports.graph` and
+	// `ports.inspect` answer from the snapshot for the listeners, but the
+	// connections between them are a second, unrelated trip to the OS —
+	// `netstat -ano` on Windows, `lsof` on macOS, `ss` on Linux, plus a
+	// `docker inspect` whenever a container is listening. Left un-injectable,
+	// a unit test of the *handler* pays for all of that on whatever machine CI
+	// happens to be, and on a Windows runner with no Docker running it is
+	// seconds, not milliseconds.
+	Graph func(listening []ports.ListeningPort) ([]ports.Connection, error)
+
+	// Probe overrides the health probe. Tests inject a fake; production leaves
+	// it nil and gets ports.ProbeHealth. Both the configured-health tick and
+	// the `ports.health` / `ports.inspect` handlers go through it, so a test
+	// never opens a real socket.
+	Probe Probe
+
 	// Now overrides the clock, for tests.
 	Now func() time.Time
 }
@@ -115,6 +136,12 @@ func New(opts Options) *Loop {
 	if opts.Scan == nil {
 		opts.Scan = osScan
 	}
+	if opts.Graph == nil {
+		opts.Graph = osGraph
+	}
+	if opts.Probe == nil {
+		opts.Probe = ports.ProbeHealth
+	}
 	now := opts.Now
 	if now == nil {
 		now = time.Now
@@ -140,6 +167,32 @@ func osScan(include Include) ([]ports.ListeningPort, error) {
 		ports.EnrichStats(pp, docker.AllContainerStatsAsEntries())
 	}
 	return pp, nil
+}
+
+// osGraph is the production connection graph: the established links between
+// listening ports, plus the ones Docker only knows about.
+func osGraph(listening []ports.ListeningPort) ([]ports.Connection, error) {
+	edges, err := ports.BuildGraph(listening)
+	if err != nil {
+		return nil, err
+	}
+	containerEdges, err := docker.BuildDockerGraph(listening)
+	if err != nil {
+		return nil, fmt.Errorf("container graph: %w", err)
+	}
+	return append(edges, containerEdges...), nil
+}
+
+// Graph reports the established connections between the given listening ports.
+// Callers pass the listeners they already have — from the snapshot — so this
+// never re-scans for them.
+func (l *Loop) Graph(listening []ports.ListeningPort) ([]ports.Connection, error) {
+	return l.opts.Graph(listening)
+}
+
+// Probe runs one health probe through the loop's seam.
+func (l *Loop) Probe(host string, port int, path string, timeout time.Duration) ports.HealthResult {
+	return l.opts.Probe(host, port, path, timeout)
 }
 
 // SetDemand installs the demand callback after construction. The daemon uses
@@ -291,7 +344,7 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	// say which port has a `health:` path. It runs on every tick regardless of
 	// `include`: a health path in a `.sonar.yaml` is part of what the service
 	// is, not an opt-in statistic (step 1A.7).
-	probeConfigured(rows, groupRows)
+	probeConfigured(rows, groupRows, l.opts.Probe)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()


### PR DESCRIPTION
Roadmap step 1A.10. Windows had no per-process cwd, so `project_root`, git-root groups and cwd-based names did not exist there.

- `batchGetCwds` on Windows now reads each process's PEB: `OpenProcess` → `NtQueryInformationProcess(ProcessBasicInformation)` → `ProcessParameters` → `CurrentDirectory.DosPath`, via `golang.org/x/sys/windows` (already a dependency, `CGO_ENABLED=0` unchanged). Per-pid failures return an empty cwd and never fail the batch.
- Results are long-path expanded (`GetLongPathName`) so they agree with `groups.Canonical`, with `\\?\` prefixes unfolded and trailing separators stripped.
- A 32-bit sonar reading a 64-bit process returns an empty cwd (documented).
- New integration test, not OS-guarded: two listeners spawned inside a git checkout with no `.sonar.yaml` must carry the canonical `cwd`, a `project_root`, and group under the repo name in `sonar list --tree`. This is the assertion Windows lacked.

The PEB read has not executed locally (no Windows host); the offset arithmetic is unit-tested against the documented 64-bit and 32-bit layouts and this PR's Windows job is the first real run.