### PR TITLE
feat: add port claims with claims.acquire, release, list and sonar claim

### DIFF
--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -187,17 +187,20 @@
         "worktree": {
           "type": "string"
         },
+        "key": {
+          "type": "string"
+        },
         "count": {
+          "type": "integer"
+        },
+        "ttl_seconds": {
           "type": "integer"
         },
         "ttl_ms": {
           "type": "integer"
         }
       },
-      "type": "object",
-      "required": [
-        "project"
-      ]
+      "type": "object"
     },
     "ClaimsAcquireResult": {
       "properties": {

--- a/internal/claims/006_claims.sql
+++ b/internal/claims/006_claims.sql
@@ -1,0 +1,18 @@
+-- 006_claims.sql — port claims (spec 2 §4).
+--
+-- A claim is a reservation in sonar's book-keeping, not an OS-level bind: it
+-- keeps parallel agents off each other's ports and gives one (project,
+-- worktree) pair the same ports every time. One row per claimed port; the key
+-- is `<project>/<worktree>` and groups the ports a caller holds.
+
+CREATE TABLE IF NOT EXISTS claims (
+    port       INTEGER PRIMARY KEY,
+    key        TEXT NOT NULL,
+    project    TEXT NOT NULL,
+    worktree   TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_claims_key     ON claims(key);
+CREATE INDEX IF NOT EXISTS idx_claims_expires ON claims(expires_at);

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -1,0 +1,349 @@
+package claims
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// DefaultTTL is how long a claim lives when the caller does not say: one day,
+// the `claim_port` tool's default in spec 2.
+const DefaultTTL = 24 * time.Hour
+
+// MaxCount caps how many ports one key may hold, so a typo in `count` cannot
+// reserve a whole range.
+const MaxCount = 64
+
+// acquireAttempts is how often Acquire re-derives its ports when the table
+// changed underneath it. Inside one daemon the mutex makes a second attempt
+// unnecessary; a second writer on the same database (two daemons on one HOME)
+// is what this is for.
+const acquireAttempts = 3
+
+// ErrExhausted is returned when the range holds no free port left.
+var ErrExhausted = errors.New("no free port left in the claim range")
+
+// ErrNoProject is returned when neither a key nor a project was given.
+var ErrNoProject = errors.New("a claim needs a project or a key")
+
+// Table is the persistence Manager needs; *store.Store's Claims view is the
+// production implementation.
+type Table interface {
+	Put(rows ...store.ClaimRow) error
+	Get(key string) ([]store.ClaimRow, error)
+	List() ([]store.ClaimRow, error)
+	Delete(key string) (int, error)
+	Expire(now time.Time) (int, error)
+}
+
+// Options tunes a Manager. The zero value uses the spec's range, the wall
+// clock and no listener probe.
+type Options struct {
+	// Range is the window ports are derived from. Zero means DefaultRange.
+	Range Range
+	// Now is the clock, replaced in tests.
+	Now func() time.Time
+	// Listening reports the ports something is bound to right now — the
+	// daemon's scan snapshot. A claim never hands out a port that is already
+	// serving, except one this same key already holds (that listener is very
+	// likely the caller's own process, and taking the port away from it would
+	// break the idempotency the whole feature exists for).
+	Listening func() (map[int]bool, error)
+	// DefaultTTL overrides DefaultTTL for callers that pass no ttl.
+	DefaultTTL time.Duration
+}
+
+// Manager is the claims book. One lives in the daemon, per database.
+type Manager struct {
+	table Table
+	rng   Range
+	now   func() time.Time
+	ttl   time.Duration
+	live  func() (map[int]bool, error)
+
+	mu sync.Mutex
+}
+
+// New builds a manager over a claims table.
+func New(t Table, o Options) *Manager {
+	m := &Manager{table: t, rng: o.Range, now: o.Now, ttl: o.DefaultTTL, live: o.Listening}
+	if m.rng.Valid() != nil {
+		m.rng = DefaultRange
+	}
+	if m.now == nil {
+		m.now = time.Now
+	}
+	if m.ttl <= 0 {
+		m.ttl = DefaultTTL
+	}
+	return m
+}
+
+// Range reports the window this manager derives from.
+func (m *Manager) Range() Range { return m.rng }
+
+// Request is one acquire. Key wins when set; otherwise it is derived from
+// Project and Worktree.
+type Request struct {
+	Key      string
+	Project  string
+	Worktree string
+	Count    int
+	TTL      time.Duration
+}
+
+// Result is what an acquire hands back: the same shape as claims.acquire.
+type Result struct {
+	Key       string
+	Project   string
+	Worktree  string
+	Ports     []int
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// Acquire reserves Count ports for a key and returns them.
+//
+// The same key gets the same ports every time: the ports it already holds are
+// taken first, in port order, and only the shortfall is probed for. Probing
+// starts at the port derived from the key and walks upward, skipping ports
+// that are listening and ports another key holds. The TTL is refreshed on
+// every call, so a live agent keeps its block and an abandoned one lets go.
+func (m *Manager) Acquire(req Request) (Result, error) {
+	key, project, worktree, err := resolve(req)
+	if err != nil {
+		return Result{}, err
+	}
+	count := req.Count
+	if count == 0 {
+		count = 1
+	}
+	if count < 1 || count > MaxCount {
+		return Result{}, fmt.Errorf("claims: count must be between 1 and %d", MaxCount)
+	}
+	ttl := req.TTL
+	if ttl <= 0 {
+		ttl = m.ttl
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var lastErr error
+	for attempt := 0; attempt < acquireAttempts; attempt++ {
+		res, err := m.acquireOnce(key, project, worktree, count, ttl)
+		if err == nil {
+			return res, nil
+		}
+		if !errors.Is(err, store.ErrClaimed) {
+			return Result{}, err
+		}
+		lastErr = err
+	}
+	return Result{}, lastErr
+}
+
+func (m *Manager) acquireOnce(key, project, worktree string, count int, ttl time.Duration) (Result, error) {
+	now := m.now()
+	if _, err := m.table.Expire(now); err != nil {
+		return Result{}, err
+	}
+	rows, err := m.table.List()
+	if err != nil {
+		return Result{}, err
+	}
+	listening, err := m.listening()
+	if err != nil {
+		return Result{}, err
+	}
+
+	heldBy := make(map[int]string, len(rows))
+	own := make([]store.ClaimRow, 0, count)
+	for _, r := range rows {
+		heldBy[r.Port] = r.Key
+		if r.Key == key {
+			own = append(own, r)
+		}
+	}
+	sort.Slice(own, func(i, j int) bool { return own[i].Port < own[j].Port })
+
+	created := make(map[int]time.Time, len(own))
+	chosen := make([]int, 0, count)
+	taken := make(map[int]bool, count)
+	for _, r := range own {
+		if len(chosen) == count {
+			break
+		}
+		chosen = append(chosen, r.Port)
+		taken[r.Port] = true
+		created[r.Port] = r.CreatedAt
+	}
+
+	for i := 0; len(chosen) < count && i < m.rng.Span(); i++ {
+		port := m.rng.At(key, i)
+		if taken[port] || listening[port] {
+			continue
+		}
+		if holder, ok := heldBy[port]; ok && holder != key {
+			continue
+		}
+		chosen = append(chosen, port)
+		taken[port] = true
+	}
+	if len(chosen) < count {
+		return Result{}, fmt.Errorf("%w (%d-%d): wanted %d, found %d",
+			ErrExhausted, m.rng.Start, m.rng.End, count, len(chosen))
+	}
+	sort.Ints(chosen)
+
+	// A shrinking count leaves ports behind; drop the whole key first so what
+	// claims.list reports is exactly what the caller was just told it holds.
+	if len(own) > len(chosen) {
+		if _, err := m.table.Delete(key); err != nil {
+			return Result{}, err
+		}
+	}
+
+	expires := now.Add(ttl)
+	write := make([]store.ClaimRow, 0, len(chosen))
+	for _, port := range chosen {
+		at, ok := created[port]
+		if !ok {
+			at = now
+		}
+		write = append(write, store.ClaimRow{
+			Port: port, Key: key, Project: project, Worktree: worktree,
+			CreatedAt: at, ExpiresAt: expires,
+		})
+	}
+	if err := m.table.Put(write...); err != nil {
+		return Result{}, err
+	}
+
+	first := now
+	for _, port := range chosen {
+		if at, ok := created[port]; ok && at.Before(first) {
+			first = at
+		}
+	}
+	return Result{
+		Key: key, Project: project, Worktree: worktree,
+		Ports: chosen, CreatedAt: first, ExpiresAt: expires,
+	}, nil
+}
+
+// Release drops every port held under key and reports how many went. A key
+// nobody holds releases nothing, without erroring.
+func (m *Manager) Release(key string) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, err := m.table.Expire(m.now()); err != nil {
+		return 0, err
+	}
+	return m.table.Delete(key)
+}
+
+// List returns the live claims, one row per key, ports ascending.
+func (m *Manager) List() ([]state.Claim, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, err := m.table.Expire(m.now()); err != nil {
+		return nil, err
+	}
+	rows, err := m.table.List()
+	if err != nil {
+		return nil, err
+	}
+	return group(rows), nil
+}
+
+// Held maps every claimed port to the key holding it, after sweeping expired
+// rows. `ports.next` uses it to skip foreign claims.
+func (m *Manager) Held() (map[int]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, err := m.table.Expire(m.now()); err != nil {
+		return nil, err
+	}
+	rows, err := m.table.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int]string, len(rows))
+	for _, r := range rows {
+		out[r.Port] = r.Key
+	}
+	return out, nil
+}
+
+// group folds the per-port rows into one Claim per key.
+func group(rows []store.ClaimRow) []state.Claim {
+	byKey := map[string]*state.Claim{}
+	order := []string{}
+	for _, r := range rows {
+		c, ok := byKey[r.Key]
+		if !ok {
+			c = &state.Claim{
+				Key: r.Key, Project: r.Project, Worktree: r.Worktree,
+				CreatedAt: r.CreatedAt.Format(time.RFC3339),
+				ExpiresAt: r.ExpiresAt.Format(time.RFC3339),
+			}
+			byKey[r.Key] = c
+			order = append(order, r.Key)
+		}
+		c.Ports = append(c.Ports, r.Port)
+		if r.CreatedAt.Format(time.RFC3339) < c.CreatedAt {
+			c.CreatedAt = r.CreatedAt.Format(time.RFC3339)
+		}
+		if r.ExpiresAt.Format(time.RFC3339) > c.ExpiresAt {
+			c.ExpiresAt = r.ExpiresAt.Format(time.RFC3339)
+		}
+	}
+	sort.Strings(order)
+	out := make([]state.Claim, 0, len(order))
+	for _, k := range order {
+		c := byKey[k]
+		sort.Ints(c.Ports)
+		out = append(out, *c)
+	}
+	return out
+}
+
+func (m *Manager) listening() (map[int]bool, error) {
+	if m.live == nil {
+		return map[int]bool{}, nil
+	}
+	live, err := m.live()
+	if err != nil {
+		return nil, err
+	}
+	if live == nil {
+		return map[int]bool{}, nil
+	}
+	return live, nil
+}
+
+// resolve turns a request into the key and the project/worktree stored with
+// it. An explicit key wins; project and worktree are then recovered from it
+// unless the caller sent them too.
+func resolve(req Request) (key, project, worktree string, err error) {
+	project, worktree = req.Project, req.Worktree
+	key = req.Key
+	if key == "" {
+		if project == "" {
+			return "", "", "", ErrNoProject
+		}
+		key = Key(project, worktree)
+	}
+	if project == "" {
+		project, worktree = SplitKey(key)
+	} else if worktree == "" {
+		worktree = DefaultWorktree
+	}
+	return key, project, worktree, nil
+}

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -290,18 +290,18 @@ func group(rows []store.ClaimRow) []state.Claim {
 		if !ok {
 			c = &state.Claim{
 				Key: r.Key, Project: r.Project, Worktree: r.Worktree,
-				CreatedAt: r.CreatedAt.Format(time.RFC3339),
-				ExpiresAt: r.ExpiresAt.Format(time.RFC3339),
+				CreatedAt: stamp(r.CreatedAt),
+				ExpiresAt: stamp(r.ExpiresAt),
 			}
 			byKey[r.Key] = c
 			order = append(order, r.Key)
 		}
 		c.Ports = append(c.Ports, r.Port)
-		if r.CreatedAt.Format(time.RFC3339) < c.CreatedAt {
-			c.CreatedAt = r.CreatedAt.Format(time.RFC3339)
+		if stamp(r.CreatedAt) < c.CreatedAt {
+			c.CreatedAt = stamp(r.CreatedAt)
 		}
-		if r.ExpiresAt.Format(time.RFC3339) > c.ExpiresAt {
-			c.ExpiresAt = r.ExpiresAt.Format(time.RFC3339)
+		if stamp(r.ExpiresAt) > c.ExpiresAt {
+			c.ExpiresAt = stamp(r.ExpiresAt)
 		}
 	}
 	sort.Strings(order)
@@ -313,6 +313,10 @@ func group(rows []store.ClaimRow) []state.Claim {
 	}
 	return out
 }
+
+// stamp is the wire form of a claim time: UTC RFC 3339, so the strings sort
+// chronologically and every client reads one zone.
+func stamp(t time.Time) string { return t.UTC().Format(time.RFC3339) }
 
 func (m *Manager) listening() (map[int]bool, error) {
 	if m.live == nil {

--- a/internal/claims/claims_test.go
+++ b/internal/claims/claims_test.go
@@ -1,0 +1,283 @@
+package claims_test
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/claims"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// newManager builds a manager over a real temp database, so the SQL that
+// enforces one holder per port is exercised together with the probe.
+func newManager(t *testing.T, listening map[int]bool, now func() time.Time) (*claims.Manager, *store.Store) {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "sonar.db"))
+	if err != nil {
+		t.Fatalf("opening the store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return claims.New(st.Claims(), claims.Options{
+		Now:       now,
+		Listening: func() (map[int]bool, error) { return listening, nil },
+	}), st
+}
+
+func acquire(t *testing.T, m *claims.Manager, req claims.Request) claims.Result {
+	t.Helper()
+	res, err := m.Acquire(req)
+	if err != nil {
+		t.Fatalf("Acquire(%+v): %v", req, err)
+	}
+	return res
+}
+
+func TestTheSameKeyAlwaysGetsTheSamePorts(t *testing.T) {
+	m, _ := newManager(t, nil, nil)
+	first := acquire(t, m, claims.Request{Project: "myapp", Worktree: "feature-x"})
+	second := acquire(t, m, claims.Request{Project: "myapp", Worktree: "feature-x"})
+
+	if len(first.Ports) != 1 || first.Ports[0] != claims.DefaultRange.Base("myapp/feature-x") {
+		t.Fatalf("ports = %v, want the derived base port", first.Ports)
+	}
+	if second.Ports[0] != first.Ports[0] {
+		t.Errorf("second acquire = %v, want the same port as %v", second.Ports, first.Ports)
+	}
+	if first.Key != "myapp/feature-x" {
+		t.Errorf("key = %q", first.Key)
+	}
+}
+
+func TestDifferentWorktreesGetDifferentPorts(t *testing.T) {
+	m, _ := newManager(t, nil, nil)
+	a := acquire(t, m, claims.Request{Project: "myapp", Worktree: "feature-x"})
+	b := acquire(t, m, claims.Request{Project: "myapp", Worktree: "feature-y"})
+	if a.Ports[0] == b.Ports[0] {
+		t.Fatalf("both worktrees got port %d", a.Ports[0])
+	}
+}
+
+func TestProbeSkipsListeningPorts(t *testing.T) {
+	key := "myapp/main"
+	base := claims.DefaultRange.Base(key)
+	m, _ := newManager(t, map[int]bool{base: true, base + 1: true}, nil)
+
+	res := acquire(t, m, claims.Request{Key: key})
+	if res.Ports[0] != base+2 {
+		t.Fatalf("ports = %v, want the first port past the two listeners (%d)", res.Ports, base+2)
+	}
+}
+
+func TestProbeSkipsPortsAnotherKeyHolds(t *testing.T) {
+	// Two keys derived to overlap: hold the whole of one key's block with a
+	// foreign claim and the second key has to walk past it.
+	key := "myapp/main"
+	base := claims.DefaultRange.Base(key)
+	m, st := newManager(t, nil, nil)
+
+	expires := time.Now().Add(time.Hour)
+	if err := st.Claims().Put(
+		store.ClaimRow{Port: base, Key: "other/main", Project: "other", Worktree: "main", ExpiresAt: expires},
+		store.ClaimRow{Port: base + 1, Key: "other/main", Project: "other", Worktree: "main", ExpiresAt: expires},
+	); err != nil {
+		t.Fatalf("seeding a foreign claim: %v", err)
+	}
+
+	res := acquire(t, m, claims.Request{Key: key, Count: 2})
+	for _, p := range res.Ports {
+		if p == base || p == base+1 {
+			t.Fatalf("ports = %v, want none of the foreign claim's ports", res.Ports)
+		}
+	}
+	if len(res.Ports) != 2 {
+		t.Fatalf("ports = %v, want two", res.Ports)
+	}
+}
+
+func TestReacquireRefreshesTheTTLAndKeepsCreatedAt(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	clock := now
+	m, st := newManager(t, nil, func() time.Time { return clock })
+
+	first := acquire(t, m, claims.Request{Key: "myapp/main", TTL: time.Hour})
+	if !first.ExpiresAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("expires_at = %v, want %v", first.ExpiresAt, now.Add(time.Hour))
+	}
+
+	clock = now.Add(30 * time.Minute)
+	second := acquire(t, m, claims.Request{Key: "myapp/main", TTL: time.Hour})
+	if second.Ports[0] != first.Ports[0] {
+		t.Fatalf("refresh moved the port: %v -> %v", first.Ports, second.Ports)
+	}
+	if !second.ExpiresAt.Equal(clock.Add(time.Hour)) {
+		t.Errorf("expires_at = %v, want the refreshed %v", second.ExpiresAt, clock.Add(time.Hour))
+	}
+
+	rows, err := st.Claims().Get("myapp/main")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("Get = %v, %v", rows, err)
+	}
+	if !rows[0].CreatedAt.Equal(now) {
+		t.Errorf("created_at = %v, want the original %v", rows[0].CreatedAt, now)
+	}
+}
+
+func TestExpiredClaimsAreSweptAndTheirPortsReused(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	clock := now
+	m, st := newManager(t, nil, func() time.Time { return clock })
+
+	stale := acquire(t, m, claims.Request{Key: "gone/main", TTL: time.Minute})
+
+	clock = now.Add(2 * time.Minute)
+	live, err := m.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("List = %+v, want the expired claim swept", live)
+	}
+	rows, err := st.Claims().List()
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("rows = %v, %v; want the table swept", rows, err)
+	}
+
+	// The port is free again for a key that probes onto it.
+	if err := st.Claims().Put(store.ClaimRow{
+		Port: stale.Ports[0], Key: "next/main", Project: "next", Worktree: "main",
+		ExpiresAt: clock.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("reclaiming the expired port: %v", err)
+	}
+}
+
+func TestCountShrinksAndGrowsAroundTheSamePorts(t *testing.T) {
+	m, _ := newManager(t, nil, nil)
+	three := acquire(t, m, claims.Request{Key: "myapp/main", Count: 3})
+	if len(three.Ports) != 3 {
+		t.Fatalf("ports = %v, want three", three.Ports)
+	}
+
+	one := acquire(t, m, claims.Request{Key: "myapp/main", Count: 1})
+	if len(one.Ports) != 1 || one.Ports[0] != three.Ports[0] {
+		t.Fatalf("ports = %v, want just %d", one.Ports, three.Ports[0])
+	}
+	live, err := m.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(live) != 1 || len(live[0].Ports) != 1 {
+		t.Fatalf("claims = %+v, want the surplus ports released", live)
+	}
+
+	grown := acquire(t, m, claims.Request{Key: "myapp/main", Count: 3})
+	if grown.Ports[0] != three.Ports[0] || len(grown.Ports) != 3 {
+		t.Fatalf("ports = %v, want to grow back around %v", grown.Ports, three.Ports)
+	}
+}
+
+func TestConcurrentAcquiresNeverCollide(t *testing.T) {
+	m, _ := newManager(t, nil, nil)
+
+	const keys = 24
+	var wg sync.WaitGroup
+	results := make([][]int, keys)
+	errs := make([]error, keys)
+	start := make(chan struct{})
+	for i := 0; i < keys; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			res, err := m.Acquire(claims.Request{
+				Project: "myapp", Worktree: string(rune('a' + i)), Count: 2,
+			})
+			results[i], errs[i] = res.Ports, err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	seen := map[int]int{}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+		if len(results[i]) != 2 {
+			t.Fatalf("worker %d got %v, want two ports", i, results[i])
+		}
+		for _, p := range results[i] {
+			if prev, dup := seen[p]; dup {
+				t.Fatalf("workers %d and %d both got port %d", prev, i, p)
+			}
+			seen[p] = i
+		}
+	}
+}
+
+func TestReleaseFreesThePortsAndIsIdempotent(t *testing.T) {
+	m, _ := newManager(t, nil, nil)
+	res := acquire(t, m, claims.Request{Key: "myapp/main", Count: 2})
+
+	n, err := m.Release("myapp/main")
+	if err != nil || n != 2 {
+		t.Fatalf("Release = %d, %v; want 2, nil", n, err)
+	}
+	n, err = m.Release("myapp/main")
+	if err != nil || n != 0 {
+		t.Fatalf("second Release = %d, %v; want 0, nil", n, err)
+	}
+	held, err := m.Held()
+	if err != nil || len(held) != 0 {
+		t.Fatalf("Held = %v, %v; want empty", held, err)
+	}
+	// And the ports are handed out again.
+	again := acquire(t, m, claims.Request{Key: "myapp/main", Count: 2})
+	if again.Ports[0] != res.Ports[0] {
+		t.Errorf("after release ports = %v, want %v", again.Ports, res.Ports)
+	}
+}
+
+func TestAcquireNeedsAProjectOrKey(t *testing.T) {
+	m, _ := newManager(t, nil, nil)
+	if _, err := m.Acquire(claims.Request{}); !errors.Is(err, claims.ErrNoProject) {
+		t.Fatalf("err = %v, want ErrNoProject", err)
+	}
+}
+
+func TestAFullRangeIsReportedNotSilentlyShort(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "sonar.db"))
+	if err != nil {
+		t.Fatalf("opening the store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	small := claims.Range{Start: 20000, End: 20003}
+	listening := map[int]bool{20000: true, 20001: true, 20002: true, 20003: true}
+	m := claims.New(st.Claims(), claims.Options{
+		Range:     small,
+		Listening: func() (map[int]bool, error) { return listening, nil },
+	})
+	if _, err := m.Acquire(claims.Request{Key: "myapp/main"}); !errors.Is(err, claims.ErrExhausted) {
+		t.Fatalf("err = %v, want ErrExhausted", err)
+	}
+}
+
+func TestAPortTheSameKeyHoldsIsKeptEvenWhileItListens(t *testing.T) {
+	key := "myapp/main"
+	base := claims.DefaultRange.Base(key)
+	listening := map[int]bool{}
+	m, _ := newManager(t, listening, nil)
+
+	first := acquire(t, m, claims.Request{Key: key})
+	// The caller starts its server on the port it was given; asking again must
+	// return the same port rather than stepping past its own listener.
+	listening[first.Ports[0]] = true
+	second := acquire(t, m, claims.Request{Key: key})
+	if second.Ports[0] != base {
+		t.Fatalf("ports = %v, want to keep %d", second.Ports, base)
+	}
+}

--- a/internal/claims/hash.go
+++ b/internal/claims/hash.go
@@ -1,0 +1,106 @@
+// Package claims reserves ports for a (project, worktree) pair.
+//
+// A claim is book-keeping, not an OS-level bind: sonar records that a port is
+// spoken for so parallel agents in different worktrees stop picking the same
+// one, and so the same worktree gets the same ports every time. A process
+// outside sonar can still take a claimed port, which is why every acquire
+// probes the live scan before handing a port back.
+//
+// The derivation follows spec 2 §4: the key is `<project>/<worktree>`, the
+// starting port is a stable hash of that key into a 10-port block of the
+// configured range, and the probe walks upward from there.
+package claims
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultWorktree is the worktree name for a primary checkout, so a repo
+// nobody has branched from still has a full key.
+const DefaultWorktree = "main"
+
+// BlockSize is the stride between derived starting ports: neighbouring keys
+// land in different 10-port blocks, so a project needing a handful of ports
+// takes them without stepping on the next key's block.
+const BlockSize = 10
+
+// Range is the window claims are derived from. DefaultRange follows spec 2 §4:
+// 10-port blocks in 10000–32699, above the usual dev-server ports and below
+// every OS ephemeral range (Linux 32768+, macOS 49152+), so a claimed port is
+// never one the kernel hands out to an outgoing connection.
+type Range struct {
+	Start int
+	End   int
+}
+
+// DefaultRange is the range used when a caller does not configure one.
+var DefaultRange = Range{Start: 10000, End: 32699}
+
+// Valid reports whether r is a usable port window.
+func (r Range) Valid() error {
+	if r.Start < 1 || r.End > 65535 || r.Start > r.End {
+		return fmt.Errorf("claims: invalid port range %d-%d", r.Start, r.End)
+	}
+	return nil
+}
+
+// Span is how many ports the range holds.
+func (r Range) Span() int { return r.End - r.Start + 1 }
+
+// Key builds the claim key for a project and worktree. An empty worktree is
+// the primary checkout, which the spec names "main".
+func Key(project, worktree string) string {
+	p := strings.Trim(strings.TrimSpace(project), "/")
+	w := strings.Trim(strings.TrimSpace(worktree), "/")
+	if w == "" {
+		w = DefaultWorktree
+	}
+	return p + "/" + w
+}
+
+// SplitKey recovers the project and worktree a key was built from. A key with
+// no separator is all project, with the worktree defaulted.
+func SplitKey(key string) (project, worktree string) {
+	p, w, ok := strings.Cut(strings.TrimSpace(key), "/")
+	if !ok || strings.TrimSpace(w) == "" {
+		return p, DefaultWorktree
+	}
+	return p, w
+}
+
+// Base is the port a key's probe starts from: the same key always derives the
+// same port, in this process and in every other one, because the hash is
+// fnv-1a over the key alone.
+func (r Range) Base(key string) int {
+	h := fnv1a32(key)
+	blocks := r.Span() / BlockSize
+	if blocks < 1 {
+		return r.Start + int(h%uint32(r.Span()))
+	}
+	return r.Start + int(h%uint32(blocks))*BlockSize
+}
+
+// At is the i-th candidate port for key, counting from Base and wrapping back
+// to the start of the range rather than running off its end.
+func (r Range) At(key string, i int) int {
+	span := r.Span()
+	offset := (r.Base(key) - r.Start + i%span + span) % span
+	return r.Start + offset
+}
+
+// fnv1a32 is the 32-bit FNV-1a hash of s. Written out rather than taken from
+// hash/fnv so the constants are visible: the derived port is part of the
+// contract with every other sonar on the machine and must never drift.
+func fnv1a32(s string) uint32 {
+	const (
+		offset = 2166136261
+		prime  = 16777619
+	)
+	h := uint32(offset)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime
+	}
+	return h
+}

--- a/internal/claims/hash_test.go
+++ b/internal/claims/hash_test.go
@@ -1,0 +1,99 @@
+package claims
+
+import "testing"
+
+// The derived port is a contract between every sonar on the machine — two
+// worktrees only agree because they both compute the same number — so the
+// hash is pinned to golden values here. A change to fnv1a32, to the key shape
+// or to DefaultRange moves every worktree's ports and must be a deliberate
+// edit to this table, not a silent refactor.
+func TestBaseIsPinnedAndProcessIndependent(t *testing.T) {
+	// Golden numbers: computed once, then frozen. Two processes agree because
+	// they both compute these, so a change here is a change every worktree on
+	// the machine feels.
+	golden := map[string]int{
+		"sonar/main":        25900,
+		"myapp/feature-x":   21700,
+		"myapp/feature-y":   22190,
+		"sonar/2A.6-claims": 14040,
+		"":                  11110,
+	}
+	for key, want := range golden {
+		if got := DefaultRange.Base(key); got != want {
+			t.Errorf("Base(%q) = %d, want the pinned %d (the derivation moved)", key, got, want)
+		}
+	}
+}
+
+func TestBaseIsInsideTheRangeAndOnABlockBoundary(t *testing.T) {
+	for _, key := range []string{"a/b", "sonar/main", "x/y", "long-project-name/some-long-worktree-name"} {
+		got := DefaultRange.Base(key)
+		if got < DefaultRange.Start || got > DefaultRange.End {
+			t.Errorf("Base(%q) = %d, outside %d-%d", key, got, DefaultRange.Start, DefaultRange.End)
+		}
+		if (got-DefaultRange.Start)%BlockSize != 0 {
+			t.Errorf("Base(%q) = %d, not on a %d-port block boundary", key, got, BlockSize)
+		}
+	}
+}
+
+func TestDifferentWorktreesLandInDifferentBlocks(t *testing.T) {
+	a := DefaultRange.Base(Key("myapp", "feature-x"))
+	b := DefaultRange.Base(Key("myapp", "feature-y"))
+	if a == b {
+		t.Fatalf("two worktrees derived the same base port %d", a)
+	}
+}
+
+func TestAtWalksUpwardAndWrapsInsideTheRange(t *testing.T) {
+	r := Range{Start: 10000, End: 10009}
+	key := "wrap/me"
+	base := r.Base(key)
+	seen := map[int]bool{}
+	for i := 0; i < r.Span(); i++ {
+		p := r.At(key, i)
+		if p < r.Start || p > r.End {
+			t.Fatalf("At(%d) = %d, outside %d-%d", i, p, r.Start, r.End)
+		}
+		if seen[p] {
+			t.Fatalf("At(%d) = %d repeated before the range was exhausted", i, p)
+		}
+		seen[p] = true
+	}
+	if len(seen) != r.Span() {
+		t.Fatalf("walked %d distinct ports, want the whole %d-port range", len(seen), r.Span())
+	}
+	if got := r.At(key, 1); got != r.Start+(base-r.Start+1)%r.Span() {
+		t.Errorf("At(1) = %d, want the port after the base", got)
+	}
+}
+
+func TestKeyAndSplitKey(t *testing.T) {
+	cases := []struct{ project, worktree, key string }{
+		{"sonar", "", "sonar/" + DefaultWorktree},
+		{"sonar", "main", "sonar/main"},
+		{" myapp ", " feature-x ", "myapp/feature-x"},
+	}
+	for _, c := range cases {
+		if got := Key(c.project, c.worktree); got != c.key {
+			t.Errorf("Key(%q, %q) = %q, want %q", c.project, c.worktree, got, c.key)
+		}
+	}
+	if p, w := SplitKey("myapp/feature-x"); p != "myapp" || w != "feature-x" {
+		t.Errorf("SplitKey = %q, %q", p, w)
+	}
+	if p, w := SplitKey("myapp"); p != "myapp" || w != DefaultWorktree {
+		t.Errorf("SplitKey(%q) = %q, %q", "myapp", p, w)
+	}
+}
+
+func TestRangeValidation(t *testing.T) {
+	if err := DefaultRange.Valid(); err != nil {
+		t.Fatalf("DefaultRange is invalid: %v", err)
+	}
+	for _, r := range []Range{{0, 100}, {100, 70000}, {900, 800}} {
+		if err := r.Valid(); err == nil {
+			t.Errorf("%v was accepted", r)
+		}
+	}
+}

--- a/internal/claims/migration.go
+++ b/internal/claims/migration.go
@@ -1,0 +1,26 @@
+package claims
+
+import (
+	_ "embed"
+
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// Migration 006 is the version the cross-spec contract (§8) reserves for
+// claims. Like the other reserved slots it is registered from the package that
+// owns it rather than shipped inside internal/store, so a build that never
+// links claims never grows the table.
+//
+// It is applied by any store the claims package is linked into — the daemon,
+// and the CLI through it. A database that reaches version 6 before migration
+// 005 (sessions) exists in the binary would never see 005 afterwards, because
+// store.migrate compares against the highest applied version; both migrations
+// ship in the same binary from the first release that has either, so the gap
+// only matters to a development build of one branch alone.
+//
+//go:embed 006_claims.sql
+var migrationSQL string
+
+func init() {
+	store.RegisterMigration(store.VersionClaims, "claims", migrationSQL)
+}

--- a/internal/claims/store_test.go
+++ b/internal/claims/store_test.go
@@ -1,0 +1,181 @@
+package claims_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// This file covers migration 006 and the claims table it creates. It lives
+// here rather than in internal/store because the migration is registered by
+// this package: a store test binary that does not link claims must not grow
+// the table (cross-spec contract §8).
+
+func openStore(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "sonar.db"))
+	if err != nil {
+		t.Fatalf("opening the store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// TestMigrationTakesTheStoreToVersionSix is the v2 -> v6 step: on this branch
+// 003, 004 and 005 are not registered, so the version sequence has to tolerate
+// the gap. It does — store.migrate applies every registered migration above
+// the applied version — and the gap is recorded in the migration's own doc
+// comment: a database that reaches 6 without 005 in the binary would not pick
+// 005 up later, which only a single-branch development build can produce.
+func TestMigrationTakesTheStoreToVersionSix(t *testing.T) {
+	st := openStore(t)
+
+	v, err := st.Version()
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if v != store.VersionClaims {
+		t.Fatalf("version = %d, want %d", v, store.VersionClaims)
+	}
+
+	var applied []int
+	rows, err := st.DB().Query(`SELECT version FROM schema_version ORDER BY version`)
+	if err != nil {
+		t.Fatalf("reading schema_version: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var n int
+		if err := rows.Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		applied = append(applied, n)
+	}
+	if len(applied) < 3 || applied[len(applied)-1] != store.VersionClaims {
+		t.Fatalf("applied versions = %v, want them to end at %d", applied, store.VersionClaims)
+	}
+
+	var name string
+	if err := st.DB().QueryRow(
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'claims'`).Scan(&name); err != nil {
+		t.Fatalf("the claims table is missing: %v", err)
+	}
+}
+
+func TestClaimsTableRoundTrip(t *testing.T) {
+	c := openStore(t).Claims()
+	now := time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+
+	if err := c.Put(
+		store.ClaimRow{Port: 10001, Key: "a/main", Project: "a", Worktree: "main", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		store.ClaimRow{Port: 10002, Key: "a/main", Project: "a", Worktree: "main", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+		store.ClaimRow{Port: 20001, Key: "b/main", Project: "b", Worktree: "main", CreatedAt: now, ExpiresAt: now.Add(2 * time.Hour)},
+	); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := c.Get("a/main")
+	if err != nil || len(got) != 2 || got[0].Port != 10001 || got[1].Port != 10002 {
+		t.Fatalf("Get = %+v, %v", got, err)
+	}
+	if !got[0].CreatedAt.Equal(now) || !got[0].ExpiresAt.Equal(now.Add(time.Hour)) {
+		t.Errorf("times did not round trip: %+v", got[0])
+	}
+
+	all, err := c.List()
+	if err != nil || len(all) != 3 {
+		t.Fatalf("List = %+v, %v", all, err)
+	}
+
+	n, err := c.Delete("a/main")
+	if err != nil || n != 2 {
+		t.Fatalf("Delete = %d, %v; want 2", n, err)
+	}
+	if n, err := c.Delete("nobody/main"); err != nil || n != 0 {
+		t.Fatalf("Delete of an unheld key = %d, %v; want 0, nil", n, err)
+	}
+}
+
+func TestPutRefusesAPortAnotherKeyHoldsAndWritesNothing(t *testing.T) {
+	c := openStore(t).Claims()
+	now := time.Now()
+	if err := c.Put(store.ClaimRow{
+		Port: 10001, Key: "a/main", Project: "a", Worktree: "main", ExpiresAt: now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	err := c.Put(
+		store.ClaimRow{Port: 10005, Key: "b/main", Project: "b", Worktree: "main", ExpiresAt: now.Add(time.Hour)},
+		store.ClaimRow{Port: 10001, Key: "b/main", Project: "b", Worktree: "main", ExpiresAt: now.Add(time.Hour)},
+	)
+	if !errors.Is(err, store.ErrClaimed) {
+		t.Fatalf("Put over a foreign claim = %v, want ErrClaimed", err)
+	}
+	rows, err := c.Get("b/main")
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("rows = %+v, %v; want the whole Put rolled back", rows, err)
+	}
+}
+
+func TestPutKeepsTheOriginalCreatedAtOnRefresh(t *testing.T) {
+	c := openStore(t).Claims()
+	first := time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+	later := first.Add(time.Hour)
+
+	row := store.ClaimRow{Port: 10001, Key: "a/main", Project: "a", Worktree: "main", CreatedAt: first, ExpiresAt: first.Add(time.Hour)}
+	if err := c.Put(row); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	row.CreatedAt, row.ExpiresAt = later, later.Add(time.Hour)
+	if err := c.Put(row); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	got, err := c.Get("a/main")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("Get = %+v, %v", got, err)
+	}
+	if !got[0].CreatedAt.Equal(first) {
+		t.Errorf("created_at = %v, want the original %v", got[0].CreatedAt, first)
+	}
+	if !got[0].ExpiresAt.Equal(later.Add(time.Hour)) {
+		t.Errorf("expires_at = %v, want the refreshed one", got[0].ExpiresAt)
+	}
+}
+
+func TestExpireDropsOnlyTheClaimsThatRanOut(t *testing.T) {
+	c := openStore(t).Claims()
+	now := time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+	if err := c.Put(
+		store.ClaimRow{Port: 10001, Key: "gone/main", Project: "gone", Worktree: "main", CreatedAt: now, ExpiresAt: now.Add(time.Minute)},
+		store.ClaimRow{Port: 10002, Key: "live/main", Project: "live", Worktree: "main", CreatedAt: now, ExpiresAt: now.Add(time.Hour)},
+	); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	n, err := c.Expire(now.Add(2 * time.Minute))
+	if err != nil || n != 1 {
+		t.Fatalf("Expire = %d, %v; want 1", n, err)
+	}
+	rows, err := c.List()
+	if err != nil || len(rows) != 1 || rows[0].Key != "live/main" {
+		t.Fatalf("rows = %+v, %v; want only the live claim", rows, err)
+	}
+}
+
+func TestPutRejectsNonsense(t *testing.T) {
+	c := openStore(t).Claims()
+	if err := c.Put(store.ClaimRow{Port: 0, Key: "a/main"}); err == nil {
+		t.Error("port 0 was accepted")
+	}
+	if err := c.Put(store.ClaimRow{Port: 10001, Key: "  "}); err == nil {
+		t.Error("an empty key was accepted")
+	}
+	if err := c.Put(); err != nil {
+		t.Errorf("Put with no rows = %v, want nil", err)
+	}
+}

--- a/internal/cmd/claim.go
+++ b/internal/cmd/claim.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/claims"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var (
+	claimProject  string
+	claimWorktree string
+	claimCount    int
+	claimTTLFlag  string
+	claimRelease  bool
+	claimListFlag bool
+	claimJSON     bool
+	claimsJSON    bool
+)
+
+var claimCmd = &cobra.Command{
+	Use:   "claim",
+	Short: "Reserve ports for this project and worktree",
+	Long: `Reserve ports for this project and worktree.
+
+The same worktree gets the same ports every time: the ports are derived from
+the project and worktree names, then probed upward past anything that is
+listening or claimed by someone else. Parallel agents in sibling worktrees
+therefore never pick the same port, and ` + "`sonar next`" + ` steps over every claim
+but your own.
+
+Project and worktree default to the git checkout containing the current
+directory. A claim is sonar's book-keeping, not an OS-level bind: a process
+outside sonar can still take the port.
+
+Examples:
+  sonar claim                 # one port for this worktree
+  sonar claim --count 3       # three
+  sonar claim --ttl 2h        # expire sooner than the 24h default
+  sonar claim --release       # give this worktree's ports back
+  sonar claim --list --json   # every live claim on this machine`,
+	Args: cobra.NoArgs,
+	RunE: claimRun,
+}
+
+// `sonar claims` is the read-only half, as named in spec 2 §4.
+var claimsCmd = &cobra.Command{
+	Use:   "claims",
+	Short: "List live port claims",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		c, err := connectForWrite(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+		return listClaims(cmd.Context(), c, claimsJSON)
+	},
+}
+
+func init() {
+	claimCmd.Flags().StringVar(&claimProject, "project", "", "Project name (default: the git checkout's name)")
+	claimCmd.Flags().StringVar(&claimWorktree, "worktree", "", "Worktree name (default: this checkout's, or main)")
+	claimCmd.Flags().IntVarP(&claimCount, "count", "n", 1, "How many ports to claim")
+	claimCmd.Flags().StringVar(&claimTTLFlag, "ttl", "24h", "How long the claim lives (e.g. 2h, 30m)")
+	claimCmd.Flags().BoolVar(&claimRelease, "release", false, "Release this key's ports instead of claiming")
+	claimCmd.Flags().BoolVar(&claimListFlag, "list", false, "List live claims instead of claiming")
+	claimCmd.Flags().BoolVar(&claimJSON, "json", false, "Output as JSON")
+	claimsCmd.Flags().BoolVar(&claimsJSON, "json", false, "Output as JSON")
+	rootCmd.AddCommand(claimCmd)
+	rootCmd.AddCommand(claimsCmd)
+}
+
+func claimRun(cmd *cobra.Command, _ []string) error {
+	ttl, err := claimTTL()
+	if err != nil {
+		return err
+	}
+	if claimCount < 1 {
+		return fmt.Errorf("--count must be at least 1")
+	}
+
+	c, err := connectForWrite(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if claimListFlag {
+		return listClaims(cmd.Context(), c, claimJSON)
+	}
+
+	project, worktree := claimIdentity()
+	key := claims.Key(project, worktree)
+
+	if claimRelease {
+		var res rpc.ClaimsReleaseResult
+		if err := c.Call(cmd.Context(), "claims.release",
+			rpc.ClaimsReleaseParams{Key: key}, &res); err != nil {
+			return daemonError(err)
+		}
+		if claimJSON {
+			return writeJSON(struct {
+				Key      string `json:"key"`
+				Released int    `json:"released"`
+			}{key, res.Released})
+		}
+		fmt.Printf("released %d port(s) held by %s\n", res.Released, key)
+		return nil
+	}
+
+	res, err := acquireClaim(cmd.Context(), c, rpc.ClaimsAcquireParams{
+		Project:    project,
+		Worktree:   worktree,
+		Count:      claimCount,
+		TTLSeconds: int64(ttl / time.Second),
+	})
+	if err != nil {
+		return err
+	}
+	return printClaim(project, worktree, res, claimJSON)
+}
+
+// acquireClaim is the one call `sonar claim` and `sonar next --claim` share.
+func acquireClaim(ctx context.Context, c *client.Client, params rpc.ClaimsAcquireParams) (rpc.ClaimsAcquireResult, error) {
+	var res rpc.ClaimsAcquireResult
+	if err := c.Call(ctx, "claims.acquire", params, &res); err != nil {
+		return res, daemonError(err)
+	}
+	return res, nil
+}
+
+func printClaim(project, worktree string, res rpc.ClaimsAcquireResult, asJSON bool) error {
+	if asJSON {
+		return writeJSON(struct {
+			Key       string `json:"key"`
+			Project   string `json:"project"`
+			Worktree  string `json:"worktree"`
+			Ports     []int  `json:"ports"`
+			ExpiresAt string `json:"expires_at"`
+		}{res.Key, project, worktree, res.Ports, res.ExpiresAt})
+	}
+	for _, p := range res.Ports {
+		fmt.Println(p)
+	}
+	return nil
+}
+
+func listClaims(ctx context.Context, c *client.Client, asJSON bool) error {
+	var res rpc.ClaimsListResult
+	if err := c.Call(ctx, "claims.list", struct{}{}, &res); err != nil {
+		return daemonError(err)
+	}
+	if asJSON {
+		if res.Claims == nil {
+			res.Claims = []state.Claim{}
+		}
+		return writeJSON(res)
+	}
+	if len(res.Claims) == 0 {
+		fmt.Println("no ports are claimed")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "%s\t%s\t%s\n", display.Dim("KEY"), display.Dim("PORTS"), display.Dim("EXPIRES"))
+	for _, cl := range res.Claims {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", cl.Key, joinPorts(cl.Ports), expiresIn(cl.ExpiresAt))
+	}
+	return w.Flush()
+}
+
+func joinPorts(ports []int) string {
+	parts := make([]string, 0, len(ports))
+	for _, p := range ports {
+		parts = append(parts, fmt.Sprint(p))
+	}
+	return strings.Join(parts, ",")
+}
+
+// expiresIn prints the remaining life of a claim, which is what a human is
+// actually asking when they list claims.
+func expiresIn(at string) string {
+	t, err := time.Parse(time.RFC3339, at)
+	if err != nil {
+		return at
+	}
+	d := time.Until(t)
+	if d <= 0 {
+		return "expired"
+	}
+	return "in " + d.Round(time.Minute).String()
+}
+
+func claimTTL() (time.Duration, error) {
+	ttl, err := time.ParseDuration(strings.TrimSpace(claimTTLFlag))
+	if err != nil {
+		return 0, fmt.Errorf("--ttl %q is not a duration (try 24h, 90m)", claimTTLFlag)
+	}
+	if ttl <= 0 {
+		return 0, fmt.Errorf("--ttl must be positive")
+	}
+	return ttl, nil
+}
+
+// claimIdentity derives the project and worktree from the current directory:
+// the git checkout's name, and the worktree name for a linked worktree (spec 2
+// §4). A directory outside any repository claims under its own name.
+func claimIdentity() (project, worktree string) {
+	if claimProject != "" || claimWorktree != "" {
+		project, worktree = claimProject, claimWorktree
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	root, wt, ok := groups.Find(cwd)
+	switch {
+	case !ok:
+		if project == "" {
+			project = filepath.Base(cwd)
+		}
+	case wt != "":
+		// groups.Find spells a linked worktree "<repo>@<name>".
+		repo, name, _ := strings.Cut(wt, "@")
+		if project == "" {
+			project = repo
+		}
+		if worktree == "" {
+			worktree = name
+		}
+	default:
+		if project == "" {
+			project = filepath.Base(root)
+		}
+	}
+	if project == "" {
+		project = "sonar"
+	}
+	if worktree == "" {
+		worktree = claims.DefaultWorktree
+	}
+	return project, worktree
+}

--- a/internal/cmd/next.go
+++ b/internal/cmd/next.go
@@ -17,6 +17,7 @@ import (
 var (
 	nextConsecutiveFlag int
 	nextJSONFlag        bool
+	nextClaimFlag       bool
 )
 
 var nextCmd = &cobra.Command{
@@ -34,7 +35,8 @@ Examples:
   sonar next 8000         # first free port starting from 8000
   sonar next 3000-3100    # first free port in range 3000-3100
   sonar next -n 3          # find 3 consecutive free ports from 3000
-  sonar next 8000 --json  # JSON output`,
+  sonar next 8000 --json  # JSON output
+  sonar next --claim      # reserve the port for this worktree, not just report it`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: nextRun,
 }
@@ -42,12 +44,23 @@ Examples:
 func init() {
 	nextCmd.Flags().IntVarP(&nextConsecutiveFlag, "consecutive", "n", 1, "Number of consecutive free ports to find")
 	nextCmd.Flags().BoolVar(&nextJSONFlag, "json", false, "Output as JSON")
+	nextCmd.Flags().BoolVar(&nextClaimFlag, "claim", false, "Claim the ports for this project and worktree (needs the daemon)")
 	rootCmd.AddCommand(nextCmd)
 }
 
 func nextRun(cmd *cobra.Command, args []string) error {
 	startPort := 3000
 	endPort := 65535
+
+	if nextClaimFlag {
+		if len(args) == 1 {
+			return fmt.Errorf("--claim derives its own ports; drop the port argument")
+		}
+		if nextConsecutiveFlag < 1 {
+			return fmt.Errorf("--consecutive must be at least 1")
+		}
+		return nextClaim(cmd)
+	}
 
 	if len(args) == 1 {
 		arg := args[0]
@@ -154,4 +167,27 @@ func findFreePorts(occupied map[int]bool, start, end, count int) []int {
 		}
 	}
 	return consecutive
+}
+
+// nextClaim is `sonar next --claim`: instead of reporting a port that is free
+// right now, reserve it for this project and worktree so the next agent asking
+// gets a different one. The ports come from the claim range, not from the
+// --start argument, which is why the two cannot be combined.
+func nextClaim(cmd *cobra.Command) error {
+	c, err := connectForWrite(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	project, worktree := claimIdentity()
+	res, err := acquireClaim(cmd.Context(), c, rpc.ClaimsAcquireParams{
+		Project:  project,
+		Worktree: worktree,
+		Count:    nextConsecutiveFlag,
+	})
+	if err != nil {
+		return err
+	}
+	return printClaim(project, worktree, res, nextJSONFlag)
 }

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -1,0 +1,167 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/claims"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// The claims namespace (spec 2 §4). A claim reserves a port in sonar's
+// book-keeping so parallel agents in different worktrees stop picking the same
+// one; it is not an OS-level bind, and the handlers say so in their errors.
+func init() {
+	RegisterHandler("claims.acquire", handleClaimsAcquire)
+	RegisterHandler("claims.release", handleClaimsRelease)
+	RegisterHandler("claims.list", handleClaimsList)
+	RegisterCapability("claims")
+}
+
+// Every claims call runs under one lock: the acquire probe reads the table,
+// picks ports and writes them back, and two of those interleaving would hand
+// the same port to two keys. The calls are rare and short, so a daemon-wide
+// mutex is the whole concurrency story. (The unique constraint on
+// claims.port is the second line of defence, for a second daemon on the same
+// database.)
+var claimsMu sync.Mutex
+
+// claimsManager builds the manager for this request, or reports the daemon
+// that came up without a database.
+func claimsManager(rt *Runtime) (*claims.Manager, error) {
+	st := rt.Store
+	if st == nil {
+		return nil, errNoStore()
+	}
+	return claims.New(st.Claims(), claims.Options{
+		Listening: func() (map[int]bool, error) { return listeningPorts(rt) },
+	}), nil
+}
+
+// listeningPorts is the live scan as a set, which is how the claim probe skips
+// ports something is already serving on.
+func listeningPorts(rt *Runtime) (map[int]bool, error) {
+	rows, err := readPorts(rt, scanner.Include{})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int]bool, len(rows))
+	for _, row := range rows {
+		out[row.Port] = true
+	}
+	return out, nil
+}
+
+func handleClaimsAcquire(_ context.Context, req *Request) (any, error) {
+	var p rpc.ClaimsAcquireParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	claimsMu.Lock()
+	defer claimsMu.Unlock()
+	m, err := claimsManager(req.Runtime)
+	if err != nil {
+		return nil, err
+	}
+	res, err := m.Acquire(claims.Request{
+		Key:      p.Key,
+		Project:  p.Project,
+		Worktree: p.Worktree,
+		Count:    p.Count,
+		TTL:      claimTTL(p),
+	})
+	if err != nil {
+		return nil, claimsError("acquiring a claim", err)
+	}
+	return rpc.ClaimsAcquireResult{
+		MutationResult: rpc.MutationResult{OK: true, Affected: portKeys(res.Ports)},
+		Key:            res.Key,
+		Ports:          res.Ports,
+		ExpiresAt:      res.ExpiresAt.Format(time.RFC3339),
+	}, nil
+}
+
+func handleClaimsRelease(_ context.Context, req *Request) (any, error) {
+	var p rpc.ClaimsReleaseParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	if p.Key == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "key is required",
+			`release the key claims.acquire returned, e.g. {"key": "sonar/main"}`)
+	}
+	claimsMu.Lock()
+	defer claimsMu.Unlock()
+	m, err := claimsManager(req.Runtime)
+	if err != nil {
+		return nil, err
+	}
+	n, err := m.Release(p.Key)
+	if err != nil {
+		return nil, claimsError("releasing a claim", err)
+	}
+	return rpc.ClaimsReleaseResult{OK: true, Released: n}, nil
+}
+
+func handleClaimsList(_ context.Context, req *Request) (any, error) {
+	claimsMu.Lock()
+	defer claimsMu.Unlock()
+	m, err := claimsManager(req.Runtime)
+	if err != nil {
+		return nil, err
+	}
+	live, err := m.List()
+	if err != nil {
+		return nil, claimsError("listing claims", err)
+	}
+	if live == nil {
+		live = []state.Claim{}
+	}
+	return rpc.ClaimsListResult{Claims: live}, nil
+}
+
+// claimTTL reads the spec's ttl_seconds, falling back to the ttl_ms the
+// generated schema has always carried. Zero means the manager's default.
+func claimTTL(p rpc.ClaimsAcquireParams) time.Duration {
+	switch {
+	case p.TTLSeconds > 0:
+		return time.Duration(p.TTLSeconds) * time.Second
+	case p.TTLMs > 0:
+		return time.Duration(p.TTLMs) * time.Millisecond
+	default:
+		return 0
+	}
+}
+
+func portKeys(ports []int) []string {
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		out = append(out, strconv.Itoa(p)+":")
+	}
+	return out
+}
+
+// claimsError maps the manager's failures onto the contract's error codes:
+// claim_conflict (1201) for a port another key holds, not_found when the range
+// is full, invalid_params for a request that names nothing.
+func claimsError(what string, err error) error {
+	switch {
+	case errors.Is(err, store.ErrClaimed):
+		return rpc.NewError(rpc.CodeClaimConflict, err.Error(),
+			"another key holds that port; release it or ask for a different count")
+	case errors.Is(err, claims.ErrExhausted):
+		return rpc.NewError(rpc.CodeNotFound, err.Error(),
+			"release stale claims with `sonar claim --release` or widen the range")
+	case errors.Is(err, claims.ErrNoProject):
+		return rpc.NewError(rpc.CodeInvalidParams, err.Error(),
+			`send {"project": "myapp", "worktree": "main"} or {"key": "myapp/main"}`)
+	default:
+		return storeError(what, err)
+	}
+}

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -83,7 +83,7 @@ func handleClaimsAcquire(_ context.Context, req *Request) (any, error) {
 		MutationResult: rpc.MutationResult{OK: true, Affected: portKeys(res.Ports)},
 		Key:            res.Key,
 		Ports:          res.Ports,
-		ExpiresAt:      res.ExpiresAt.Format(time.RFC3339),
+		ExpiresAt:      res.ExpiresAt.UTC().Format(time.RFC3339),
 	}, nil
 }
 

--- a/internal/daemon/handlers_claims_test.go
+++ b/internal/daemon/handlers_claims_test.go
@@ -1,0 +1,237 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/claims"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+func TestClaimsCapabilityIsAdvertised(t *testing.T) {
+	for _, c := range Capabilities() {
+		if c == "claims" {
+			return
+		}
+	}
+	t.Fatalf("capabilities = %v, missing claims", Capabilities())
+}
+
+func TestAcquireIsDeterministicAndIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := storeHarness(t, ctx)
+	c := h.dial(ctx)
+
+	want := claims.DefaultRange.Base("myapp/feature-x")
+
+	var first rpc.ClaimsAcquireResult
+	if e := c.call("claims.acquire", rpc.ClaimsAcquireParams{
+		Project: "myapp", Worktree: "feature-x",
+	}, &first); e != nil {
+		t.Fatalf("claims.acquire: %v", e)
+	}
+	if !first.OK || first.Key != "myapp/feature-x" {
+		t.Fatalf("result = %+v", first)
+	}
+	if len(first.Ports) != 1 || first.Ports[0] != want {
+		t.Fatalf("ports = %v, want the derived %d", first.Ports, want)
+	}
+	if first.ExpiresAt == "" {
+		t.Error("expires_at is empty")
+	}
+	if _, err := time.Parse(time.RFC3339, first.ExpiresAt); err != nil {
+		t.Errorf("expires_at %q is not RFC 3339: %v", first.ExpiresAt, err)
+	}
+
+	var second rpc.ClaimsAcquireResult
+	if e := c.call("claims.acquire", rpc.ClaimsAcquireParams{
+		Key: "myapp/feature-x", TTLSeconds: 60,
+	}, &second); e != nil {
+		t.Fatalf("second claims.acquire: %v", e)
+	}
+	if len(second.Ports) != 1 || second.Ports[0] != want {
+		t.Fatalf("second acquire = %v, want the same port", second.Ports)
+	}
+	if second.ExpiresAt >= first.ExpiresAt {
+		t.Errorf("expires_at = %s, want the shorter ttl to move it earlier than %s",
+			second.ExpiresAt, first.ExpiresAt)
+	}
+}
+
+func TestAcquireSkipsAListeningPort(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	base := claims.DefaultRange.Base("myapp/main")
+	h, _ := storeHarness(t, ctx, ports.ListeningPort{
+		Port: base, PID: 4242, Process: "python3", Command: "python3 -m http.server",
+	})
+	c := h.dial(ctx)
+
+	var res rpc.ClaimsAcquireResult
+	if e := c.call("claims.acquire", rpc.ClaimsAcquireParams{Project: "myapp"}, &res); e != nil {
+		t.Fatalf("claims.acquire: %v", e)
+	}
+	if len(res.Ports) != 1 || res.Ports[0] != base+1 {
+		t.Fatalf("ports = %v, want %d: the base port is serving", res.Ports, base+1)
+	}
+}
+
+func TestClaimsListAndRelease(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := storeHarness(t, ctx)
+	c := h.dial(ctx)
+
+	for _, key := range []string{"alpha/main", "beta/main"} {
+		var res rpc.ClaimsAcquireResult
+		if e := c.call("claims.acquire", rpc.ClaimsAcquireParams{Key: key, Count: 2}, &res); e != nil {
+			t.Fatalf("claims.acquire %s: %v", key, e)
+		}
+	}
+
+	var list rpc.ClaimsListResult
+	if e := c.call("claims.list", struct{}{}, &list); e != nil {
+		t.Fatalf("claims.list: %v", e)
+	}
+	if len(list.Claims) != 2 {
+		t.Fatalf("claims = %+v, want two", list.Claims)
+	}
+	if list.Claims[0].Key != "alpha/main" || len(list.Claims[0].Ports) != 2 {
+		t.Errorf("first claim = %+v", list.Claims[0])
+	}
+	if list.Claims[0].Project != "alpha" || list.Claims[0].Worktree != "main" {
+		t.Errorf("project/worktree were not recovered from the key: %+v", list.Claims[0])
+	}
+
+	var rel rpc.ClaimsReleaseResult
+	if e := c.call("claims.release", rpc.ClaimsReleaseParams{Key: "alpha/main"}, &rel); e != nil {
+		t.Fatalf("claims.release: %v", e)
+	}
+	if !rel.OK || rel.Released != 2 {
+		t.Fatalf("release = %+v, want two ports released", rel)
+	}
+
+	if e := c.call("claims.list", struct{}{}, &list); e != nil {
+		t.Fatalf("claims.list: %v", e)
+	}
+	if len(list.Claims) != 1 || list.Claims[0].Key != "beta/main" {
+		t.Fatalf("claims after release = %+v, want only beta", list.Claims)
+	}
+}
+
+func TestReleaseNeedsAKeyAndAcquireNeedsAProject(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := storeHarness(t, ctx)
+	c := h.dial(ctx)
+
+	if e := c.call("claims.release", rpc.ClaimsReleaseParams{}, nil); e == nil ||
+		e.Code != rpc.CodeInvalidParams {
+		t.Fatalf("release with no key = %v, want invalid_params", e)
+	}
+	if e := c.call("claims.acquire", rpc.ClaimsAcquireParams{}, nil); e == nil ||
+		e.Code != rpc.CodeInvalidParams {
+		t.Fatalf("acquire with no project = %v, want invalid_params", e)
+	}
+}
+
+func TestPortsNextSkipsForeignClaimsAndReusesItsOwn(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := storeHarness(t, ctx)
+	c := h.dial(ctx)
+
+	var claimed rpc.ClaimsAcquireResult
+	if e := c.call("claims.acquire", rpc.ClaimsAcquireParams{Key: "myapp/main"}, &claimed); e != nil {
+		t.Fatalf("claims.acquire: %v", e)
+	}
+	port := claimed.Ports[0]
+
+	// Starting the search at the claimed port: a foreign caller steps over it.
+	var next rpc.PortsNextResult
+	if e := c.call("ports.next", rpc.PortsNextParams{Start: port}, &next); e != nil {
+		t.Fatalf("ports.next: %v", e)
+	}
+	if len(next.Ports) != 1 || next.Ports[0] == port {
+		t.Fatalf("ports.next = %v, want it to skip the claimed %d", next.Ports, port)
+	}
+
+	// The key that holds it sees it as free.
+	key := "myapp/main"
+	if e := c.call("ports.next", rpc.PortsNextParams{Start: port, ClaimKey: &key}, &next); e != nil {
+		t.Fatalf("ports.next with claim_key: %v", e)
+	}
+	if len(next.Ports) != 1 || next.Ports[0] != port {
+		t.Fatalf("ports.next with its own claim_key = %v, want %d", next.Ports, port)
+	}
+
+	// A released claim stops excluding anything.
+	if e := c.call("claims.release", rpc.ClaimsReleaseParams{Key: key}, nil); e != nil {
+		t.Fatalf("claims.release: %v", e)
+	}
+	if e := c.call("ports.next", rpc.PortsNextParams{Start: port}, &next); e != nil {
+		t.Fatalf("ports.next after release: %v", e)
+	}
+	if next.Ports[0] != port {
+		t.Fatalf("ports.next after release = %v, want %d back", next.Ports, port)
+	}
+}
+
+// TestTwoAgentsAskingAtOnceGetDifferentPorts is the step's demo in test form:
+// parallel agents, one daemon, no collision.
+func TestTwoAgentsAskingAtOnceGetDifferentPorts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := storeHarness(t, ctx)
+
+	const agents = 8
+	conns := make([]*testClient, agents)
+	for i := range conns {
+		conns[i] = h.dial(ctx)
+	}
+
+	var (
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		got   = map[int]string{}
+		fails []string
+		start = make(chan struct{})
+	)
+	for i := 0; i < agents; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			key := "myapp/" + string(rune('a'+i))
+			var res rpc.ClaimsAcquireResult
+			if e := conns[i].call("claims.acquire", rpc.ClaimsAcquireParams{Key: key}, &res); e != nil {
+				mu.Lock()
+				fails = append(fails, key+": "+e.Message)
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, p := range res.Ports {
+				if prev, dup := got[p]; dup {
+					fails = append(fails, "port collision on "+key+" and "+prev)
+				}
+				got[p] = key
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if len(fails) > 0 {
+		t.Fatalf("%v", fails)
+	}
+	if len(got) != agents {
+		t.Fatalf("handed out %d distinct ports to %d agents", len(got), agents)
+	}
+}

--- a/internal/daemon/ports.go
+++ b/internal/daemon/ports.go
@@ -310,7 +310,14 @@ func handlePortsNext(_ context.Context, req *Request) (any, error) {
 		occupied[row.Port] = true
 	}
 
-	// Claims (spec 2) exclude further ports here in a later step.
+	// Claims (spec 2 §4) are reservations nobody is listening on yet, so they
+	// have to be excluded here too — otherwise `sonar next` hands out the port
+	// another worktree is about to bind. A caller that passes its own
+	// claim_key still sees its own ports as free.
+	if err := excludeClaims(req.Runtime, p.ClaimKey, occupied); err != nil {
+		return nil, err
+	}
+
 	free := make([]int, 0, count)
 	for port := start; port <= end; port++ {
 		if occupied[port] {
@@ -427,3 +434,34 @@ func sortedPorts(pp []int) []int {
 
 // nowRFC3339 stamps stream chunks.
 func nowRFC3339() string { return time.Now().Format(time.RFC3339) }
+
+// excludeClaims marks every port held by a foreign claim as occupied. Ports
+// held by claimKey itself stay free: re-running `sonar next --claim` in the
+// worktree that owns them must return the same ports. A daemon with no
+// database has no claims and excludes nothing.
+func excludeClaims(rt *Runtime, claimKey *string, occupied map[int]bool) error {
+	if rt.Store == nil {
+		return nil
+	}
+	claimsMu.Lock()
+	defer claimsMu.Unlock()
+	m, err := claimsManager(rt)
+	if err != nil {
+		return err
+	}
+	held, err := m.Held()
+	if err != nil {
+		return claimsError("reading claims", err)
+	}
+	own := ""
+	if claimKey != nil {
+		own = *claimKey
+	}
+	for port, key := range held {
+		if own != "" && key == own {
+			continue
+		}
+		occupied[port] = true
+	}
+	return nil
+}

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -439,11 +439,20 @@ type RunsSpawnResult struct {
 
 // ---------------------------------------------------------------- claims ---
 
+// ClaimsAcquireParams is the `claim_port` tool's shape (spec 2 §4). Either a
+// project or an explicit key identifies the claim: the CLI derives both from
+// the git root of its own cwd, which the daemon cannot see.
+//
+// TTLSeconds is the spec's field and wins; TTLMs is kept because the generated
+// schema has always carried it and every other duration on this wire is in
+// milliseconds. Neither set means DefaultTTL (24h).
 type ClaimsAcquireParams struct {
-	Project  string `json:"project"`
-	Worktree string `json:"worktree,omitempty"`
-	Count    int    `json:"count,omitempty"`
-	TTLMs    int64  `json:"ttl_ms,omitempty"`
+	Project    string `json:"project,omitempty"`
+	Worktree   string `json:"worktree,omitempty"`
+	Key        string `json:"key,omitempty"`
+	Count      int    `json:"count,omitempty"`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty"`
+	TTLMs      int64  `json:"ttl_ms,omitempty"`
 }
 
 type ClaimsAcquireResult struct {

--- a/internal/store/claims.go
+++ b/internal/store/claims.go
@@ -1,0 +1,166 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// A claim is a reservation in sonar's book-keeping: the port is not bound, it
+// is only spoken for, so `ports.next` and the next `claims.acquire` step over
+// it. Migration 006 holds one row per claimed port; the key groups the ports
+// one (project, worktree) pair holds.
+
+// ErrClaimed is returned by Claims.Put when a port is already held by a
+// different key. The daemon maps it to the contract's claim_conflict (1201).
+var ErrClaimed = errors.New("port is claimed by another key")
+
+// ClaimRow is one claimed port.
+type ClaimRow struct {
+	Port      int
+	Key       string
+	Project   string
+	Worktree  string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// Claims is the claims table. Get it from Store.Claims; the zero value is not
+// usable.
+type Claims struct{ s *Store }
+
+// Claims returns the claims table view of the store.
+func (s *Store) Claims() Claims { return Claims{s: s} }
+
+// Put writes rows, reusing the stored created_at of a port this key already
+// holds so a refresh does not restart its clock. The whole set is written in
+// one transaction: either every port is claimed or none is, which is what lets
+// two acquires racing for the same block fail cleanly instead of interleaving.
+//
+// A port held by a different, unexpired key is never taken: Put returns
+// ErrClaimed and rolls back. Sweep expired rows first (see Expire) so a stale
+// row does not block a live caller.
+func (c Claims) Put(rows ...ClaimRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	for _, r := range rows {
+		if r.Port < 1 || r.Port > 65535 {
+			return fmt.Errorf("store: claim port %d is out of range", r.Port)
+		}
+		if strings.TrimSpace(r.Key) == "" {
+			return errors.New("store: a claim needs a key")
+		}
+	}
+
+	c.s.wmu.Lock()
+	defer c.s.wmu.Unlock()
+
+	tx, err := c.s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("claiming ports: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, r := range rows {
+		var holder string
+		var createdAt string
+		err := tx.QueryRow(`SELECT key, created_at FROM claims WHERE port = ?`, r.Port).
+			Scan(&holder, &createdAt)
+		switch {
+		case err == nil && holder != r.Key:
+			return fmt.Errorf("port %d: %w (%s)", r.Port, ErrClaimed, holder)
+		case err == nil:
+			// Keep the original created_at; only the expiry moves.
+		default:
+			createdAt = timeToString(nonZero(r.CreatedAt))
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO claims(port, key, project, worktree, created_at, expires_at)
+			 VALUES(?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(port) DO UPDATE SET
+			     key        = excluded.key,
+			     project    = excluded.project,
+			     worktree   = excluded.worktree,
+			     expires_at = excluded.expires_at`,
+			r.Port, r.Key, r.Project, r.Worktree, createdAt, timeToString(nonZero(r.ExpiresAt)),
+		); err != nil {
+			return fmt.Errorf("claiming port %d: %w", r.Port, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("claiming ports: %w", err)
+	}
+	return nil
+}
+
+// Get returns the ports held under key, lowest first.
+func (c Claims) Get(key string) ([]ClaimRow, error) {
+	return c.query(`SELECT port, key, project, worktree, created_at, expires_at
+	                  FROM claims WHERE key = ? ORDER BY port`, key)
+}
+
+// List returns every claim row, by key then port.
+func (c Claims) List() ([]ClaimRow, error) {
+	return c.query(`SELECT port, key, project, worktree, created_at, expires_at
+	                  FROM claims ORDER BY key, port`)
+}
+
+// Delete drops every port held under key and reports how many rows went.
+// Releasing a key nobody holds is not an error.
+func (c Claims) Delete(key string) (int, error) {
+	return c.deleteWhere(`DELETE FROM claims WHERE key = ?`, key)
+}
+
+// Expire drops every claim that expired at or before now and reports how many
+// rows went. Every claims.* call sweeps first, which is the lazy pruning the
+// spec asks for.
+func (c Claims) Expire(now time.Time) (int, error) {
+	return c.deleteWhere(`DELETE FROM claims WHERE expires_at <= ?`, timeToString(nonZero(now)))
+}
+
+func (c Claims) deleteWhere(query string, args ...any) (int, error) {
+	c.s.wmu.Lock()
+	defer c.s.wmu.Unlock()
+	res, err := c.s.db.Exec(query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("removing claims: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, nil // the write happened; the driver just cannot count it
+	}
+	return int(n), nil
+}
+
+func (c Claims) query(query string, args ...any) ([]ClaimRow, error) {
+	rows, err := c.s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("reading claims: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []ClaimRow
+	for rows.Next() {
+		var r ClaimRow
+		var created, expires string
+		if err := rows.Scan(&r.Port, &r.Key, &r.Project, &r.Worktree, &created, &expires); err != nil {
+			return nil, fmt.Errorf("reading claims: %w", err)
+		}
+		if r.CreatedAt, err = timeFromString(created); err != nil {
+			return nil, fmt.Errorf("claim on port %d has an unreadable created_at: %w", r.Port, err)
+		}
+		if r.ExpiresAt, err = timeFromString(expires); err != nil {
+			return nil, fmt.Errorf("claim on port %d has an unreadable expires_at: %w", r.Port, err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func nonZero(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now()
+	}
+	return t
+}


### PR DESCRIPTION
Roadmap step 2A.6.

- `internal/claims`: deterministic per-worktree ports (`base = 10000 + fnv1a(key) mod 2270 * 10`, spec 2 §4), probing past listeners and foreign claims, same-key idempotency with TTL refresh, exact `count` semantics, lazy expiry.
- Migration 006 (`claims` table) registered from the claims package; store accessors in `internal/store/claims.go`.
- Daemon methods `claims.acquire {project?, worktree?, key?, count?, ttl_seconds?}`, `claims.release {key}`, `claims.list`; `ports.next {claim_key?}` treats foreign claims as occupied. Capability `claims`.
- CLI: `sonar claim`, `sonar claims`, `sonar next --claim`.
- Schema regenerated (`ClaimsAcquireParams` gained `key` and `ttl_seconds`; `project` optional when a key is given).

Note for the sessions branch (2A.4): the store applies migrations by `MAX(version)`, so a dev database that reached v6 before 005 existed will not get 005 later; delete the dev db or track applied versions individually.