### PR TITLE
feat: attribute ports to agent sessions and add sessions.list, inspect and kill

### DIFF
--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -2034,6 +2034,9 @@
         },
         "include": {
           "$ref": "#/definitions/Include"
+        },
+        "session": {
+          "type": "string"
         }
       },
       "type": "object"
@@ -2488,6 +2491,9 @@
         "id": {
           "type": "string"
         },
+        "session": {
+          "$ref": "#/definitions/Session"
+        },
         "allow_outside_home": {
           "type": "boolean"
         }
@@ -2541,7 +2547,7 @@
           "type": "integer"
         },
         "session": {
-          "type": "string"
+          "$ref": "#/definitions/Session"
         },
         "allow_outside_home": {
           "type": "boolean"

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -22,6 +22,7 @@ import (
 var (
 	killPIDFlag        []int
 	killGroupFlag      string
+	killSessionFlag    string
 	killAllFlag        bool
 	killFilterFlag     string
 	killProjectFlag    string
@@ -45,6 +46,7 @@ Examples:
   sonar kill 3000 5432 --force         # SIGKILL both
   sonar kill --pid 12345 --tree        # a process and everything below it
   sonar kill -g sonar                  # a whole group, confirms unless --yes
+  sonar kill --session current -y      # everything this agent session started
   sonar kill --all --filter docker -y  # every container publishing a port
   sonar kill --all --project my-app    # one Docker Compose project
   sonar kill 3000 --ip 127.0.0.1       # disambiguate a multi-bind port
@@ -59,6 +61,8 @@ matches a running process is read as a pid.`,
 func init() {
 	killCmd.Flags().IntSliceVar(&killPIDFlag, "pid", nil, "Kill by process id (repeatable)")
 	killCmd.Flags().StringVarP(&killGroupFlag, "group", "g", "", "Kill every port in a group")
+	killCmd.Flags().StringVar(&killSessionFlag, "session", "",
+		"Stop everything an agent `session` started (`current` is this shell's own)")
 	killCmd.Flags().BoolVar(&killAllFlag, "all", false, "Kill every listening port")
 	killCmd.Flags().StringVar(&killFilterFlag, "filter", "", "With --all: keep only docker, user or system ports")
 	killCmd.Flags().StringVar(&killProjectFlag, "project", "", "With --all: keep only one Docker Compose project")
@@ -72,12 +76,21 @@ func init() {
 	killCmd.Flags().String("ip", "", "Bind address, when a port is bound to several")
 	killCmd.Flags().BoolVar(&killJSONFlag, "json", false, "Print the result list as JSON")
 	killCmd.MarkFlagsMutuallyExclusive("group", "all")
+	killCmd.MarkFlagsMutuallyExclusive("session", "all")
+	killCmd.MarkFlagsMutuallyExclusive("session", "group")
 	rootCmd.AddCommand(killCmd)
 }
 
 func runKill(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 	bindIP, _ := cmd.Flags().GetString("ip")
+
+	if killSessionFlag != "" {
+		if len(args) > 0 || len(killPIDFlag) > 0 {
+			return fmt.Errorf("--session cannot be combined with ports or pids")
+		}
+		return killSession(cmd.Context())
+	}
 
 	// A reachable daemon does the killing, so it rescans straight afterwards
 	// and the history ring sees the port go down (contract §22). Without this

--- a/internal/cmd/killroute.go
+++ b/internal/cmd/killroute.go
@@ -129,3 +129,56 @@ func graceMs(opts killer.Options) int {
 	}
 	return int(opts.Grace.Milliseconds())
 }
+
+// killSession is `sonar kill --session <id>`: the session form of `-g`,
+// answered by `sessions.kill` for the same reason `-g` is answered by
+// `groups.kill` — the daemon owns the membership, so it does the selecting.
+// There is no direct-scan path: a session only exists in the daemon.
+func killSession(ctx context.Context) error {
+	id, err := currentSession(killSessionFlag)
+	if err != nil {
+		return err
+	}
+	c, err := sessionsDaemon(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	snapshot, err := daemonList(ctx, c, rpc.PortsListParams{All: true})
+	if err != nil {
+		return cliError(err)
+	}
+
+	call := func(dryRun bool) ([]killer.Result, error) {
+		var env rpc.KillEnvelope
+		err := c.Call(ctx, "sessions.kill", rpc.SessionsKillParams{
+			ID:     id,
+			Tree:   killTreeFlag,
+			Force:  forceFlag,
+			DryRun: dryRun,
+		}, &env)
+		return env.Results, err
+	}
+
+	if !killYesFlag && !killDryRunFlag {
+		plan, err := call(true)
+		if err != nil {
+			return cliError(err)
+		}
+		if len(plan) == 0 {
+			fmt.Printf("Session %s has nothing running.\n", id)
+			return nil
+		}
+		if !confirmPlan(plan, snapshot) {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	results, err := call(killDryRunFlag)
+	if err != nil {
+		return cliError(err)
+	}
+	return reportKill(os.Stdout, results, snapshot, killJSONFlag, killDryRunFlag)
+}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -29,6 +30,7 @@ var (
 	ipv4Flag       bool
 	ipv6Flag       bool
 	groupFlag      string
+	sessionFlag    string
 	tagFlag        string
 	treeFlag       bool
 )
@@ -53,6 +55,8 @@ func init() {
 	listCmd.Flags().BoolVarP(&ipv4Flag, "ipv4", "4", false, "Show only IPv4 ports")
 	listCmd.Flags().BoolVarP(&ipv6Flag, "ipv6", "6", false, "Show only IPv6 ports")
 	listCmd.Flags().StringVar(&groupFlag, "group", "", "Show only ports in this `group`")
+	listCmd.Flags().StringVar(&sessionFlag, "session", "",
+		"Show only the ports an agent `session` started (`current` is this shell's own)")
 	listCmd.Flags().StringVar(&tagFlag, "tag", "", "Alias of --group, kept for one release")
 	listCmd.Flags().BoolVar(&treeFlag, "tree", false, "Group the ports into a tree instead of a table")
 	listCmd.MarkFlagsMutuallyExclusive("ipv4", "ipv6")
@@ -78,10 +82,16 @@ func listRun(cmd *cobra.Command, args []string) error {
 		ipVersion = "IPv6"
 	}
 
+	session, err := currentSession(sessionFlag)
+	if err != nil {
+		return err
+	}
+
 	results, index, err := listPorts(cmd.Context(), listQuery{
 		showApps:  showApps,
 		filter:    activeFilter,
 		group:     group,
+		session:   session,
 		ipVersion: ipVersion,
 	})
 	if err != nil {
@@ -113,6 +123,11 @@ func listRun(cmd *cobra.Command, args []string) error {
 	}
 	return nil
 }
+
+// errSessionNeedsDaemon is what --session says when nothing is listening on
+// the daemon socket.
+var errSessionNeedsDaemon = errors.New(
+	"--session needs a running daemon; start one with `sonar serve --detach`")
 
 // hasHiddenProcesses reports whether the scan ran unprivileged and at least one
 // listening socket came back without a resolvable process name — the signature
@@ -232,6 +247,7 @@ type listQuery struct {
 	showApps  bool
 	filter    string
 	group     string
+	session   string
 	ipVersion string
 }
 
@@ -240,6 +256,9 @@ type listQuery struct {
 // a one-line note otherwise. The group index is only built on the direct path;
 // through the daemon the tree view derives what it needs from the rows.
 func listPorts(ctx context.Context, q listQuery) ([]ports.ListeningPort, *groups.Index, error) {
+	if hostFlag != "" && q.session != "" {
+		return nil, nil, errors.New("--session and --host cannot be combined: a session is local daemon state")
+	}
 	if hostFlag != "" {
 		// A remote host is scanned over SSH; the local daemon knows nothing
 		// about it.
@@ -257,6 +276,7 @@ func listPorts(ctx context.Context, q listQuery) ([]ports.ListeningPort, *groups
 		defer c.Close()
 		rows, err := daemonList(ctx, c, rpc.PortsListParams{
 			Group:     strPtrOrNil(q.group),
+			Session:   strPtrOrNil(q.session),
 			Filter:    strPtrOrNil(q.filter),
 			All:       q.showApps,
 			IPVersion: strPtrOrNil(q.ipVersion),
@@ -268,6 +288,13 @@ func listPorts(ctx context.Context, q listQuery) ([]ports.ListeningPort, *groups
 		// A daemon that answered with an error is a real failure, not a
 		// reason to scan twice.
 		return nil, nil, err
+	}
+
+	if q.session != "" {
+		// A session is daemon state: it lives in the run registry and the
+		// database, and a direct scan has no way to know one existed. Saying
+		// so beats printing an empty table (contract §20).
+		return nil, nil, errSessionNeedsDaemon
 	}
 
 	results, err := ports.Scan()

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sessionsAllFlag  bool
+	sessionsJSONFlag bool
+)
+
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions [id]",
+	Short: "Show the agent sessions that started something",
+	Long: `List the coding-agent sessions sonar has attributed runs to.
+
+A session is one agent — Claude Code, Codex, Cursor — identified by
+SONAR_SESSION (` + "`<tool>:<id>`" + `) or detected from the environment it
+spawns commands in. Active sessions have at least one run still alive;
+inactive ones are kept for seven days.
+
+Examples:
+  sonar sessions                     # the sessions with something running
+  sonar sessions --all               # including the ones that have finished
+  sonar sessions claude-code:abc123  # the runs and ports of one session
+  sonar list --session abc123        # the ports one session started
+  sonar kill --session abc123        # stop everything it started`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runSessions,
+}
+
+func init() {
+	sessionsCmd.Flags().BoolVarP(&sessionsAllFlag, "all", "a", false,
+		"Include sessions with nothing running")
+	sessionsCmd.Flags().BoolVar(&sessionsJSONFlag, "json", false, "Output as JSON")
+	rootCmd.AddCommand(sessionsCmd)
+}
+
+func runSessions(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	c, err := sessionsDaemon(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if len(args) == 1 {
+		return inspectSession(cmd.Context(), c, args[0])
+	}
+	return listSessions(cmd.Context(), c)
+}
+
+// sessionsDaemon connects without autostarting. Sessions live in the daemon's
+// memory and database, so there is nothing a direct scan could answer with —
+// unlike the read commands in contract §20, this one has to say so.
+func sessionsDaemon(ctx context.Context) (*client.Client, error) {
+	c, err := dialDaemon(ctx)
+	if err != nil {
+		if errors.Is(err, client.ErrNotRunning) {
+			return nil, errors.New("sessions need a running daemon; start one with `sonar serve --detach`")
+		}
+		return nil, err
+	}
+	return c, nil
+}
+
+func listSessions(ctx context.Context, c *client.Client) error {
+	var out rpc.SessionsListResult
+	err := c.Call(ctx, "sessions.list", rpc.SessionsListParams{ActiveOnly: !sessionsAllFlag}, &out)
+	if err != nil {
+		return cliError(err)
+	}
+
+	if sessionsJSONFlag {
+		return writeJSON(map[string]any{"sessions": nonNil(out.Sessions)})
+	}
+	if len(out.Sessions) == 0 {
+		if sessionsAllFlag {
+			fmt.Println("No agent sessions recorded.")
+		} else {
+			fmt.Println("No active agent sessions. Try --all.")
+		}
+		return nil
+	}
+
+	fmt.Printf("%-26s %-13s %-22s %-20s %-6s %-6s %s\n",
+		display.Bold("SESSION"), display.Bold("TOOL"), display.Bold("WORKTREE"),
+		display.Bold("BRANCH"), display.Bold("RUNS"), display.Bold("PORTS"), display.Bold("STATE"))
+	for _, s := range out.Sessions {
+		fmt.Printf("%-26s %-13s %-22s %-20s %-6d %-6d %s\n",
+			display.Cyan(s.ID), toolLabel(s.Session), dash(s.Worktree), dash(s.Branch),
+			s.Runs, s.Ports, sessionState(s))
+	}
+	return nil
+}
+
+func inspectSession(ctx context.Context, c *client.Client, id string) error {
+	var out rpc.SessionsInspectResult
+	if err := c.Call(ctx, "sessions.inspect", rpc.SessionsInspectParams{ID: id}, &out); err != nil {
+		return cliError(err)
+	}
+	if sessionsJSONFlag {
+		return writeJSON(out)
+	}
+
+	s := out.Session
+	fmt.Printf("%s %s\n", display.Bold("Session"), display.Cyan(s.ID))
+	fmt.Printf("  %-10s %s\n", "tool", toolLabel(s.Session))
+	if s.Label != "" {
+		fmt.Printf("  %-10s %s\n", "label", s.Label)
+	}
+	fmt.Printf("  %-10s %s\n", "worktree", dash(s.Worktree))
+	fmt.Printf("  %-10s %s\n", "branch", dash(s.Branch))
+	fmt.Printf("  %-10s %s\n", "state", sessionState(s))
+	if s.FirstSeen != "" {
+		fmt.Printf("  %-10s %s\n", "first seen", s.FirstSeen)
+	}
+	if s.LastSeen != "" {
+		fmt.Printf("  %-10s %s\n", "last seen", s.LastSeen)
+	}
+
+	fmt.Printf("\n%s\n", display.Bold("Runs"))
+	if len(out.Runs) == 0 {
+		fmt.Println("  none running")
+	}
+	for _, r := range out.Runs {
+		fmt.Printf("  %-10s %-18s %-14s pid %-7d %s\n",
+			r.ID, display.Cyan(r.Group), r.Name, r.PID, portList(r.Ports))
+	}
+
+	fmt.Printf("\n%s\n", display.Bold("Ports"))
+	if len(out.Ports) == 0 {
+		fmt.Println("  none listening")
+	}
+	for _, p := range out.Ports {
+		fmt.Printf("  %-7d %-24s %s\n", p.Port, p.DisplayName, p.URL)
+	}
+	return nil
+}
+
+// toolLabel names the agent, marking a detected session so the reader knows
+// sonar inferred it rather than being told (spec 2 §3).
+func toolLabel(s state.Session) string {
+	tool := s.Tool
+	if tool == "" {
+		tool = sessions.ToolAgent
+	}
+	if s.Detected {
+		return tool + display.Dim("?")
+	}
+	return tool
+}
+
+func sessionState(s state.SessionRecord) string {
+	if s.Active {
+		return display.Green("active")
+	}
+	return display.Dim("inactive")
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func nonNil(s []state.SessionRecord) []state.SessionRecord {
+	if s == nil {
+		return []state.SessionRecord{}
+	}
+	return s
+}
+
+// currentSession resolves the `current` shorthand spec 2 §3 gives
+// `--session`: the session this shell is in, read from its own environment.
+func currentSession(id string) (string, error) {
+	if !strings.EqualFold(strings.TrimSpace(id), "current") {
+		return id, nil
+	}
+	s, ok := sessions.Detect(sessions.Options{})
+	if !ok {
+		return "", errors.New("no agent session in this environment; pass a session id, or set SONAR_SESSION")
+	}
+	return s.ID, nil
+}

--- a/internal/cmd/sessions_test.go
+++ b/internal/cmd/sessions_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// `--session current` is spec 2 §3's shorthand: it resolves from this shell's
+// own environment, and says so when there is nothing to resolve.
+func TestCurrentSessionResolvesFromTheEnvironment(t *testing.T) {
+	t.Setenv(sessions.EnvSession, "claude-code:abc123")
+	got, err := currentSession("current")
+	if err != nil {
+		t.Fatalf("currentSession: %v", err)
+	}
+	if got != "abc123" {
+		t.Errorf("currentSession(current) = %q, want abc123", got)
+	}
+
+	// Anything else is passed through untouched.
+	if got, err := currentSession("some-id"); err != nil || got != "some-id" {
+		t.Errorf("currentSession(some-id) = %q, %v", got, err)
+	}
+	if got, err := currentSession(""); err != nil || got != "" {
+		t.Errorf("currentSession(\"\") = %q, %v", got, err)
+	}
+}
+
+func TestCurrentSessionWithoutAnAgentIsAnError(t *testing.T) {
+	for _, key := range []string{
+		sessions.EnvSession, sessions.EnvSessionID, sessions.EnvClaudeCode,
+		sessions.EnvClaudeCodeSessionID, sessions.EnvClaudeSessionID,
+		sessions.EnvCodexThreadID, sessions.EnvCodexSandbox, sessions.EnvCursorAgent,
+		sessions.EnvCursorAgentSessionID,
+	} {
+		t.Setenv(key, "")
+	}
+	if _, err := currentSession("current"); err == nil {
+		t.Error("currentSession(current) outside an agent did not fail")
+	}
+}
+
+// --session is daemon state, so the direct-scan path refuses rather than
+// printing an empty table (contract §20 is about reads that *can* fall back).
+func TestListSessionNeedsADaemon(t *testing.T) {
+	prev := dialDaemon
+	dialDaemon = func(context.Context) (*client.Client, error) { return nil, client.ErrNotRunning }
+	t.Cleanup(func() { dialDaemon = prev })
+
+	_, _, err := listPorts(context.Background(), listQuery{session: "abc"})
+	if !errors.Is(err, errSessionNeedsDaemon) {
+		t.Errorf("listPorts with --session and no daemon = %v, want errSessionNeedsDaemon", err)
+	}
+}
+
+func TestSessionsCommandWithoutADaemonSaysSo(t *testing.T) {
+	prev := dialDaemon
+	dialDaemon = func(context.Context) (*client.Client, error) { return nil, client.ErrNotRunning }
+	t.Cleanup(func() { dialDaemon = prev })
+
+	_, err := sessionsDaemon(context.Background())
+	if err == nil {
+		t.Fatal("sessionsDaemon without a daemon did not fail")
+	}
+	if !strings.Contains(err.Error(), "sonar serve") {
+		t.Errorf("error = %q, want it to name the command that starts a daemon", err)
+	}
+}
+
+// A detected session is rendered with a marker, so a reader can tell "the
+// agent told us" from "we recognised its environment" (spec 2 §3).
+func TestToolLabelMarksADetectedSession(t *testing.T) {
+	told := toolLabel(state.Session{Tool: sessions.ToolClaudeCode})
+	guessed := toolLabel(state.Session{Tool: sessions.ToolClaudeCode, Detected: true})
+	if told == guessed {
+		t.Errorf("a detected session renders identically to a declared one: %q", told)
+	}
+	if !strings.Contains(guessed, sessions.ToolClaudeCode) {
+		t.Errorf("label = %q, want it to name the tool", guessed)
+	}
+	if got := toolLabel(state.Session{}); got == "" {
+		t.Error("a session with no tool rendered as an empty label")
+	}
+}
+
+func TestSessionStateReadsActive(t *testing.T) {
+	if !strings.Contains(sessionState(state.SessionRecord{Active: true}), "active") {
+		t.Error("an active session is not labelled active")
+	}
+	if !strings.Contains(sessionState(state.SessionRecord{}), "inactive") {
+		t.Error("an inactive session is not labelled inactive")
+	}
+}

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -18,7 +18,9 @@ import (
 	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/runs"
 	"github.com/raskrebs/sonar/internal/selfupdate"
+	"github.com/raskrebs/sonar/internal/sessions"
 	"github.com/raskrebs/sonar/internal/spawn"
+	"github.com/raskrebs/sonar/internal/state"
 	"github.com/spf13/cobra"
 
 	// The daemon serves runs.register/unregister/list/spawn from this package's
@@ -33,6 +35,10 @@ var (
 	startDetach bool
 	startList   bool
 	startJSON   bool
+
+	// startSession is the agent session this invocation belongs to, detected
+	// once in startRun and carried into whichever spawn path runs.
+	startSession state.Session
 )
 
 // registerTimeout bounds the daemon round-trips around a run. A slow or absent
@@ -83,6 +89,12 @@ func startRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolving the working directory: %w", err)
 	}
 	res := spawn.Resolve(cwd, args, startGroup, startName)
+	// The agent session is detected here, in the process the agent actually
+	// spawned: the daemon's own environment is a service manager's, not an
+	// agent's, so it could never detect this (spec 2 §3).
+	session, _ := sessions.Capture(cwd, sessions.Options{})
+
+	startSession = session
 
 	if startDetach {
 		return startDetached(cmd, args, cwd, res)
@@ -106,6 +118,7 @@ func startAttached(cmd *cobra.Command, argv []string, cwd string, res spawn.Reso
 		Group:    res.Group,
 		Name:     res.Name,
 		PortHint: startPort,
+		Session:  startSession,
 	})
 	if err != nil {
 		return err
@@ -145,6 +158,10 @@ func startDetached(cmd *cobra.Command, argv []string, cwd string, res spawn.Reso
 			// The CLI is the user: it may start commands anywhere.
 			AllowOutsideHome: true,
 		}
+		if startSession.ID != "" {
+			s := startSession
+			params.Session = &s
+		}
 		if startPort > 0 {
 			hint := startPort
 			params.PortHint = &hint
@@ -166,6 +183,7 @@ func startDetached(cmd *cobra.Command, argv []string, cwd string, res spawn.Reso
 		Group:    res.Group,
 		Name:     res.Name,
 		PortHint: startPort,
+		Session:  startSession,
 		Detach:   true,
 	})
 	if err != nil {
@@ -203,6 +221,10 @@ func registerRun(h *spawn.Handle) bool {
 			StartedAt:        h.StartedAt.Format(time.RFC3339),
 			ID:               &h.ID,
 			AllowOutsideHome: true,
+		}
+		if h.Session.ID != "" {
+			s := h.Session
+			params.Session = &s
 		}
 		if h.PortHint > 0 {
 			hint := h.PortHint

--- a/internal/daemon/handlers_sessions.go
+++ b/internal/daemon/handlers_sessions.go
@@ -1,0 +1,327 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// The sessions namespace (spec 2 §3). A session is an agent — Claude Code,
+// Codex, Cursor — that asked sonar to start something. The run registry is the
+// authority on which sessions are live; the store remembers the rest for the
+// seven days `port_history` may still name them.
+//
+// The collection itself is built here and handed to the scanner, so `sessions`
+// rides in every snapshot and delta like the other four collections
+// (contract §5) instead of being a read-only side table.
+func init() {
+	RegisterHandler("sessions.list", handleSessionsList)
+	RegisterHandler("sessions.inspect", handleSessionsInspect)
+	RegisterHandler("sessions.kill", handleSessionsKill)
+	RegisterCapability("sessions")
+
+	OnStart(func(rt *Runtime) {
+		rt.Scanner.SetSessions(func(ports []state.Port) []state.SessionRecord {
+			return sessionRecords(rt, ports)
+		})
+		startSessionMaintenance(rt)
+	})
+	OnShutdown(func(bool) { stopSessionMaintenance() })
+}
+
+// sessionRuns is the optional interface the installed run registry implements
+// to report which agent session started each live run. It is an assertion
+// rather than a method on RunRegistry because internal/daemon/runsreg imports
+// this package, never the other way round (contract §8).
+type sessionRuns interface {
+	SessionRuns() []sessions.Live
+}
+
+// liveSessions is every live run that carries a session.
+func liveSessions(rt *Runtime) []sessions.Live {
+	if reg, ok := rt.Runs().(sessionRuns); ok {
+		return reg.SessionRuns()
+	}
+	return nil
+}
+
+// knownSessions is what the store remembers, live or not.
+func knownSessions(rt *Runtime) []sessions.Known {
+	if rt.Store == nil {
+		return nil
+	}
+	rows, err := rt.Store.Sessions().List()
+	if err != nil {
+		rt.Logger.Warn("reading recorded sessions", "error", err)
+		return nil
+	}
+	out := make([]sessions.Known, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, sessions.Known{
+			Session:   sessionFromRow(r),
+			FirstSeen: r.FirstSeen,
+			LastSeen:  r.LastSeen,
+		})
+	}
+	return out
+}
+
+func sessionFromRow(r store.SessionRow) state.Session {
+	return state.Session{
+		ID: r.ID, Tool: r.Tool, Label: r.Label,
+		Worktree: r.Worktree, Branch: r.Branch, Detected: r.Detected,
+	}
+}
+
+// sessionRecords is the `sessions` collection for one scan tick.
+func sessionRecords(rt *Runtime, ports []state.Port) []state.SessionRecord {
+	return sessions.Records(knownSessions(rt), liveSessions(rt), ports)
+}
+
+func handleSessionsList(_ context.Context, req *Request) (any, error) {
+	var p rpc.SessionsListParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	records := sessionRecords(req.Runtime, sessionPorts(req.Runtime))
+	out := make([]state.SessionRecord, 0, len(records))
+	for _, rec := range records {
+		if p.ActiveOnly && !rec.Active {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return rpc.SessionsListResult{Sessions: out}, nil
+}
+
+func handleSessionsInspect(_ context.Context, req *Request) (any, error) {
+	var p rpc.SessionsInspectParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(p.ID)
+	if id == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "id is required",
+			`send {"id": "claude-code:abc123"}`)
+	}
+
+	ports := sessionPorts(req.Runtime)
+	records := sessionRecords(req.Runtime, ports)
+	rec, ok := findSession(records, id)
+	if !ok {
+		return nil, sessionNotFound(id)
+	}
+
+	live := sessions.RunsOf(liveSessions(req.Runtime), rec.ID)
+	runs := make([]rpc.RunRecord, 0, len(live))
+	for _, l := range live {
+		runs = append(runs, rpc.RunRecord{
+			ID: l.RunID, PID: l.PID, Group: l.Group, Name: l.Name,
+			Cmd: l.Cmd, Cwd: l.Cwd,
+			StartedAt: l.StartedAt.Format(time.RFC3339),
+			Ports:     runPorts(ports, l),
+			Status:    "running",
+		})
+	}
+	return rpc.SessionsInspectResult{
+		Session: rec,
+		Runs:    runs,
+		Ports:   sessions.PortsOf(ports, rec.ID),
+	}, nil
+}
+
+// handleSessionsKill stops everything one session started. It is the session
+// form of `groups.kill` (contract §3) and returns the same envelope: the
+// session's listening ports are the targets, plus the pid of any of its runs
+// that is not listening on anything yet, so "stop everything this session
+// started" also catches a dev server still coming up.
+func handleSessionsKill(ctx context.Context, req *Request) (any, error) {
+	var p rpc.SessionsKillParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(p.ID)
+	if id == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "id is required",
+			`send {"id": "claude-code:abc123"}`)
+	}
+
+	snap, err := killSnapshot(req)
+	if err != nil {
+		return nil, err
+	}
+	live := sessions.RunsOf(liveSessions(req.Runtime), id)
+	targets := sessionTargets(snap, live, id)
+	if len(targets) == 0 {
+		if _, ok := findSession(sessionRecords(req.Runtime, snap.Ports), id); !ok {
+			return nil, sessionNotFound(id)
+		}
+		// A known session with nothing running: an empty envelope, not an
+		// error. "Stop everything this session started" succeeded trivially.
+		return killEnvelope(nil), nil
+	}
+
+	opts := killer.Options{
+		Tree:   p.Tree,
+		Force:  p.Force,
+		DryRun: p.DryRun,
+		Ports:  killerRows(snap),
+	}
+	rows := killer.KillPorts(ctx, targets, opts)
+	afterKill(req, opts.DryRun)
+	return killEnvelope(rows), nil
+}
+
+// sessionTargets selects what a session owns: every listening port stamped
+// with it, then the root pid of any of its runs that owns none of them.
+func sessionTargets(snap state.Snapshot, live []sessions.Live, id string) []killer.Target {
+	var out []killer.Target
+	covered := map[int]bool{}
+	for _, p := range snap.Ports {
+		if p.Session == nil || p.Session.ID != id {
+			continue
+		}
+		out = append(out, killer.Target{Port: p.Port, BindAddress: p.BindAddress})
+		if p.Run != nil {
+			covered[p.Run.RootPID] = true
+		}
+	}
+	for _, l := range live {
+		if l.PID > 0 && !covered[l.PID] {
+			out = append(out, killer.Target{PID: l.PID})
+		}
+	}
+	return out
+}
+
+// runPorts lists the ports one run currently holds.
+func runPorts(ports []state.Port, l sessions.Live) []int {
+	out := []int{}
+	seen := map[int]bool{}
+	for i := range ports {
+		r := ports[i].Run
+		if r == nil || (r.RootPID != l.PID && r.ID != l.RunID) {
+			continue
+		}
+		if !seen[ports[i].Port] {
+			seen[ports[i].Port] = true
+			out = append(out, ports[i].Port)
+		}
+	}
+	return out
+}
+
+// findSession matches a session by its full id, and — because the ids are long
+// — by a unique prefix, which is what makes `sonar sessions <id>` usable by
+// hand. An ambiguous prefix is reported rather than guessed.
+func findSession(records []state.SessionRecord, id string) (state.SessionRecord, bool) {
+	for _, rec := range records {
+		if rec.ID == id {
+			return rec, true
+		}
+	}
+	var hit state.SessionRecord
+	n := 0
+	for _, rec := range records {
+		if strings.HasPrefix(rec.ID, id) {
+			hit, n = rec, n+1
+		}
+	}
+	if n == 1 {
+		return hit, true
+	}
+	return state.SessionRecord{}, false
+}
+
+func sessionNotFound(id string) error {
+	return rpc.NewError(rpc.CodeSessionNotFound, "no session "+id,
+		"run `sonar sessions --all` to see the sessions this daemon knows")
+}
+
+// sessionPorts is the port table the collection is built from: the cache when
+// it is warm, a scan otherwise. Sessions change when runs start and stop, not
+// between scans, so a cached table is always good enough here.
+func sessionPorts(rt *Runtime) []state.Port {
+	if snap := rt.Scanner.Cached(); snap.Seq > 0 {
+		return snap.Ports
+	}
+	rows, err := readPorts(rt, scanner.Include{})
+	if err != nil {
+		return nil
+	}
+	return rows
+}
+
+// sessionMaintenanceInterval is how often live sessions are touched and dead
+// ones pruned. It is a minute rather than the scan cadence because both are
+// database writes and neither is urgent: the seven-day window has a minute of
+// slack in it.
+const sessionMaintenanceInterval = time.Minute
+
+var sessionMaintenanceStop chan struct{}
+
+// startSessionMaintenance keeps last_seen fresh for every live session and
+// drops the ones nothing has started anything with for sessions.Retention
+// (spec 2 §3: inactive sessions are kept 7 days, then pruned).
+func startSessionMaintenance(rt *Runtime) {
+	stopSessionMaintenance()
+	if rt.Store == nil {
+		return
+	}
+	stop := make(chan struct{})
+	sessionMaintenanceStop = stop
+	go func() {
+		t := time.NewTicker(sessionMaintenanceInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				SweepSessions(rt, time.Now())
+			}
+		}
+	}()
+}
+
+func stopSessionMaintenance() {
+	if sessionMaintenanceStop != nil {
+		close(sessionMaintenanceStop)
+		sessionMaintenanceStop = nil
+	}
+}
+
+// SweepSessions is one maintenance pass: touch the live sessions, prune the
+// ones last seen more than sessions.Retention ago. Exported so a test can run
+// a pass without waiting out the timer.
+func SweepSessions(rt *Runtime, now time.Time) {
+	if rt == nil || rt.Store == nil {
+		return
+	}
+	table := rt.Store.Sessions()
+	seen := map[string]bool{}
+	for _, l := range liveSessions(rt) {
+		if l.Session.ID == "" || seen[l.Session.ID] {
+			continue
+		}
+		seen[l.Session.ID] = true
+		if err := table.Touch(l.Session.ID, now); err != nil {
+			rt.Logger.Warn("touching a live session", "session", l.Session.ID, "error", err)
+		}
+	}
+	n, err := table.Prune(now.Add(-sessions.Retention))
+	if err != nil {
+		rt.Logger.Warn("pruning sessions", "error", err)
+		return
+	}
+	if n > 0 {
+		rt.Logger.Info("pruned inactive sessions", "count", n)
+	}
+}

--- a/internal/daemon/handlers_sessions_test.go
+++ b/internal/daemon/handlers_sessions_test.go
@@ -1,0 +1,298 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// fakeRuns is a run registry carrying sessions, standing in for
+// internal/daemon/runsreg — which this package must not import.
+type fakeRuns struct {
+	live []sessions.Live
+}
+
+func (f *fakeRuns) Run(p state.Port) (state.Run, bool) {
+	for _, l := range f.live {
+		if l.PID == p.PID {
+			return state.Run{ID: l.RunID, Group: l.Group, Name: l.Name, RootPID: l.PID}, true
+		}
+	}
+	return state.Run{}, false
+}
+
+func (f *fakeRuns) Prune() {}
+
+func (f *fakeRuns) Session(p state.Port) (state.Session, bool) {
+	for _, l := range f.live {
+		if l.PID == p.PID {
+			return l.Session, true
+		}
+	}
+	return state.Session{}, false
+}
+
+func (f *fakeRuns) SessionRuns() []sessions.Live { return f.live }
+
+func testSession(id string) state.Session {
+	return state.Session{
+		ID: id, Tool: sessions.ToolClaudeCode, Label: "ship it",
+		Worktree: "feature-x", Branch: "feature/x", Detected: true,
+	}
+}
+
+// sessionHarness is a daemon whose fake scan shows one listener owned by one
+// agent session, with the run registry and the store both wired up.
+func sessionHarness(t *testing.T, ctx context.Context) (*testHarness, *fakeRuns) {
+	t.Helper()
+	h := newHarness(t, ctx)
+	runs := &fakeRuns{live: []sessions.Live{{
+		RunID: "run1", PID: 4242, Group: "shop", Name: "web",
+		Cmd: "python3 -m http.server", Cwd: "/home/me/code/shop",
+		StartedAt: time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC),
+		Session:   testSession("claude-code:abc"),
+	}}}
+	h.srv.runtime.SetRuns(runs)
+	h.setRows(ports.ListeningPort{
+		Port: 3000, BindAddress: "127.0.0.1", PID: 4242, Process: "python3",
+		Command: "python3 -m http.server", IPVersion: "IPv4",
+	})
+	h.loop.Invalidate()
+	if _, err := h.loop.Snapshot(scanner.Include{}); err != nil {
+		t.Fatalf("priming the snapshot: %v", err)
+	}
+	return h, runs
+}
+
+// openSessionStore gives a harness a temp database with the sessions table in
+// it. The directory is the caller's, claimed before the harness exists so the
+// store is closed before it is removed.
+func openSessionStore(t *testing.T, h *testHarness, dir string) {
+	t.Helper()
+	h.withStore(filepath.Join(dir, "sonar.db"))
+}
+
+func TestSessionsListReportsRunsPortsAndActivity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	c := h.dial(ctx)
+
+	var out rpc.SessionsListResult
+	if e := c.call("sessions.list", rpc.SessionsListParams{}, &out); e != nil {
+		t.Fatalf("sessions.list: %v", e)
+	}
+	if len(out.Sessions) != 1 {
+		t.Fatalf("sessions = %+v, want one", out.Sessions)
+	}
+	got := out.Sessions[0]
+	if got.ID != "claude-code:abc" || got.Tool != sessions.ToolClaudeCode {
+		t.Errorf("identity = %+v", got.Session)
+	}
+	if got.Worktree != "feature-x" || got.Branch != "feature/x" || !got.Detected {
+		t.Errorf("git context did not survive the wire: %+v", got.Session)
+	}
+	if got.Runs != 1 || got.Ports != 1 || !got.Active {
+		t.Errorf("counts = runs %d, ports %d, active %v", got.Runs, got.Ports, got.Active)
+	}
+}
+
+func TestSessionsListActiveOnlyHidesFinishedSessions(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	openSessionStore(t, h, dir)
+
+	// A session recorded but with nothing running.
+	if err := h.srv.runtime.Store.Sessions().Upsert(store.SessionRow{
+		ID: "codex:done", Tool: sessions.ToolCodex,
+		FirstSeen: time.Now().Add(-time.Hour), LastSeen: time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("recording a finished session: %v", err)
+	}
+
+	c := h.dial(ctx)
+	var all rpc.SessionsListResult
+	if e := c.call("sessions.list", rpc.SessionsListParams{}, &all); e != nil {
+		t.Fatalf("sessions.list: %v", e)
+	}
+	if len(all.Sessions) != 2 {
+		t.Fatalf("sessions.list = %+v, want both", all.Sessions)
+	}
+
+	var active rpc.SessionsListResult
+	if e := c.call("sessions.list", rpc.SessionsListParams{ActiveOnly: true}, &active); e != nil {
+		t.Fatalf("sessions.list active_only: %v", e)
+	}
+	if len(active.Sessions) != 1 || active.Sessions[0].ID != "claude-code:abc" {
+		t.Errorf("active_only = %+v", active.Sessions)
+	}
+}
+
+func TestSessionsInspectListsRunsAndPorts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	c := h.dial(ctx)
+
+	var out rpc.SessionsInspectResult
+	if e := c.call("sessions.inspect", rpc.SessionsInspectParams{ID: "claude-code:abc"}, &out); e != nil {
+		t.Fatalf("sessions.inspect: %v", e)
+	}
+	if out.Session.ID != "claude-code:abc" {
+		t.Errorf("session = %+v", out.Session)
+	}
+	if len(out.Runs) != 1 || out.Runs[0].ID != "run1" || out.Runs[0].PID != 4242 {
+		t.Fatalf("runs = %+v", out.Runs)
+	}
+	if len(out.Runs[0].Ports) != 1 || out.Runs[0].Ports[0] != 3000 {
+		t.Errorf("run ports = %+v", out.Runs[0].Ports)
+	}
+	if len(out.Ports) != 1 || out.Ports[0].Port != 3000 {
+		t.Fatalf("ports = %+v", out.Ports)
+	}
+	if out.Ports[0].Session == nil || out.Ports[0].Session.ID != "claude-code:abc" {
+		t.Errorf("the port came back without its session: %+v", out.Ports[0].Session)
+	}
+}
+
+// A prefix is enough, because the ids are long and people type them.
+func TestSessionsInspectAcceptsAUniquePrefix(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	c := h.dial(ctx)
+
+	var out rpc.SessionsInspectResult
+	if e := c.call("sessions.inspect", rpc.SessionsInspectParams{ID: "claude-code:a"}, &out); e != nil {
+		t.Fatalf("sessions.inspect by prefix: %v", e)
+	}
+	if out.Session.ID != "claude-code:abc" {
+		t.Errorf("session = %q", out.Session.ID)
+	}
+}
+
+func TestSessionsInspectUnknownIDIsSessionNotFound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	c := h.dial(ctx)
+
+	e := c.call("sessions.inspect", rpc.SessionsInspectParams{ID: "nope"}, nil)
+	if e == nil {
+		t.Fatal("want an error for an unknown session")
+	}
+	if e.Code != rpc.CodeSessionNotFound {
+		t.Errorf("code = %d, want %d (session_not_found)", e.Code, rpc.CodeSessionNotFound)
+	}
+}
+
+func TestSessionsKillRequiresAnID(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	c := h.dial(ctx)
+
+	if e := c.call("sessions.kill", rpc.SessionsKillParams{}, nil); e == nil {
+		t.Fatal("want invalid_params for a missing id")
+	}
+}
+
+// A dry run reports the plan and changes nothing, in the same envelope
+// groups.kill returns (contract §3).
+func TestSessionsKillDryRunReturnsTheKillEnvelope(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	c := h.dial(ctx)
+
+	var env rpc.KillEnvelope
+	if e := c.call("sessions.kill", rpc.SessionsKillParams{ID: "claude-code:abc", DryRun: true}, &env); e != nil {
+		t.Fatalf("sessions.kill --dry-run: %v", e)
+	}
+	if len(env.Results) != 1 {
+		t.Fatalf("results = %+v, want the session's one port", env.Results)
+	}
+	if env.Results[0].Port != 3000 {
+		t.Errorf("planned target = %+v", env.Results[0])
+	}
+	if env.Affected == nil {
+		t.Error("affected is null; contract §3 wants an array")
+	}
+}
+
+func TestSessionTargetsCoversPortsThenPidlessRuns(t *testing.T) {
+	s := testSession("s1")
+	snap := state.Snapshot{Ports: []state.Port{
+		{Port: 3000, BindAddress: "127.0.0.1", PID: 100, Session: &s,
+			Run: &state.Run{ID: "run1", RootPID: 100}},
+		{Port: 5432, BindAddress: "127.0.0.1", PID: 999},
+	}}
+	live := []sessions.Live{
+		{RunID: "run1", PID: 100, Session: s},
+		{RunID: "run2", PID: 200, Session: s}, // started, nothing listening yet
+	}
+
+	got := sessionTargets(snap, live, "s1")
+	if len(got) != 2 {
+		t.Fatalf("targets = %+v, want the port and the silent run", got)
+	}
+	if got[0] != (killer.Target{Port: 3000, BindAddress: "127.0.0.1"}) {
+		t.Errorf("first target = %+v", got[0])
+	}
+	if got[1] != (killer.Target{PID: 200}) {
+		t.Errorf("second target = %+v, want the pid of the run with no port", got[1])
+	}
+}
+
+func TestSweepSessionsTouchesLiveAndPrunesOld(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := sessionHarness(t, ctx)
+	openSessionStore(t, h, dir)
+
+	table := h.srv.runtime.Store.Sessions()
+	now := time.Date(2026, 9, 20, 12, 0, 0, 0, time.UTC)
+	long := now.Add(-30 * 24 * time.Hour)
+
+	// The live session, recorded long ago, and a stale one nothing runs.
+	if err := table.Upsert(store.SessionRow{ID: "claude-code:abc", FirstSeen: long, LastSeen: long}); err != nil {
+		t.Fatal(err)
+	}
+	if err := table.Upsert(store.SessionRow{ID: "codex:gone", FirstSeen: long, LastSeen: long}); err != nil {
+		t.Fatal(err)
+	}
+
+	SweepSessions(h.srv.runtime, now)
+
+	rows, err := table.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != "claude-code:abc" {
+		t.Fatalf("after the sweep: %+v", rows)
+	}
+	if !rows[0].LastSeen.Equal(now.UTC()) {
+		t.Errorf("the live session was not touched: %v", rows[0].LastSeen)
+	}
+}
+
+func TestSessionsCapabilityIsAnnounced(t *testing.T) {
+	for _, c := range Capabilities() {
+		if c == "sessions" {
+			return
+		}
+	}
+	t.Errorf("daemon.hello capabilities = %v, want sessions", Capabilities())
+}

--- a/internal/daemon/ports.go
+++ b/internal/daemon/ports.go
@@ -110,6 +110,9 @@ func handlePortsList(_ context.Context, req *Request) (any, error) {
 		if p.Group != nil && *p.Group != "" && !inGroup(row, *p.Group) {
 			continue
 		}
+		if p.Session != nil && *p.Session != "" && !inSession(row, *p.Session) {
+			continue
+		}
 		out = append(out, filterPort(row, include))
 	}
 	return rpc.PortsListResult{Ports: out}, nil
@@ -125,6 +128,16 @@ func inGroup(p state.Port, group string) bool {
 		return true
 	}
 	return false
+}
+
+// inSession matches a port against a session id, accepting the same unique
+// prefix `sonar sessions <id>` accepts so the two commands take the same
+// argument.
+func inSession(p state.Port, id string) bool {
+	if p.Session == nil {
+		return false
+	}
+	return p.Session.ID == id || strings.HasPrefix(p.Session.ID, id)
 }
 
 // normalizeIPVersion accepts both the wire's "IPv4"/"IPv6" and the shorthand

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -108,6 +108,10 @@ type PortsListParams struct {
 	All       bool    `json:"all,omitempty"`
 	IPVersion *string `json:"ip_version,omitempty"`
 	Include   Include `json:"include,omitempty"`
+	// Session keeps only the ports an agent session started (spec 2 §3). It
+	// is a daemon-side filter because a session lives in the daemon, not in
+	// the scan.
+	Session *string `json:"session,omitempty"`
 }
 
 type PortsListResult struct {
@@ -377,6 +381,10 @@ type RunsRegisterParams struct {
 	PortHint  *int    `json:"port_hint,omitempty"`
 	StartedAt string  `json:"started_at"`
 	ID        *string `json:"id,omitempty"`
+	// Session is the agent session that asked for this run (spec 2 §3). The
+	// caller detects it: `sonar start` reads its own environment, which is the
+	// agent's, while the daemon's is not.
+	Session *state.Session `json:"session,omitempty"`
 	// AllowOutsideHome opts out of the daemon's refusal to record a run whose
 	// cwd is outside the user's home (daemon spec, "Transport details"). The
 	// CLI sets it; the MCP server does not.
@@ -418,7 +426,7 @@ type RunsSpawnParams struct {
 	Group            *string           `json:"group,omitempty"`
 	Name             *string           `json:"name,omitempty"`
 	PortHint         *int              `json:"port_hint,omitempty"`
-	Session          *string           `json:"session,omitempty"`
+	Session          *state.Session    `json:"session,omitempty"`
 	AllowOutsideHome bool              `json:"allow_outside_home,omitempty"`
 }
 

--- a/internal/daemon/runsreg/handlers.go
+++ b/internal/daemon/runsreg/handlers.go
@@ -11,8 +11,10 @@ import (
 	"github.com/raskrebs/sonar/internal/daemon"
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/sessions"
 	"github.com/raskrebs/sonar/internal/spawn"
 	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/store"
 )
 
 // Default is the registry this daemon serves. One daemon, one registry: the
@@ -105,8 +107,12 @@ func handleRegister(_ context.Context, req *daemon.Request) (any, error) {
 	if t, err := time.Parse(time.RFC3339, p.StartedAt); err == nil {
 		rec.StartedAt = t
 	}
+	if p.Session != nil && p.Session.ID != "" {
+		rec.Session = *p.Session
+	}
 
 	rec = Default.Register(rec)
+	rememberSession(req.Runtime, rec.Session)
 	req.Runtime.Logger.Debug("run registered",
 		"id", rec.ID, "pid", rec.PID, "group", rec.Group, "name", rec.Name)
 	// The next scan should see the new run's ports, not wait out the backoff.
@@ -159,6 +165,20 @@ func handleSpawn(ctx context.Context, req *daemon.Request) (any, error) {
 		hint = *p.PortHint
 	}
 
+	// The daemon's own environment says nothing about the agent that called
+	// it, so a session has to be sent: `runs.spawn {session}` when the caller
+	// captured one, otherwise whatever the request's own env carries.
+	session := state.Session{}
+	if p.Session != nil {
+		session = *p.Session
+	}
+	if session.ID == "" {
+		if s, ok := sessions.DetectFromEnv(envSlice(p.Env), sessions.Options{}); ok {
+			s.Worktree, s.Branch = sessions.GitContext(cwd)
+			session = s
+		}
+	}
+
 	h, err := Spawn(ctx, req.Runtime, spawn.Request{
 		Argv:     p.Argv,
 		Cwd:      cwd,
@@ -166,6 +186,7 @@ func handleSpawn(ctx context.Context, req *daemon.Request) (any, error) {
 		Group:    res.Group,
 		Name:     res.Name,
 		PortHint: hint,
+		Session:  session,
 		Detach:   true,
 	})
 	if err != nil {
@@ -207,7 +228,9 @@ func Spawn(ctx context.Context, rt *daemon.Runtime, req spawn.Request) (*spawn.H
 		Cwd:       h.Cwd,
 		PortHint:  h.PortHint,
 		StartedAt: h.StartedAt,
+		Session:   h.Session,
 	})
+	rememberSession(rt, h.Session)
 	rt.Logger.Info("spawned a run",
 		"id", h.ID, "pid", h.PID, "group", h.Group, "name", h.Name, "log", h.LogPath)
 	rt.Scanner.Wake()
@@ -221,6 +244,33 @@ func Spawn(ctx context.Context, rt *daemon.Runtime, req spawn.Request) (*spawn.H
 		rt.Scanner.Wake()
 	}(rt, h)
 	return h, nil
+}
+
+// rememberSession writes a session through to the store the moment a run
+// carries one, so an agent's session survives a daemon restart and stays
+// readable for the seven days after its last run exits.
+func rememberSession(rt *daemon.Runtime, s state.Session) {
+	if s.ID == "" || rt == nil || rt.Store == nil {
+		return
+	}
+	now := time.Now()
+	err := rt.Store.Sessions().Upsert(store.SessionRow{
+		ID: s.ID, Tool: s.Tool, Label: s.Label,
+		Worktree: s.Worktree, Branch: s.Branch, Detected: s.Detected,
+		FirstSeen: now, LastSeen: now,
+	})
+	if err != nil {
+		rt.Logger.Warn("recording an agent session", "session", s.ID, "error", err)
+	}
+}
+
+// envSlice renders a wire env map as the KEY=VALUE slice detection reads.
+func envSlice(env map[string]string) []string {
+	out := make([]string, 0, len(env))
+	for k, v := range env {
+		out = append(out, k+"="+v)
+	}
+	return out
 }
 
 // CheckCwd cleans a working directory and enforces the home-directory rule.

--- a/internal/daemon/runsreg/registry.go
+++ b/internal/daemon/runsreg/registry.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/runs"
+	"github.com/raskrebs/sonar/internal/sessions"
 	"github.com/raskrebs/sonar/internal/state"
 )
 
@@ -38,6 +39,10 @@ type Record struct {
 	Cwd       string
 	PortHint  int
 	StartedAt time.Time
+	// Session is the agent session that asked for this run, or the zero value
+	// when nothing did (spec 2 §3). It travels with the run so every port the
+	// run opens can be stamped with it.
+	Session state.Session
 }
 
 // Registry holds the live runs. The zero value is not usable; call New.
@@ -168,6 +173,42 @@ func (r *Registry) Run(p state.Port) (state.Run, bool) {
 		return *p.Run, true
 	}
 	return state.Run{}, false
+}
+
+// Session implements groups.SessionRegistry: it reports the agent session that
+// started the run owning this port, using the same PPID walk the run
+// attribution uses, so a port and its run can never disagree about who started
+// them.
+func (r *Registry) Session(p state.Port) (state.Session, bool) {
+	rec, found := r.ancestor(p.PID, p.PPID)
+	if !found || rec.Session.ID == "" {
+		return state.Session{}, false
+	}
+	return rec.Session, true
+}
+
+// SessionRuns lists every live run that carries a session. The daemon's
+// sessions handlers read it through an interface assertion on the installed
+// run registry, which is how package daemon reaches this data without
+// importing the package that registers itself into it.
+func (r *Registry) SessionRuns() []sessions.Live {
+	out := []sessions.Live{}
+	for _, rec := range r.List() {
+		if rec.Session.ID == "" {
+			continue
+		}
+		out = append(out, sessions.Live{
+			RunID:     rec.ID,
+			PID:       rec.PID,
+			Group:     rec.Group,
+			Name:      rec.Name,
+			Cmd:       rec.Cmd,
+			Cwd:       rec.Cwd,
+			StartedAt: rec.StartedAt,
+			Session:   rec.Session,
+		})
+	}
+	return out
 }
 
 // ancestor walks up from pid looking for a registered run. hintPPID is the

--- a/internal/daemon/runsreg/session_test.go
+++ b/internal/daemon/runsreg/session_test.go
@@ -1,0 +1,90 @@
+package runsreg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+func agentSession() state.Session {
+	return state.Session{
+		ID: "claude-code:abc", Tool: sessions.ToolClaudeCode,
+		Label: "ship 2A.4", Worktree: "feature-x", Branch: "feature/x", Detected: true,
+	}
+}
+
+// A session registered with a run comes back on the run, on the ports the run
+// owns, and in the list the daemon's sessions handlers read.
+func TestSessionRoundTrip(t *testing.T) {
+	r := testRegistry(100)
+	started := time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC)
+	r.Register(Record{
+		ID: "run1", PID: 100, Group: "web", Name: "dev", Cmd: "npm run dev",
+		Cwd: "/home/me/code/shop", StartedAt: started, Session: agentSession(),
+	})
+
+	rec, ok := r.Lookup(100)
+	if !ok || rec.Session.ID != "claude-code:abc" {
+		t.Fatalf("Lookup = %+v, %v", rec, ok)
+	}
+
+	got, ok := r.Session(state.Port{PID: 100})
+	if !ok {
+		t.Fatal("Session did not attribute the run's own pid")
+	}
+	if got != agentSession() {
+		t.Errorf("Session = %+v, want %+v", got, agentSession())
+	}
+
+	live := r.SessionRuns()
+	if len(live) != 1 {
+		t.Fatalf("SessionRuns = %+v, want one entry", live)
+	}
+	want := sessions.Live{
+		RunID: "run1", PID: 100, Group: "web", Name: "dev", Cmd: "npm run dev",
+		Cwd: "/home/me/code/shop", StartedAt: started, Session: agentSession(),
+	}
+	if live[0] != want {
+		t.Errorf("SessionRuns[0] = %+v, want %+v", live[0], want)
+	}
+}
+
+// A child of the run inherits its session, through the same PPID walk that
+// decides the run itself: `npm run dev` -> vite -> esbuild is one session.
+func TestSessionFollowsThePPIDWalk(t *testing.T) {
+	r := testRegistry(100)
+	r.Parents = func() map[int]int { return map[int]int{300: 200, 200: 100, 100: 1} }
+	r.Register(Record{ID: "run1", PID: 100, Group: "web", Name: "dev", Session: agentSession()})
+
+	if got, ok := r.Session(state.Port{PID: 300, PPID: 200}); !ok || got.ID != "claude-code:abc" {
+		t.Errorf("a grandchild's port got session %+v, %v", got, ok)
+	}
+}
+
+// A run nobody attributed to a session has none, and neither do its ports:
+// a plain shell must not invent a session for every dev server on the machine.
+func TestRunsWithoutASessionReportNone(t *testing.T) {
+	r := testRegistry(100)
+	r.Register(Record{ID: "run1", PID: 100, Group: "web", Name: "dev"})
+
+	if _, ok := r.Session(state.Port{PID: 100}); ok {
+		t.Error("a run with no session reported one")
+	}
+	if live := r.SessionRuns(); len(live) != 0 {
+		t.Errorf("SessionRuns = %+v, want empty", live)
+	}
+	if r.SessionRuns() == nil {
+		t.Error("SessionRuns returned nil rather than an empty slice")
+	}
+}
+
+// A dead run leaves the session list with it, so "active" means what it says.
+func TestSessionRunsDropsDeadRuns(t *testing.T) {
+	r := testRegistry()
+	r.Register(Record{ID: "run1", PID: 100, Session: agentSession()})
+	if live := r.SessionRuns(); len(live) != 0 {
+		t.Errorf("SessionRuns kept a dead run: %+v", live)
+	}
+}

--- a/internal/daemon/sessions_integration_test.go
+++ b/internal/daemon/sessions_integration_test.go
@@ -1,0 +1,257 @@
+//go:build integration
+
+// Integration coverage for slice 2A.4: a real `sonar start` under an agent's
+// environment, a real listener, and the sessions namespace answering about it.
+// Run with `go test -tags integration ./internal/daemon/...`.
+package daemon_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// TestSessionAttributionEndToEnd is the step's acceptance demo in one test: a
+// listener started under CLAUDE_CODE_SESSION_ID is attributed to that session,
+// `sessions.list` shows it with its worktree and branch, `ports.list
+// {session}` narrows to its ports, and `sessions.kill` stops it and leaves the
+// session inactive.
+func TestSessionAttributionEndToEnd(t *testing.T) {
+	listener, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newEnv(t)
+	repo := gitCheckout(t, e.home, "shop", "feature/x")
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	sub, err := c.Subscribe(ctx, client.SubscribeOptions{Events: true})
+	if err != nil {
+		t.Fatalf("state.subscribe: %v", err)
+	}
+
+	const sessionID = "itest-session-1"
+	port := freePort(t)
+	start := e.command("start", "--group", "itest", "--name", "web",
+		"--port", strconv.Itoa(port), "--", listener, strconv.Itoa(port))
+	start.Dir = repo
+	start.Env = append(start.Env,
+		"CLAUDE_CODE_SESSION_ID="+sessionID,
+		"SONAR_SESSION_LABEL=acceptance demo")
+	var out safeBuffer
+	start.Stdout, start.Stderr = &out, &out
+	ownProcessGroup(start)
+	if err := start.Start(); err != nil {
+		t.Fatalf("sonar start: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCommand(start)
+		if t.Failed() {
+			t.Logf("sonar start output:\n%s", out.String())
+		}
+	})
+
+	added, ok := waitForAttributedPort(t, sub, port, 60*time.Second)
+	if !ok {
+		t.Fatalf("no delta carried port %d with its run within 60s\n%s", port, out.String())
+	}
+	if added.Session == nil {
+		t.Fatalf("port %d was published with no session\n%s", port, out.String())
+	}
+	if added.Session.ID != sessionID {
+		t.Errorf("session id = %q, want %q", added.Session.ID, sessionID)
+	}
+	if added.Session.Tool != sessions.ToolClaudeCode {
+		t.Errorf("tool = %q, want %s", added.Session.Tool, sessions.ToolClaudeCode)
+	}
+	if !added.Session.Detected {
+		t.Error("a session recognised from CLAUDE_CODE_SESSION_ID must be marked detected")
+	}
+	if added.Session.Branch != "feature/x" {
+		t.Errorf("branch = %q, want feature/x", added.Session.Branch)
+	}
+	if added.Session.Label != "acceptance demo" {
+		t.Errorf("label = %q", added.Session.Label)
+	}
+
+	// sessions.list sees it, with the run and the port counted.
+	var list rpc.SessionsListResult
+	if err := c.Call(ctx, "sessions.list", rpc.SessionsListParams{ActiveOnly: true}, &list); err != nil {
+		t.Fatalf("sessions.list: %v", err)
+	}
+	rec, found := findRecord(list.Sessions, sessionID)
+	if !found {
+		t.Fatalf("sessions.list did not carry %s: %+v", sessionID, list.Sessions)
+	}
+	if rec.Runs < 1 || rec.Ports < 1 || !rec.Active {
+		t.Errorf("record = %+v, want an active session with a run and a port", rec)
+	}
+	if rec.Branch != "feature/x" {
+		t.Errorf("record branch = %q", rec.Branch)
+	}
+
+	// sessions.inspect lists the run and the port.
+	var inspect rpc.SessionsInspectResult
+	if err := c.Call(ctx, "sessions.inspect", rpc.SessionsInspectParams{ID: sessionID}, &inspect); err != nil {
+		t.Fatalf("sessions.inspect: %v", err)
+	}
+	if len(inspect.Runs) != 1 || len(inspect.Ports) != 1 || inspect.Ports[0].Port != port {
+		t.Errorf("inspect = %d runs, %d ports", len(inspect.Runs), len(inspect.Ports))
+	}
+
+	// ports.list narrows to the session, and rejects an unknown one by
+	// returning nothing rather than everything.
+	var scoped rpc.PortsListResult
+	id := sessionID
+	if err := c.Call(ctx, "ports.list", rpc.PortsListParams{All: true, Session: &id}, &scoped); err != nil {
+		t.Fatalf("ports.list --session: %v", err)
+	}
+	if len(scoped.Ports) != 1 || scoped.Ports[0].Port != port {
+		t.Errorf("ports.list --session = %+v, want only port %d", scoped.Ports, port)
+	}
+	other := "nobody"
+	if err := c.Call(ctx, "ports.list", rpc.PortsListParams{All: true, Session: &other}, &scoped); err != nil {
+		t.Fatalf("ports.list --session nobody: %v", err)
+	}
+	if len(scoped.Ports) != 0 {
+		t.Errorf("an unknown session matched %d ports", len(scoped.Ports))
+	}
+
+	// sessions.kill stops everything the session started.
+	var env rpc.KillEnvelope
+	if err := c.Call(ctx, "sessions.kill", rpc.SessionsKillParams{ID: sessionID}, &env); err != nil {
+		t.Fatalf("sessions.kill: %v", err)
+	}
+	if !env.OK || len(env.Results) == 0 {
+		t.Fatalf("sessions.kill envelope = %+v", env)
+	}
+	if !waitForRemoved(t, sub, port, 45*time.Second) {
+		t.Fatalf("port %d never went away after sessions.kill", port)
+	}
+
+	// And the session goes inactive: it is still known, with nothing running.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		var after rpc.SessionsListResult
+		if err := c.Call(ctx, "sessions.list", rpc.SessionsListParams{}, &after); err != nil {
+			t.Fatalf("sessions.list after the kill: %v", err)
+		}
+		rec, found := findRecord(after.Sessions, sessionID)
+		if found && !rec.Active && rec.Runs == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("session %s never went inactive: %+v", sessionID, after.Sessions)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// active_only now hides it.
+	var active rpc.SessionsListResult
+	if err := c.Call(ctx, "sessions.list", rpc.SessionsListParams{ActiveOnly: true}, &active); err != nil {
+		t.Fatalf("sessions.list active_only: %v", err)
+	}
+	if _, found := findRecord(active.Sessions, sessionID); found {
+		t.Errorf("active_only still lists the finished session: %+v", active.Sessions)
+	}
+}
+
+// TestStartWithoutAnAgentHasNoSession is the other half of the contract: a
+// plain shell must not manufacture a session for every dev server.
+func TestStartWithoutAnAgentHasNoSession(t *testing.T) {
+	listener, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	sub, err := c.Subscribe(ctx, client.SubscribeOptions{Events: true})
+	if err != nil {
+		t.Fatalf("state.subscribe: %v", err)
+	}
+
+	port := freePort(t)
+	start := e.command("start", "--group", "plain", "--name", "web",
+		"--port", strconv.Itoa(port), "--", listener, strconv.Itoa(port))
+	start.Dir = e.home
+	start.Env = append(start.Env, "CLAUDECODE=", "CLAUDE_CODE_SESSION_ID=",
+		"CLAUDE_SESSION_ID=", "CODEX_THREAD_ID=", "CODEX_SANDBOX=",
+		"CURSOR_AGENT=", "SONAR_SESSION=", "SONAR_SESSION_ID=")
+	var out safeBuffer
+	start.Stdout, start.Stderr = &out, &out
+	ownProcessGroup(start)
+	if err := start.Start(); err != nil {
+		t.Fatalf("sonar start: %v", err)
+	}
+	t.Cleanup(func() { stopCommand(start) })
+
+	added, ok := waitForAttributedPort(t, sub, port, 45*time.Second)
+	if !ok {
+		t.Fatalf("no delta carried port %d\n%s", port, out.String())
+	}
+	if added.Session != nil {
+		t.Errorf("a shell-started run got session %+v", *added.Session)
+	}
+
+	var list rpc.SessionsListResult
+	if err := c.Call(ctx, "sessions.list", rpc.SessionsListParams{}, &list); err != nil {
+		t.Fatalf("sessions.list: %v", err)
+	}
+	if len(list.Sessions) != 0 {
+		t.Errorf("sessions.list = %+v, want none", list.Sessions)
+	}
+}
+
+func findRecord(recs []state.SessionRecord, id string) (state.SessionRecord, bool) {
+	for _, r := range recs {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return state.SessionRecord{}, false
+}
+
+// gitCheckout makes a real repository under home with one commit on branch,
+// because the session's branch is read from .git.
+func gitCheckout(t *testing.T, home, name, branch string) string {
+	t.Helper()
+	dir := filepath.Join(home, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(cmd.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git %v: %v\n%s", args, err, strings.TrimSpace(string(out)))
+		}
+	}
+	run("init", "-q", "-b", branch, ".")
+	run("commit", "-q", "--allow-empty", "-m", "first")
+	return dir
+}

--- a/internal/groups/attribute.go
+++ b/internal/groups/attribute.go
@@ -58,6 +58,7 @@ func AttributeWith(pp []ports.ListeningPort, pins Pins, runs Registry, index *In
 	stampRuns(pp, runs)
 
 	resolved := Resolve(state.FromListeningAll(pp), pins, runs, index)
+	stampSessions(resolved, runs)
 	for i := range resolved {
 		pp[i].ProjectRoot = deref(resolved[i].ProjectRoot)
 		pp[i].Group = deref(resolved[i].Group)
@@ -74,6 +75,27 @@ func deref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// stampSessions puts the agent session of the owning run onto every port it
+// owns, from the same registry and the same ancestry walk that decided the
+// run. It runs after Resolve because it stamps the contract rows, not the
+// scanner rows: `session` is a daemon concept with no place in `runs.json`, so
+// the direct-scan path has nothing to stamp and this is a no-op there.
+func stampSessions(resolved []state.Port, runs Registry) {
+	reg, ok := runs.(SessionRegistry)
+	if !ok {
+		return
+	}
+	for i := range resolved {
+		if resolved[i].PID <= 0 {
+			continue
+		}
+		if s, found := reg.Session(resolved[i]); found && s.ID != "" {
+			session := s
+			resolved[i].Session = &session
+		}
+	}
 }
 
 // stampRuns writes the registry's run attribution onto the scan rows before

--- a/internal/groups/attribute_session_test.go
+++ b/internal/groups/attribute_session_test.go
@@ -1,0 +1,78 @@
+package groups
+
+import (
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// sessionRunSet is a Registry that also implements SessionRegistry, which is
+// what the daemon's run registry looks like once a run carries a session.
+type sessionRunSet struct {
+	runSet
+	session state.Session
+}
+
+func (s sessionRunSet) Session(p state.Port) (state.Session, bool) {
+	if p.Port != s.port {
+		return state.Session{}, false
+	}
+	return s.session, true
+}
+
+func TestAttributeWithStampsTheSession(t *testing.T) {
+	want := state.Session{
+		ID: "claude-code:abc", Tool: "claude-code",
+		Worktree: "feature-x", Branch: "feature/x", Detected: true,
+	}
+	pp := []ports.ListeningPort{
+		{Port: 3000, PID: 11, Process: "node", Command: "node server.js"},
+		{Port: 4000, PID: 12, Process: "python3", Command: "python3 -m http.server"},
+	}
+
+	resolved, _ := AttributeWith(pp, NoPins{},
+		sessionRunSet{runSet: runSet{port: 4000, id: "r1", group: "itest", name: "web"}, session: want},
+		nil)
+
+	byPort := map[int]state.Port{}
+	for _, p := range resolved {
+		byPort[p.Port] = p
+	}
+
+	got := byPort[4000].Session
+	if got == nil {
+		t.Fatal("the run's port was published with no session")
+	}
+	if *got != want {
+		t.Errorf("session = %+v, want %+v", *got, want)
+	}
+	if byPort[4000].Run == nil || byPort[4000].Run.ID != "r1" {
+		t.Errorf("the session was stamped but the run was not: %+v", byPort[4000].Run)
+	}
+	if byPort[3000].Session != nil {
+		t.Errorf("an unattributed port got session %+v", byPort[3000].Session)
+	}
+}
+
+// A registry that knows nothing about sessions publishes null sessions, which
+// is the direct-scan path: runs.json has no session column.
+func TestAttributeWithoutASessionRegistryLeavesSessionsNull(t *testing.T) {
+	pp := []ports.ListeningPort{{Port: 4000, PID: 12, Process: "python3"}}
+	resolved, _ := AttributeWith(pp, NoPins{},
+		runSet{port: 4000, id: "r1", group: "itest", name: "web"}, nil)
+	if resolved[0].Session != nil {
+		t.Errorf("session = %+v, want nil", resolved[0].Session)
+	}
+}
+
+// An empty session id is not a session: a registry that answers ok with a zero
+// value must not put an empty badge on the row.
+func TestAttributeWithIgnoresAnEmptySessionID(t *testing.T) {
+	pp := []ports.ListeningPort{{Port: 4000, PID: 12, Process: "python3"}}
+	resolved, _ := AttributeWith(pp, NoPins{},
+		sessionRunSet{runSet: runSet{port: 4000, id: "r1", group: "g", name: "n"}}, nil)
+	if resolved[0].Session != nil {
+		t.Errorf("session = %+v, want nil", resolved[0].Session)
+	}
+}

--- a/internal/groups/resolve.go
+++ b/internal/groups/resolve.go
@@ -31,6 +31,14 @@ type Registry interface {
 	Run(p state.Port) (run state.Run, ok bool)
 }
 
+// SessionRegistry is the optional half of Registry: a registry that also knows
+// which agent session started a run reports it here, and AttributeWith stamps
+// it onto the port (spec 2 §3, contract §5). A registry that does not
+// implement it simply publishes ports with a null session.
+type SessionRegistry interface {
+	Session(p state.Port) (session state.Session, ok bool)
+}
+
 // PortRuns reads the run attribution the scanner put on the port itself. It is
 // the direct-scan path: no daemon, so `runs.json` is the only registry there is.
 type PortRuns struct{}

--- a/internal/scanner/attribute.go
+++ b/internal/scanner/attribute.go
@@ -56,6 +56,32 @@ func (l *Loop) SetRuns(f func() groups.Registry) {
 	l.opts.Runs = f
 }
 
+// SetSessions installs the sessions-collection builder. Like SetRuns it is a
+// setter because the daemon extension that owns sessions registers itself
+// after the loop is already scanning.
+func (l *Loop) SetSessions(f func(ports []state.Port) []state.SessionRecord) {
+	if f == nil {
+		return
+	}
+	l.attr.mu.Lock()
+	defer l.attr.mu.Unlock()
+	l.opts.Sessions = f
+}
+
+// sessions builds the snapshot's sessions collection, never nil.
+func (l *Loop) sessions(rows []state.Port) []state.SessionRecord {
+	l.attr.mu.Lock()
+	build := l.opts.Sessions
+	l.attr.mu.Unlock()
+	if build == nil {
+		return []state.SessionRecord{}
+	}
+	if out := build(rows); out != nil {
+		return out
+	}
+	return []state.SessionRecord{}
+}
+
 // Invalidate drops the cached scan so the next read rescans instead of serving
 // state from before a write. `ports.rename` and `groups.assign` call it so the
 // caller sees its own change in the very next list.

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -66,6 +66,12 @@ type Options struct {
 	// built; nil, or a nil return, means groups.PortRuns{}.
 	Runs func() groups.Registry
 
+	// Sessions builds the snapshot's `sessions` collection from the ports the
+	// tick just resolved. It is a function for the same reason Runs is: the
+	// daemon installs it from an OnStart hook, after the loop exists. Nil
+	// publishes an empty collection.
+	Sessions func(ports []state.Port) []state.SessionRecord
+
 	// Scan overrides the OS scan. Tests inject a fake; production leaves it nil
 	// and gets ports.Scan + docker.EnrichPorts + ports.Enrich.
 	Scan func(include Include) ([]ports.ListeningPort, error)
@@ -279,6 +285,8 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	// is assembled: what gets published is already attributed and named.
 	rows, groupRows := l.attribute(pp)
 
+	sessionRows := l.sessions(rows)
+
 	// Configured health comes after attribution because it is the groups that
 	// say which port has a `health:` path. It runs on every tick regardless of
 	// `include`: a health path in a `.sonar.yaml` is part of what the service
@@ -308,11 +316,11 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 		DaemonVersion: l.opts.DaemonVersion,
 		Ports:         rows,
 		Groups:        groupRows,
-		// Tunnels, proxies and sessions belong to specs 2 and 3. Every
-		// collection is always an array, never null.
+		// Tunnels and proxies belong to spec 3. Every collection is always an
+		// array, never null.
 		Tunnels:  []state.Tunnel{},
 		Proxies:  []state.Proxy{},
-		Sessions: []state.SessionRecord{},
+		Sessions: sessionRows,
 	}
 
 	if l.haveSnap && !snapshotChanged(prev, next, include.Stats) {
@@ -368,7 +376,8 @@ func snapshotChanged(prev, next state.Snapshot, withStats bool) bool {
 		d = state.DiffWithStats(prev, next)
 	}
 	return len(d.Ports.Added) > 0 || len(d.Ports.Updated) > 0 || len(d.Ports.Removed) > 0 ||
-		len(d.Groups.Added) > 0 || len(d.Groups.Updated) > 0 || len(d.Groups.Removed) > 0
+		len(d.Groups.Added) > 0 || len(d.Groups.Updated) > 0 || len(d.Groups.Removed) > 0 ||
+		len(d.Sessions.Added) > 0 || len(d.Sessions.Updated) > 0 || len(d.Sessions.Removed) > 0
 }
 
 // carryHealth copies health results from the previous snapshot onto rows that

--- a/internal/scanner/sessions_test.go
+++ b/internal/scanner/sessions_test.go
@@ -1,0 +1,112 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// sessionRegistry is a run registry that also knows the agent session, the
+// shape internal/daemon/runsreg has once a run carries one.
+type sessionRegistry struct {
+	pid     int
+	session state.Session
+}
+
+func (r sessionRegistry) Run(p state.Port) (state.Run, bool) {
+	if p.PID != r.pid {
+		return state.Run{}, false
+	}
+	return state.Run{ID: "run1", Group: "shop", Name: "web", RootPID: r.pid}, true
+}
+
+func (r sessionRegistry) Session(p state.Port) (state.Session, bool) {
+	if p.PID != r.pid {
+		return state.Session{}, false
+	}
+	return r.session, true
+}
+
+// A scan tick stamps the session of the owning run onto the port and publishes
+// the sessions collection built from it.
+func TestScanStampsPortSessionAndPublishesTheCollection(t *testing.T) {
+	agent := state.Session{
+		ID: "claude-code:abc", Tool: sessions.ToolClaudeCode,
+		Worktree: "feature-x", Branch: "feature/x", Detected: true,
+	}
+	reg := sessionRegistry{pid: 11, session: agent}
+
+	l := New(Options{
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{
+				{Port: 3000, PID: 11, Process: "python3", Command: "python3 -m http.server"},
+				{Port: 5432, PID: 12, Process: "postgres"},
+			}, nil
+		},
+		Runs: func() groups.Registry { return reg },
+	})
+	l.SetSessions(func(rows []state.Port) []state.SessionRecord {
+		return sessions.Records(nil, []sessions.Live{{RunID: "run1", PID: 11, Group: "shop", Session: agent}}, rows)
+	})
+
+	snap, err := l.Snapshot(Include{})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	byPort := map[int]state.Port{}
+	for _, p := range snap.Ports {
+		byPort[p.Port] = p
+	}
+	got := byPort[3000].Session
+	if got == nil {
+		t.Fatal("the run's port was published with no session")
+	}
+	if *got != agent {
+		t.Errorf("port session = %+v, want %+v", *got, agent)
+	}
+	if byPort[5432].Session != nil {
+		t.Errorf("an unrelated port got session %+v", byPort[5432].Session)
+	}
+
+	if len(snap.Sessions) != 1 {
+		t.Fatalf("sessions collection = %+v, want one record", snap.Sessions)
+	}
+	rec := snap.Sessions[0]
+	if rec.ID != agent.ID || rec.Runs != 1 || rec.Ports != 1 || !rec.Active {
+		t.Errorf("session record = %+v", rec)
+	}
+}
+
+// Without a provider the collection is an empty array, never null: the wire
+// shape is fixed whether or not anything owns sessions in this build.
+func TestSnapshotSessionsAreNeverNull(t *testing.T) {
+	l := New(Options{Scan: func(Include) ([]ports.ListeningPort, error) { return nil, nil }})
+	snap, err := l.Snapshot(Include{})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.Sessions == nil {
+		t.Error("Snapshot.Sessions is nil")
+	}
+	if cached := l.Cached(); cached.Sessions == nil {
+		t.Error("Cached().Sessions is nil")
+	}
+}
+
+// A session appearing is a change worth publishing even when no port moved:
+// the desktop's session badge has to arrive without waiting for a port event.
+func TestSessionChangeAlonePublishes(t *testing.T) {
+	prev := state.Snapshot{Ports: []state.Port{}, Groups: []state.Group{}}
+	next := state.Snapshot{
+		Ports:    []state.Port{},
+		Groups:   []state.Group{},
+		Sessions: []state.SessionRecord{{Session: state.Session{ID: "s1"}, Active: true}},
+	}
+	if !snapshotChanged(prev, next, false) {
+		t.Error("a new session did not count as a change")
+	}
+}

--- a/internal/sessions/detect.go
+++ b/internal/sessions/detect.go
@@ -1,0 +1,288 @@
+// Package sessions attributes what sonar starts to the agent session that
+// asked for it: which coding agent, which checkout, which branch.
+//
+// The identity contract is spec 2 §3. `SONAR_SESSION` is the explicit form and
+// always wins — sonar never guesses when it is set. Everything else is
+// best-effort detection from the environment an agent leaves behind, marked
+// Detected so a client can say "probably Claude Code" rather than claiming it.
+//
+// Detection happens once, in the process that spawns the command (`sonar
+// start`, or the daemon serving `runs.spawn`); the session then travels with
+// the run and is stamped onto every port that run opens.
+package sessions
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// The environment variables that name a session (spec 2 §3, plus the two
+// SONAR_SESSION_ID / SONAR_SESSION_TOOL spellings recorded under Contract
+// notes for callers that have an id but no tool string to prefix it with).
+const (
+	EnvSession      = "SONAR_SESSION"       // "<tool>:<id>", the explicit contract
+	EnvSessionID    = "SONAR_SESSION_ID"    // an id on its own
+	EnvSessionTool  = "SONAR_SESSION_TOOL"  // the tool for EnvSessionID
+	EnvSessionLabel = "SONAR_SESSION_LABEL" // human label, any form
+
+	EnvClaudeCode           = "CLAUDECODE"
+	EnvClaudeCodeSessionID  = "CLAUDE_CODE_SESSION_ID"
+	EnvClaudeSessionID      = "CLAUDE_SESSION_ID"
+	EnvCodexSandbox         = "CODEX_SANDBOX"
+	EnvCodexThreadID        = "CODEX_THREAD_ID"
+	EnvCursorAgent          = "CURSOR_AGENT"
+	EnvCursorAgentSessionID = "CURSOR_AGENT_SESSION_ID"
+)
+
+// Tool names published in Session.tool. They are the stable strings clients
+// switch on to pick an icon, so they never change spelling.
+const (
+	ToolClaudeCode = "claude-code"
+	ToolCodex      = "codex"
+	ToolCursor     = "cursor"
+	// ToolAgent is what SONAR_SESSION_ID alone means: an agent that named
+	// itself an id but not a tool.
+	ToolAgent = "agent"
+)
+
+// Process is one row of the ancestry walk: enough to find the nearest ancestor
+// that is the agent itself, so a detected session keeps one id for the life of
+// that agent process rather than changing with every command it runs.
+type Process struct {
+	PID     int
+	PPID    int
+	Command string
+}
+
+// Options is what Detect reads. The zero value reads the real environment, the
+// real pid and the real process table; tests fill in the fields they need.
+type Options struct {
+	// Getenv looks a variable up. Nil means os.Getenv.
+	Getenv func(string) string
+	// PID is the process detection starts walking up from. Zero means os.Getpid.
+	PID int
+	// Processes lists the process table for the ancestor walk. Nil means the
+	// platform's own. A nil return falls back to the parent of PID.
+	Processes func() []Process
+}
+
+// maxAncestry bounds the ancestor walk against a cyclic process table.
+const maxAncestry = 64
+
+// Detect resolves the agent session that spawned this process.
+//
+// ok is false when nothing in the environment names an agent: a plain shell
+// starts a plain run, and inventing a session for it would attribute every dev
+// server on the machine to something. Detected on the returned session
+// distinguishes "the agent told us" (false) from "we recognised its
+// environment" (true).
+func Detect(opts Options) (state.Session, bool) {
+	get := opts.Getenv
+	if get == nil {
+		get = os.Getenv
+	}
+	label := strings.TrimSpace(get(EnvSessionLabel))
+
+	// 1. The explicit contract. `<tool>:<id>`; a value with no colon is an id
+	//    from a tool that did not say which it is.
+	if raw := strings.TrimSpace(get(EnvSession)); raw != "" {
+		tool, id, found := strings.Cut(raw, ":")
+		if !found || strings.TrimSpace(id) == "" {
+			tool, id = ToolAgent, raw
+		}
+		return session(strings.TrimSpace(tool), strings.TrimSpace(id), label, false), true
+	}
+
+	// 2. An id on its own, for a caller that has one but no tool prefix.
+	if id := strings.TrimSpace(get(EnvSessionID)); id != "" {
+		tool := strings.TrimSpace(get(EnvSessionTool))
+		if tool == "" {
+			tool = ToolAgent
+		}
+		return session(tool, id, label, false), true
+	}
+
+	// 3. Best-effort detection, in the order spec 2 §3 lists the markers.
+	for _, m := range markers {
+		id, hit := m.match(get)
+		if !hit {
+			continue
+		}
+		if id == "" {
+			id = ancestorID(opts, m.tool)
+		}
+		return session(m.tool, id, label, true), true
+	}
+	return state.Session{}, false
+}
+
+// DetectFromEnv is Detect over a `KEY=VALUE` slice, which is the shape an
+// environment arrives in over the wire (`runs.spawn {env}`) and the shape
+// exec.Cmd carries.
+func DetectFromEnv(env []string, opts Options) (state.Session, bool) {
+	table := map[string]string{}
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok {
+			table[k] = v
+		}
+	}
+	opts.Getenv = func(k string) string { return table[k] }
+	return Detect(opts)
+}
+
+// marker is one row of the detection matrix: the variables that say a tool is
+// present, and the variable that carries its own session id when it has one.
+type marker struct {
+	tool     string
+	present  []string
+	idFrom   []string
+	commands []string
+}
+
+// markers is spec 2 §3's table. Claude Code first: CLAUDECODE=1 is the marker
+// the agent itself exports, and CLAUDE_CODE_SESSION_ID is what the SessionStart
+// hook and the skill set (Contract notes).
+var markers = []marker{
+	{
+		tool:     ToolClaudeCode,
+		present:  []string{EnvClaudeCode, EnvClaudeCodeSessionID, EnvClaudeSessionID},
+		idFrom:   []string{EnvClaudeCodeSessionID, EnvClaudeSessionID},
+		commands: []string{"claude"},
+	},
+	{
+		tool:     ToolCodex,
+		present:  []string{EnvCodexThreadID, EnvCodexSandbox},
+		idFrom:   []string{EnvCodexThreadID},
+		commands: []string{"codex"},
+	},
+	{
+		tool:     ToolCursor,
+		present:  []string{EnvCursorAgent, EnvCursorAgentSessionID},
+		idFrom:   []string{EnvCursorAgentSessionID},
+		commands: []string{"cursor-agent", "cursor"},
+	},
+}
+
+// match reports whether this tool's environment is present and, when it is,
+// the id the tool named itself ("" when it named none).
+func (m marker) match(get func(string) string) (string, bool) {
+	hit := false
+	for _, key := range m.present {
+		if isSet(get(key)) {
+			hit = true
+			break
+		}
+	}
+	if !hit {
+		return "", false
+	}
+	for _, key := range m.idFrom {
+		if v := strings.TrimSpace(get(key)); v != "" {
+			return v, true
+		}
+	}
+	return "", true
+}
+
+// isSet treats the shell's own idea of "off" as unset: CLAUDECODE=0 in a
+// hand-written script means the agent is not there.
+func isSet(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
+// ancestorID is the fallback id for a tool that names none: the pid of the
+// nearest ancestor whose command is the agent, which is stable for the life of
+// that agent process — exactly the lifetime cleanup cares about.
+func ancestorID(opts Options, tool string) string {
+	pid := opts.PID
+	if pid == 0 {
+		pid = os.Getpid()
+	}
+	list := opts.Processes
+	if list == nil {
+		list = processTable
+	}
+
+	if procs := list(); len(procs) > 0 {
+		byPID := make(map[int]Process, len(procs))
+		for _, p := range procs {
+			byPID[p.PID] = p
+		}
+		names := commandsFor(tool)
+		cur := pid
+		for i := 0; i < maxAncestry; i++ {
+			p, ok := byPID[cur]
+			if !ok {
+				break
+			}
+			if matchesCommand(p.Command, names) {
+				return pidID(p.PID)
+			}
+			if p.PPID <= 1 || p.PPID == cur {
+				break
+			}
+			cur = p.PPID
+		}
+		// The agent's environment is here but the agent is not in our
+		// ancestry — a hook exported the variable into a shell the agent then
+		// detached from. The immediate parent still outlives this command,
+		// which exits in seconds, so it is the better id of the two.
+		if self, ok := byPID[pid]; ok && self.PPID > 1 {
+			return pidID(self.PPID)
+		}
+	}
+	if ppid := os.Getppid(); ppid > 1 {
+		return pidID(ppid)
+	}
+	return pidID(pid)
+}
+
+func commandsFor(tool string) []string {
+	for _, m := range markers {
+		if m.tool == tool {
+			return m.commands
+		}
+	}
+	return []string{tool}
+}
+
+// matchesCommand compares a process command against the agent's binary names,
+// tolerating a full path and a Windows .exe suffix.
+func matchesCommand(cmd string, names []string) bool {
+	base := strings.ToLower(strings.TrimSpace(cmd))
+	if base == "" {
+		return false
+	}
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.TrimSuffix(base, ".exe")
+	for _, n := range names {
+		if base == n {
+			return true
+		}
+	}
+	return false
+}
+
+func pidID(pid int) string { return "pid-" + strconv.Itoa(pid) }
+
+// session builds the wire object, leaving the git context to Capture.
+func session(tool, id, label string, detected bool) state.Session {
+	if id == "" {
+		id = pidID(os.Getpid())
+	}
+	return state.Session{
+		ID:       id,
+		Tool:     tool,
+		Label:    label,
+		Detected: detected,
+	}
+}

--- a/internal/sessions/detect_test.go
+++ b/internal/sessions/detect_test.go
@@ -1,0 +1,152 @@
+package sessions
+
+import "testing"
+
+// env builds a Getenv over a fixed table.
+func env(pairs map[string]string) func(string) string {
+	return func(k string) string { return pairs[k] }
+}
+
+// procs is a fixed ancestry: 100 is the agent, 200 the shell it spawned, 300
+// the sonar process doing the detecting.
+func procs() []Process {
+	return []Process{
+		{PID: 300, PPID: 200, Command: "sonar"},
+		{PID: 200, PPID: 100, Command: "/bin/zsh"},
+		{PID: 100, PPID: 1, Command: "/opt/homebrew/bin/claude"},
+	}
+}
+
+func TestDetectEnvMatrix(t *testing.T) {
+	cases := []struct {
+		name     string
+		env      map[string]string
+		wantOK   bool
+		id       string
+		tool     string
+		label    string
+		detected bool
+	}{
+		{
+			name:   "nothing",
+			env:    map[string]string{},
+			wantOK: false,
+		},
+		{
+			name:   "SONAR_SESSION is the contract and wins",
+			env:    map[string]string{EnvSession: "claude-code:abc123", EnvClaudeCode: "1"},
+			wantOK: true, id: "abc123", tool: "claude-code", detected: false,
+		},
+		{
+			name:   "SONAR_SESSION with a label",
+			env:    map[string]string{EnvSession: "codex:t-9", EnvSessionLabel: "refactor the killer"},
+			wantOK: true, id: "t-9", tool: "codex", label: "refactor the killer", detected: false,
+		},
+		{
+			name:   "SONAR_SESSION without a tool prefix",
+			env:    map[string]string{EnvSession: "just-an-id"},
+			wantOK: true, id: "just-an-id", tool: ToolAgent, detected: false,
+		},
+		{
+			name:   "generic SONAR_SESSION_ID",
+			env:    map[string]string{EnvSessionID: "id-7", EnvSessionLabel: "nightly"},
+			wantOK: true, id: "id-7", tool: ToolAgent, label: "nightly", detected: false,
+		},
+		{
+			name:   "generic id with an explicit tool",
+			env:    map[string]string{EnvSessionID: "id-7", EnvSessionTool: "aider"},
+			wantOK: true, id: "id-7", tool: "aider", detected: false,
+		},
+		{
+			name:   "Claude Code by CLAUDECODE, id from the ancestor pid",
+			env:    map[string]string{EnvClaudeCode: "1"},
+			wantOK: true, id: "pid-100", tool: ToolClaudeCode, detected: true,
+		},
+		{
+			name:   "Claude Code with its own session id",
+			env:    map[string]string{EnvClaudeCode: "1", EnvClaudeCodeSessionID: "cc-42"},
+			wantOK: true, id: "cc-42", tool: ToolClaudeCode, detected: true,
+		},
+		{
+			name:   "Claude Code from the session id alone",
+			env:    map[string]string{EnvClaudeSessionID: "cc-legacy"},
+			wantOK: true, id: "cc-legacy", tool: ToolClaudeCode, detected: true,
+		},
+		{
+			name:   "CLAUDECODE=0 is not an agent",
+			env:    map[string]string{EnvClaudeCode: "0"},
+			wantOK: false,
+		},
+		{
+			name:   "Codex by thread id",
+			env:    map[string]string{EnvCodexThreadID: "thr-1"},
+			wantOK: true, id: "thr-1", tool: ToolCodex, detected: true,
+		},
+		{
+			name:   "Codex by sandbox marker falls back to the parent pid",
+			env:    map[string]string{EnvCodexSandbox: "seatbelt"},
+			wantOK: true, id: "pid-200", tool: ToolCodex, detected: true,
+		},
+		{
+			name:   "Cursor",
+			env:    map[string]string{EnvCursorAgent: "1", EnvCursorAgentSessionID: "cur-3"},
+			wantOK: true, id: "cur-3", tool: ToolCursor, detected: true,
+		},
+		{
+			name:   "Claude Code wins over Codex when both are set",
+			env:    map[string]string{EnvClaudeCodeSessionID: "cc-1", EnvCodexThreadID: "thr-1"},
+			wantOK: true, id: "cc-1", tool: ToolClaudeCode, detected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Detect(Options{
+				Getenv:    env(tc.env),
+				PID:       300,
+				Processes: procs,
+			})
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (session %+v)", ok, tc.wantOK, got)
+			}
+			if !ok {
+				return
+			}
+			if got.ID != tc.id {
+				t.Errorf("id = %q, want %q", got.ID, tc.id)
+			}
+			if got.Tool != tc.tool {
+				t.Errorf("tool = %q, want %q", got.Tool, tc.tool)
+			}
+			if got.Label != tc.label {
+				t.Errorf("label = %q, want %q", got.Label, tc.label)
+			}
+			if got.Detected != tc.detected {
+				t.Errorf("detected = %v, want %v", got.Detected, tc.detected)
+			}
+		})
+	}
+}
+
+// A detected id is the agent's pid, not this process's: two commands the same
+// agent starts must land in one session.
+func TestDetectedIDIsStableAcrossCommands(t *testing.T) {
+	opts := func(pid int) Options {
+		return Options{Getenv: env(map[string]string{EnvClaudeCode: "1"}), PID: pid, Processes: procs}
+	}
+	first, _ := Detect(opts(300))
+	second, _ := Detect(opts(200))
+	if first.ID != second.ID {
+		t.Errorf("two commands of one agent got %q and %q", first.ID, second.ID)
+	}
+	if first.ID != "pid-100" {
+		t.Errorf("id = %q, want the agent's pid", first.ID)
+	}
+}
+
+func TestDetectFromEnvReadsAKeyValueSlice(t *testing.T) {
+	got, ok := DetectFromEnv([]string{"PATH=/bin", "SONAR_SESSION=cursor:c-1"}, Options{})
+	if !ok || got.ID != "c-1" || got.Tool != ToolCursor {
+		t.Fatalf("DetectFromEnv = %+v, %v", got, ok)
+	}
+}

--- a/internal/sessions/gitctx.go
+++ b/internal/sessions/gitctx.go
@@ -1,0 +1,108 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// GitContext is the checkout a command is started in: the worktree name and
+// the branch, as spec 2 §3 defines them.
+//
+// worktree is the base name of the checkout when it is a *linked* worktree —
+// `git worktree add` — and empty for the primary checkout, so a badge reading
+// "worktree feature-x" only ever appears where there really is one. branch is
+// the checked-out branch, or the short commit for a detached HEAD.
+//
+// Everything is read from the `.git` entry directly: `sonar start` must not
+// pay for a `git` subprocess on a path that runs before every dev server.
+func GitContext(cwd string) (worktree, branch string) {
+	root, linked, ok := groups.Find(cwd)
+	if !ok {
+		return "", ""
+	}
+	if linked != "" {
+		worktree = filepath.Base(root)
+	}
+	return worktree, branchOf(root)
+}
+
+// Capture is what a spawn path calls: the detected session with the git
+// context of the directory the command will run in filled in.
+func Capture(cwd string, opts Options) (state.Session, bool) {
+	s, ok := Detect(opts)
+	if !ok {
+		return state.Session{}, false
+	}
+	s.Worktree, s.Branch = GitContext(cwd)
+	return s, true
+}
+
+// branchOf reads HEAD for a checkout root, following the `.git` file of a
+// linked worktree or submodule to the directory that holds its own HEAD.
+func branchOf(root string) string {
+	gitDir := filepath.Join(root, ".git")
+	info, err := os.Lstat(gitDir)
+	if err != nil {
+		return ""
+	}
+	if info.Mode().IsRegular() {
+		target := gitFileTarget(root, gitDir)
+		if target == "" {
+			return ""
+		}
+		gitDir = target
+	}
+	return parseHead(readTrimmed(filepath.Join(gitDir, "HEAD")))
+}
+
+// gitFileTarget resolves the `gitdir:` line of a `.git` file to an absolute
+// path.
+func gitFileTarget(root, gitFile string) string {
+	for _, line := range strings.Split(readTrimmed(gitFile), "\n") {
+		rest, found := strings.CutPrefix(strings.TrimSpace(line), "gitdir:")
+		if !found {
+			continue
+		}
+		target := strings.TrimSpace(rest)
+		if target == "" {
+			return ""
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(root, target)
+		}
+		return filepath.Clean(target)
+	}
+	return ""
+}
+
+// parseHead turns a HEAD file into a branch name. A symbolic ref gives the
+// branch; a detached HEAD gives the short commit, which is still what a person
+// would call the thing they are on.
+func parseHead(head string) string {
+	if head == "" {
+		return ""
+	}
+	if ref, found := strings.CutPrefix(head, "ref:"); found {
+		ref = strings.TrimSpace(ref)
+		if short, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+			return short
+		}
+		return ref
+	}
+	if len(head) > 12 {
+		return head[:12]
+	}
+	return head
+}
+
+func readTrimmed(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/sessions/gitctx_test.go
+++ b/internal/sessions/gitctx_test.go
@@ -1,0 +1,121 @@
+package sessions
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// gitRepo makes a real checkout with one commit. Everything here reads .git
+// directly, so the fixture has to be a real repository rather than a fake.
+func gitRepo(t *testing.T, dir string) {
+	t.Helper()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(cmd.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q", "-b", "main", ".")
+	run("commit", "-q", "--allow-empty", "-m", "first")
+}
+
+func TestGitContextMainCheckoutHasNoWorktree(t *testing.T) {
+	root := t.TempDir()
+	gitRepo(t, root)
+
+	worktree, branch := GitContext(root)
+	if worktree != "" {
+		t.Errorf("worktree = %q, want empty for the primary checkout", worktree)
+	}
+	if branch != "main" {
+		t.Errorf("branch = %q, want main", branch)
+	}
+}
+
+func TestGitContextFromASubdirectory(t *testing.T) {
+	root := t.TempDir()
+	gitRepo(t, root)
+	sub := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	_, branch := GitContext(sub)
+	if branch != "main" {
+		t.Errorf("branch from a subdirectory = %q, want main", branch)
+	}
+}
+
+func TestGitContextNamesALinkedWorktree(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	gitRepo(t, root)
+
+	linked := filepath.Join(base, "feature-x")
+	cmd := exec.Command("git", "worktree", "add", "-q", "-b", "feature/x", linked)
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git worktree add: %v\n%s", err, out)
+	}
+
+	worktree, branch := GitContext(linked)
+	if worktree != "feature-x" {
+		t.Errorf("worktree = %q, want feature-x", worktree)
+	}
+	if branch != "feature/x" {
+		t.Errorf("branch = %q, want feature/x", branch)
+	}
+
+	// The primary checkout of the same repository still reports no worktree.
+	if w, _ := GitContext(root); w != "" {
+		t.Errorf("primary checkout reported worktree %q", w)
+	}
+}
+
+func TestGitContextOutsideARepository(t *testing.T) {
+	worktree, branch := GitContext(t.TempDir())
+	if worktree != "" || branch != "" {
+		t.Errorf("GitContext outside a repo = %q, %q", worktree, branch)
+	}
+}
+
+func TestCaptureFillsTheGitContext(t *testing.T) {
+	root := t.TempDir()
+	gitRepo(t, root)
+
+	got, ok := Capture(root, Options{Getenv: env(map[string]string{EnvSession: "claude-code:s1"})})
+	if !ok {
+		t.Fatal("Capture found no session")
+	}
+	if got.ID != "s1" || got.Branch != "main" {
+		t.Errorf("Capture = %+v", got)
+	}
+
+	if _, ok := Capture(root, Options{Getenv: env(nil), Processes: func() []Process { return nil }}); ok {
+		t.Error("Capture invented a session with no agent in the environment")
+	}
+}
+
+func TestParseHead(t *testing.T) {
+	for _, tc := range []struct{ head, want string }{
+		{"ref: refs/heads/main", "main"},
+		{"ref: refs/heads/feature/x", "feature/x"},
+		{"ref: refs/remotes/origin/main", "refs/remotes/origin/main"},
+		{"0123456789abcdef0123456789abcdef01234567", "0123456789ab"},
+		{"", ""},
+	} {
+		if got := parseHead(tc.head); got != tc.want {
+			t.Errorf("parseHead(%q) = %q, want %q", tc.head, got, tc.want)
+		}
+	}
+}

--- a/internal/sessions/migration.go
+++ b/internal/sessions/migration.go
@@ -1,0 +1,20 @@
+package sessions
+
+import (
+	_ "embed"
+
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// Migration 005 is the version contract §8 reserves for sessions. It is
+// registered from here, not from internal/store, because that is what a
+// reserved version means: the store holds the slot open and the owning package
+// fills it in from its own init(). internal/store asserts that its own
+// embedded set never takes a reserved number.
+//
+//go:embed migrations/005_sessions.sql
+var migration005 string
+
+func init() {
+	store.RegisterMigration(store.VersionSessions, "sessions", migration005)
+}

--- a/internal/sessions/migrations/005_sessions.sql
+++ b/internal/sessions/migrations/005_sessions.sql
@@ -1,0 +1,19 @@
+-- 005_sessions.sql — agent sessions (spec 2 §3, contract §8 reserved version 5).
+--
+-- One row per agent session sonar has ever attributed a run to. Live sessions
+-- are held in memory by the daemon's run registry; this table is what survives
+-- a restart and what keeps an inactive session readable for the seven days
+-- `port_history` may still name it. Rows are pruned on last_seen.
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id         TEXT PRIMARY KEY,
+    tool       TEXT    NOT NULL DEFAULT '',
+    label      TEXT    NOT NULL DEFAULT '',
+    worktree   TEXT    NOT NULL DEFAULT '',
+    branch     TEXT    NOT NULL DEFAULT '',
+    detected   INTEGER NOT NULL DEFAULT 0,
+    first_seen TEXT    NOT NULL,
+    last_seen  TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_last_seen ON sessions(last_seen DESC);

--- a/internal/sessions/process_unix.go
+++ b/internal/sessions/process_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package sessions
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// processTable lists pid, ppid and command in one `ps` call. Detection runs
+// once per `sonar start`, so one exec is the whole cost; a failure just means
+// the ancestor walk falls back to the parent pid.
+func processTable() []Process {
+	out, err := exec.Command("ps", "-Ao", "pid=,ppid=,comm=").Output()
+	if err != nil {
+		return nil
+	}
+	return parsePS(string(out))
+}
+
+// parsePS reads `pid ppid comm` rows. comm may contain spaces (a path), so the
+// first two fields are cut off and the rest is the command.
+func parsePS(out string) []Process {
+	var procs []Process
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		ppid, err := strconv.Atoi(fields[1])
+		if err != nil {
+			continue
+		}
+		procs = append(procs, Process{PID: pid, PPID: ppid, Command: strings.Join(fields[2:], " ")})
+	}
+	return procs
+}

--- a/internal/sessions/process_unix_test.go
+++ b/internal/sessions/process_unix_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package sessions
+
+import "testing"
+
+func TestParsePSReadsPidPpidComm(t *testing.T) {
+	got := parsePS("  100     1 /usr/bin/claude code\n 200   100 zsh\nnonsense\n")
+	if len(got) != 2 {
+		t.Fatalf("parsePS returned %d rows: %+v", len(got), got)
+	}
+	if got[0] != (Process{PID: 100, PPID: 1, Command: "/usr/bin/claude code"}) {
+		t.Errorf("first row = %+v", got[0])
+	}
+}
+
+// The real process table has this process in it, with a plausible parent.
+func TestProcessTableIncludesThisProcess(t *testing.T) {
+	procs := processTable()
+	if len(procs) == 0 {
+		t.Skip("no ps on this machine")
+	}
+	for _, p := range procs {
+		if p.Command == "" {
+			t.Errorf("process %d has no command", p.PID)
+			break
+		}
+	}
+}

--- a/internal/sessions/process_windows.go
+++ b/internal/sessions/process_windows.go
@@ -1,0 +1,7 @@
+package sessions
+
+// processTable has no cheap portable form on Windows: the CIM query the
+// scanner uses is far too expensive for something that runs on every `sonar
+// start`. Detection there relies on the agent's own session-id variable and
+// otherwise falls back to the parent pid (see ancestorID).
+func processTable() []Process { return nil }

--- a/internal/sessions/records.go
+++ b/internal/sessions/records.go
@@ -1,0 +1,154 @@
+package sessions
+
+import (
+	"sort"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// Live is one running run that carries a session, as the daemon's run registry
+// reports it. It is the whole run rather than just its id because
+// `sessions.inspect` lists the runs of a session and there is no second place
+// to look them up from.
+type Live struct {
+	RunID     string
+	PID       int
+	Group     string
+	Name      string
+	Cmd       string
+	Cwd       string
+	StartedAt time.Time
+	Session   state.Session
+}
+
+// Known is a session the store remembers, live or not. Inactive sessions are
+// kept for the prune window so `port_history` can still say who started a port
+// that is long gone.
+type Known struct {
+	Session   state.Session
+	FirstSeen time.Time
+	LastSeen  time.Time
+}
+
+// Retention is how long an inactive session is kept before Prune drops it
+// (spec 2 §3).
+const Retention = 7 * 24 * time.Hour
+
+// Records builds the `sessions` collection of the snapshot: every session the
+// store knows plus every session that has a live run, each with the counts a
+// client renders and whether it is still active.
+//
+// A session is active while it has at least one live run — not while it has a
+// port. An agent whose dev server is still coming up is active, and so is one
+// whose command binds nothing at all.
+func Records(known []Known, live []Live, ports []state.Port) []state.SessionRecord {
+	byID := map[string]*state.SessionRecord{}
+	order := []string{}
+
+	add := func(s state.Session) *state.SessionRecord {
+		if rec, ok := byID[s.ID]; ok {
+			return rec
+		}
+		rec := &state.SessionRecord{Session: s}
+		byID[s.ID] = rec
+		order = append(order, s.ID)
+		return rec
+	}
+
+	for _, k := range known {
+		rec := add(k.Session)
+		rec.FirstSeen = rfc3339(k.FirstSeen)
+		rec.LastSeen = rfc3339(k.LastSeen)
+	}
+
+	groupsSeen := map[string]map[string]bool{}
+	for _, l := range live {
+		if l.Session.ID == "" {
+			continue
+		}
+		rec := add(l.Session)
+		// The live run's own identity is fresher than a store row written when
+		// the session was first seen: a rebased worktree changes branch.
+		rec.Session = l.Session
+		rec.Runs++
+		rec.Active = true
+		if rec.FirstSeen == "" {
+			rec.FirstSeen = rfc3339(l.StartedAt)
+		}
+		if l.Group != "" {
+			if groupsSeen[l.Session.ID] == nil {
+				groupsSeen[l.Session.ID] = map[string]bool{}
+			}
+			groupsSeen[l.Session.ID][l.Group] = true
+		}
+	}
+
+	for i := range ports {
+		s := ports[i].Session
+		if s == nil || s.ID == "" {
+			continue
+		}
+		rec, ok := byID[s.ID]
+		if !ok {
+			rec = add(*s)
+			rec.Active = true
+		}
+		rec.Ports++
+		if g := ports[i].Group; g != nil && *g != "" {
+			if groupsSeen[s.ID] == nil {
+				groupsSeen[s.ID] = map[string]bool{}
+			}
+			groupsSeen[s.ID][*g] = true
+		}
+	}
+
+	out := make([]state.SessionRecord, 0, len(order))
+	for _, id := range order {
+		rec := byID[id]
+		rec.Groups = len(groupsSeen[id])
+		out = append(out, *rec)
+	}
+	// Newest activity first, so the list reads like a session log; ties break
+	// on id so the collection is stable between ticks and the delta is quiet.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Active != out[j].Active {
+			return out[i].Active
+		}
+		if out[i].LastSeen != out[j].LastSeen {
+			return out[i].LastSeen > out[j].LastSeen
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// RunsOf returns the live runs of one session, oldest first.
+func RunsOf(live []Live, id string) []Live {
+	var out []Live
+	for _, l := range live {
+		if l.Session.ID == id {
+			out = append(out, l)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].StartedAt.Before(out[j].StartedAt) })
+	return out
+}
+
+// PortsOf returns the ports attributed to one session.
+func PortsOf(ports []state.Port, id string) []state.Port {
+	out := []state.Port{}
+	for i := range ports {
+		if s := ports[i].Session; s != nil && s.ID == id {
+			out = append(out, ports[i])
+		}
+	}
+	return out
+}
+
+func rfc3339(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/sessions/records_test.go
+++ b/internal/sessions/records_test.go
@@ -1,0 +1,133 @@
+package sessions
+
+import (
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+func at(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func port(n int, group string, session *state.Session) state.Port {
+	p := state.Port{Port: n, BindAddress: "127.0.0.1", PID: 1000 + n, Session: session}
+	if group != "" {
+		g := group
+		p.Group = &g
+	}
+	return p
+}
+
+func sess(id, tool string) state.Session {
+	return state.Session{ID: id, Tool: tool, Worktree: "feature-x", Branch: "feature/x"}
+}
+
+func find(t *testing.T, recs []state.SessionRecord, id string) state.SessionRecord {
+	t.Helper()
+	for _, r := range recs {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("no record for %q in %+v", id, recs)
+	return state.SessionRecord{}
+}
+
+func TestRecordsCountsRunsPortsAndGroups(t *testing.T) {
+	s1 := sess("s1", ToolClaudeCode)
+	s2 := sess("s2", ToolCodex)
+
+	live := []Live{
+		{RunID: "r1", PID: 11, Group: "web", Session: s1, StartedAt: at("2026-09-01T10:00:00Z")},
+		{RunID: "r2", PID: 12, Group: "api", Session: s1, StartedAt: at("2026-09-01T10:01:00Z")},
+	}
+	known := []Known{
+		{Session: s1, FirstSeen: at("2026-09-01T09:00:00Z"), LastSeen: at("2026-09-01T10:01:00Z")},
+		{Session: s2, FirstSeen: at("2026-08-30T09:00:00Z"), LastSeen: at("2026-08-30T09:30:00Z")},
+	}
+	ports := []state.Port{
+		port(3000, "web", &s1),
+		port(3001, "api", &s1),
+		port(5432, "db", nil),
+	}
+
+	recs := Records(known, live, ports)
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2: %+v", len(recs), recs)
+	}
+
+	one := find(t, recs, "s1")
+	if one.Runs != 2 || one.Ports != 2 || one.Groups != 2 {
+		t.Errorf("s1 counts = runs %d, ports %d, groups %d; want 2, 2, 2",
+			one.Runs, one.Ports, one.Groups)
+	}
+	if !one.Active {
+		t.Error("s1 has live runs but is not active")
+	}
+	if one.FirstSeen != "2026-09-01T09:00:00Z" {
+		t.Errorf("s1 first_seen = %q", one.FirstSeen)
+	}
+
+	two := find(t, recs, "s2")
+	if two.Active || two.Runs != 0 || two.Ports != 0 {
+		t.Errorf("s2 = %+v, want an inactive session with no runs or ports", two)
+	}
+
+	// Active sessions sort first, so `sonar sessions` reads top-down.
+	if recs[0].ID != "s1" {
+		t.Errorf("active session is not first: %+v", recs)
+	}
+}
+
+// A port stamped with a session the store has never heard of still shows up:
+// the daemon is the authority on what is running, not the database.
+func TestRecordsIncludesUnknownSessionsFromPorts(t *testing.T) {
+	s := sess("ghost", ToolCursor)
+	recs := Records(nil, nil, []state.Port{port(4000, "web", &s)})
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1", len(recs))
+	}
+	if recs[0].Ports != 1 || !recs[0].Active {
+		t.Errorf("record = %+v", recs[0])
+	}
+}
+
+// A live run's identity is fresher than the row written when the session was
+// first recorded: a rebase changes the branch under the same id.
+func TestRecordsPrefersTheLiveSessionOverTheStoredOne(t *testing.T) {
+	stored := state.Session{ID: "s1", Tool: ToolClaudeCode, Branch: "old"}
+	live := state.Session{ID: "s1", Tool: ToolClaudeCode, Branch: "new"}
+	recs := Records(
+		[]Known{{Session: stored, LastSeen: at("2026-09-01T10:00:00Z")}},
+		[]Live{{RunID: "r1", Session: live}}, nil)
+	if recs[0].Branch != "new" {
+		t.Errorf("branch = %q, want the live run's", recs[0].Branch)
+	}
+}
+
+func TestRunsOfAndPortsOf(t *testing.T) {
+	s1, s2 := sess("s1", ToolClaudeCode), sess("s2", ToolCodex)
+	live := []Live{
+		{RunID: "late", Session: s1, StartedAt: at("2026-09-01T11:00:00Z")},
+		{RunID: "early", Session: s1, StartedAt: at("2026-09-01T10:00:00Z")},
+		{RunID: "other", Session: s2},
+	}
+	got := RunsOf(live, "s1")
+	if len(got) != 2 || got[0].RunID != "early" {
+		t.Errorf("RunsOf = %+v, want early then late", got)
+	}
+
+	ports := PortsOf([]state.Port{port(3000, "", &s1), port(3001, "", &s2)}, "s2")
+	if len(ports) != 1 || ports[0].Port != 3001 {
+		t.Errorf("PortsOf = %+v", ports)
+	}
+	if PortsOf(nil, "s1") == nil {
+		t.Error("PortsOf returned nil rather than an empty slice")
+	}
+}

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -1,0 +1,276 @@
+package sessions_test
+
+// The sessions table and its migration. These live here rather than in
+// internal/store because migration 005 is registered from internal/sessions:
+// the store holds the version open (contract §8) and the owning package fills
+// it in, so only a package that links this one has the table.
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+func openStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.Open(filepath.Join(t.TempDir(), "sonar.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func row(id string, seen time.Time) store.SessionRow {
+	return store.SessionRow{
+		ID: id, Tool: sessions.ToolClaudeCode, Label: "build the thing",
+		Worktree: "feature-x", Branch: "feature/x", Detected: true,
+		FirstSeen: seen, LastSeen: seen,
+	}
+}
+
+func TestMigration005IsTheReservedVersion(t *testing.T) {
+	s := openStore(t)
+	v, err := s.Version()
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if v != store.VersionSessions {
+		t.Errorf("version = %d, want the reserved sessions version %d", v, store.VersionSessions)
+	}
+	var n int
+	if err := s.DB().QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE name IN ('sessions','idx_sessions_last_seen')`,
+	).Scan(&n); err != nil {
+		t.Fatalf("querying sqlite_master: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("found %d of the two objects migration 005 creates", n)
+	}
+}
+
+// TestMigrateFromV2 replays a database written by a sonar that had only
+// migrations 001 and 002 and checks that 005 lands on top without losing rows.
+func TestMigrateFromV2(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sonar.db")
+
+	fixture, err := os.ReadFile(filepath.Join("testdata", "v2_schema.sql"))
+	if err != nil {
+		t.Fatalf("reading the v2 fixture: %v", err)
+	}
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("creating the v2 database: %v", err)
+	}
+	if _, err := raw.Exec(string(fixture)); err != nil {
+		t.Fatalf("applying the v2 fixture: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("closing the v2 database: %v", err)
+	}
+
+	s, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("Open on a v2 database: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if s.ResetHappened() {
+		t.Fatal("a valid v2 database was treated as corrupt")
+	}
+	if v, err := s.Version(); err != nil || v != store.VersionSessions {
+		t.Fatalf("version after upgrade = %d (%v), want %d", v, err, store.VersionSessions)
+	}
+	if name, ok, err := s.GetRename("cwd:/home/me/code/shop:3000"); err != nil || !ok || name != "storefront" {
+		t.Errorf("the v2 rename did not survive: %q, %v, %v", name, ok, err)
+	}
+	roots, err := s.Roots()
+	if err != nil || len(roots) != 1 {
+		t.Errorf("the v2 known_roots row did not survive: %v, %v", roots, err)
+	}
+	if err := s.Sessions().Upsert(row("s1", time.Now())); err != nil {
+		t.Errorf("writing to the upgraded sessions table: %v", err)
+	}
+}
+
+func TestSessionsUpsertTouchAndList(t *testing.T) {
+	s := openStore(t)
+	table := s.Sessions()
+
+	first := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	if err := table.Upsert(row("s1", first)); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// A second upsert refreshes the mutable half and moves last_seen, but
+	// first_seen is when this session first started something.
+	later := first.Add(2 * time.Hour)
+	updated := row("s1", later)
+	updated.Branch = "main"
+	updated.Detected = false
+	if err := table.Upsert(updated); err != nil {
+		t.Fatalf("Upsert again: %v", err)
+	}
+
+	rows, err := table.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("List returned %d rows, want 1", len(rows))
+	}
+	got := rows[0]
+	if !got.FirstSeen.Equal(first) {
+		t.Errorf("first_seen = %v, want the original %v", got.FirstSeen, first)
+	}
+	if !got.LastSeen.Equal(later) {
+		t.Errorf("last_seen = %v, want %v", got.LastSeen, later)
+	}
+	if got.Branch != "main" || got.Detected {
+		t.Errorf("the second upsert did not refresh the row: %+v", got)
+	}
+	if got.Tool != sessions.ToolClaudeCode || got.Worktree != "feature-x" || got.Label == "" {
+		t.Errorf("round trip lost fields: %+v", got)
+	}
+
+	touched := later.Add(time.Hour)
+	if err := table.Touch("s1", touched); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	rows, _ = table.List()
+	if !rows[0].LastSeen.Equal(touched) {
+		t.Errorf("Touch left last_seen at %v", rows[0].LastSeen)
+	}
+
+	// Touching a session nobody recorded creates nothing.
+	if err := table.Touch("ghost", touched); err != nil {
+		t.Fatalf("Touch on an unknown session: %v", err)
+	}
+	if rows, _ := table.List(); len(rows) != 1 {
+		t.Errorf("Touch created a row: %+v", rows)
+	}
+
+	if err := table.Upsert(store.SessionRow{}); err == nil {
+		t.Error("an id-less session was accepted")
+	}
+}
+
+func TestSessionsListIsNewestFirstAndGetFindsOne(t *testing.T) {
+	s := openStore(t)
+	table := s.Sessions()
+	base := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+
+	for i, id := range []string{"old", "new"} {
+		if err := table.Upsert(row(id, base.Add(time.Duration(i)*time.Hour))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := table.List()
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("List = %v, %v", rows, err)
+	}
+	if rows[0].ID != "new" {
+		t.Errorf("List order = %q, %q; want the newest first", rows[0].ID, rows[1].ID)
+	}
+
+	got, ok, err := table.Get("old")
+	if err != nil || !ok || got.ID != "old" {
+		t.Errorf("Get(old) = %+v, %v, %v", got, ok, err)
+	}
+	if _, ok, _ := table.Get("missing"); ok {
+		t.Error("Get found a session that was never recorded")
+	}
+}
+
+func TestSessionsPruneDropsOnlyTheOldOnes(t *testing.T) {
+	s := openStore(t)
+	table := s.Sessions()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+
+	if err := table.Upsert(row("stale", now.Add(-8*24*time.Hour))); err != nil {
+		t.Fatal(err)
+	}
+	if err := table.Upsert(row("recent", now.Add(-6*24*time.Hour))); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := table.Prune(now.Add(-sessions.Retention))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Prune removed %d rows, want 1", n)
+	}
+	rows, _ := table.List()
+	if len(rows) != 1 || rows[0].ID != "recent" {
+		t.Errorf("after prune: %+v", rows)
+	}
+
+	// Retention is the seven days spec 2 §3 promises.
+	if sessions.Retention != 7*24*time.Hour {
+		t.Errorf("Retention = %v, want 7 days", sessions.Retention)
+	}
+}
+
+// A database that reached version 006 under a build with claims but without
+// sessions still gets migration 005 the first time a build that owns sessions
+// opens it. This is why the store applies every registered version that has no
+// schema_version row rather than everything above the highest one.
+func TestMigration005LandsOnADatabaseAlreadyAtV6(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sonar.db")
+
+	fixture, err := os.ReadFile(filepath.Join("testdata", "v2_schema.sql"))
+	if err != nil {
+		t.Fatalf("reading the v2 fixture: %v", err)
+	}
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("creating the database: %v", err)
+	}
+	if _, err := raw.Exec(string(fixture)); err != nil {
+		t.Fatalf("applying the v2 fixture: %v", err)
+	}
+	// A sibling package's migration 006, applied by a build that never had
+	// 005 linked in.
+	if _, err := raw.Exec(
+		`CREATE TABLE claims (port INTEGER PRIMARY KEY, key TEXT NOT NULL);
+		 INSERT INTO schema_version(version, name, applied_at)
+		 VALUES (6, 'claims', '2026-09-05T00:00:00.000000000Z');`); err != nil {
+		t.Fatalf("faking migration 006: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+
+	s, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("Open on a v6 database: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if s.ResetHappened() {
+		t.Fatal("a valid database was treated as corrupt")
+	}
+	if err := s.Sessions().Upsert(row("s1", time.Now())); err != nil {
+		t.Fatalf("migration 005 did not run on a v6 database: %v", err)
+	}
+	var n int
+	if err := s.DB().QueryRow(
+		`SELECT count(*) FROM schema_version WHERE version = ?`, store.VersionSessions).Scan(&n); err != nil {
+		t.Fatalf("counting the 005 row: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("schema_version has %d rows for version %d, want 1", n, store.VersionSessions)
+	}
+	// The claims table the other build created is untouched.
+	if _, err := s.DB().Exec(`INSERT INTO claims(port, key) VALUES(3000, 'shop/main')`); err != nil {
+		t.Errorf("the sibling package's table did not survive: %v", err)
+	}
+}

--- a/internal/sessions/testdata/v2_schema.sql
+++ b/internal/sessions/testdata/v2_schema.sql
@@ -1,0 +1,67 @@
+-- Frozen copy of the schema a sonar with migrations 001 and 002 wrote, used to
+-- prove that migration 005 lands on a real user's database without losing
+-- anything. Do not "fix" this file when 001 or 002 change: the point is that
+-- it is what is on old users' disks.
+CREATE TABLE schema_version (
+    version    INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE renames (
+    key        TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE group_pins (
+    key        TEXT PRIMARY KEY,
+    group_name TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE port_events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    at           TEXT    NOT NULL,
+    kind         TEXT    NOT NULL,
+    port         INTEGER NOT NULL,
+    bind         TEXT    NOT NULL DEFAULT '',
+    pid          INTEGER NOT NULL DEFAULT 0,
+    display_name TEXT    NOT NULL DEFAULT '',
+    group_name   TEXT    NOT NULL DEFAULT '',
+    project_root TEXT    NOT NULL DEFAULT '',
+    command      TEXT    NOT NULL DEFAULT ''
+);
+
+CREATE TRIGGER port_events_ring
+AFTER INSERT ON port_events
+BEGIN
+    DELETE FROM port_events WHERE id <= NEW.id - 10000;
+END;
+
+INSERT INTO schema_version(version, name, applied_at)
+VALUES (1, 'core', '2026-01-01T00:00:00.000000000Z');
+
+INSERT INTO renames(key, name, created_at)
+VALUES ('cwd:/home/me/code/shop:3000', 'storefront', '2026-01-01T00:00:00.000000000Z');
+
+INSERT INTO group_pins(key, group_name, created_at)
+VALUES ('port:9999', 'legacy', '2026-01-01T00:00:00.000000000Z');
+
+INSERT INTO port_events(at, kind, port, pid, display_name, group_name)
+VALUES ('2026-01-01T00:00:00.000000000Z', 'port_up', 3000, 42, 'storefront', 'shop');
+
+-- Migration 002, as shipped: history indexes and the known-roots table.
+CREATE INDEX idx_port_events_at      ON port_events(at DESC);
+CREATE INDEX idx_port_events_port_at ON port_events(port, at DESC);
+
+CREATE TABLE known_roots (
+    path     TEXT PRIMARY KEY,
+    added_at TEXT NOT NULL
+);
+
+INSERT INTO schema_version(version, name, applied_at)
+VALUES (2, 'indexes_roots', '2026-01-02T00:00:00.000000000Z');
+
+INSERT INTO known_roots(path, added_at)
+VALUES ('/home/me/code/shop', '2026-01-02T00:00:00.000000000Z');

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/raskrebs/sonar/internal/state"
 )
 
 // Environment variables every child gets, so a tool that wants to know which
@@ -33,6 +35,12 @@ const (
 	EnvName     = "SONAR_NAME"
 	EnvRunID    = "SONAR_RUN_ID"
 	EnvPortHint = "SONAR_PORT"
+	// EnvSession and EnvSessionLabel re-export the agent session the caller
+	// captured, in the `<tool>:<id>` form spec 2 §3 defines. A `sonar start`
+	// nested inside this child therefore reads the session explicitly instead
+	// of detecting it again, and every run of one agent shares one id.
+	EnvSession      = "SONAR_SESSION"
+	EnvSessionLabel = "SONAR_SESSION_LABEL"
 )
 
 // Request is one command to start.
@@ -50,6 +58,11 @@ type Request struct {
 	Name  string
 	// PortHint is the port the command is expected to bind, or 0.
 	PortHint int
+	// Session is the agent session that asked for this run, captured by the
+	// caller (internal/sessions). Spawn only carries it: it puts SONAR_SESSION
+	// in the child's environment and hands it back on the Handle for the
+	// registry to store. The zero value means no session.
+	Session state.Session
 	// Detach runs the child in its own session with stdout and stderr in the
 	// run's log file, so it survives the process that started it.
 	Detach bool
@@ -76,6 +89,7 @@ type Handle struct {
 	StartedAt time.Time
 	LogPath   string
 	Detached  bool
+	Session   state.Session
 
 	cmd *exec.Cmd
 	log *os.File
@@ -117,6 +131,7 @@ func Spawn(ctx context.Context, req Request) (*Handle, error) {
 		PortHint:  req.PortHint,
 		StartedAt: time.Now(),
 		Detached:  req.Detach,
+		Session:   req.Session,
 	}
 
 	cmd := exec.Command(req.Argv[0], req.Argv[1:]...)
@@ -193,6 +208,10 @@ func childEnv(req Request, id string) []string {
 		base = os.Environ()
 	}
 	drop := map[string]bool{EnvGroup: true, EnvName: true, EnvRunID: true, EnvPortHint: true}
+	if req.Session.ID != "" {
+		drop[EnvSession] = true
+		drop[EnvSessionLabel] = true
+	}
 	out := make([]string, 0, len(base)+4)
 	for _, kv := range base {
 		if key, _, ok := strings.Cut(kv, "="); ok && drop[key] {
@@ -203,6 +222,12 @@ func childEnv(req Request, id string) []string {
 	out = append(out, EnvGroup+"="+req.Group, EnvName+"="+req.Name, EnvRunID+"="+id)
 	if req.PortHint > 0 {
 		out = append(out, EnvPortHint+"="+strconv.Itoa(req.PortHint))
+	}
+	if req.Session.ID != "" {
+		out = append(out, EnvSession+"="+req.Session.Tool+":"+req.Session.ID)
+		if req.Session.Label != "" {
+			out = append(out, EnvSessionLabel+"="+req.Session.Label)
+		}
 	}
 	return out
 }

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -17,6 +17,15 @@ var migrationFS embed.FS
 // Migration is one forward-only schema step. Every migration runs inside a
 // transaction together with the schema_version row that records it, so a
 // failed migration leaves the database on the previous version.
+//
+// schema_version records *every* applied version, one row each, and migrate
+// applies every registered version that has no row — not everything above the
+// highest one. The distinction matters because the reserved versions 003–006
+// are registered by sibling packages (contract §8), so which migrations a
+// given binary knows about depends on what it links: a database that reached
+// 006 under a build with claims but without sessions must still receive 005
+// the first time a build with sessions opens it. Comparing against
+// MAX(version) would have skipped it forever.
 type Migration struct {
 	Version int
 	Name    string
@@ -145,12 +154,14 @@ func migrate(db *sql.DB) error {
 	if _, err := db.Exec(schemaVersionDDL); err != nil {
 		return fmt.Errorf("creating schema_version: %w", err)
 	}
-	current, err := schemaVersion(db)
+	applied, err := appliedVersions(db)
 	if err != nil {
 		return err
 	}
+	// registeredMigrations is already in ascending version order, so a gap is
+	// filled in the order its author wrote it in.
 	for _, m := range registeredMigrations() {
-		if m.Version <= current {
+		if applied[m.Version] {
 			continue
 		}
 		if err := applyMigration(db, m); err != nil {
@@ -158,6 +169,27 @@ func migrate(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+// appliedVersions is the set of versions this database has already run. A
+// version recorded here is never re-applied; one that is registered but
+// missing is applied on the next open, wherever it sits in the order.
+func appliedVersions(db *sql.DB) (map[int]bool, error) {
+	rows, err := db.Query(`SELECT version FROM schema_version`)
+	if err != nil {
+		return nil, fmt.Errorf("reading schema_version: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	applied := map[int]bool{}
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("reading schema_version: %w", err)
+		}
+		applied[v] = true
+	}
+	return applied, rows.Err()
 }
 
 func applyMigration(db *sql.DB, m Migration) error {
@@ -182,7 +214,9 @@ func applyMigration(db *sql.DB, m Migration) error {
 	return nil
 }
 
-// schemaVersion reads the highest applied version, 0 for a fresh database.
+// schemaVersion reads the highest applied version, 0 for a fresh database. It
+// is what Version() reports; migrate works from the whole applied set, not
+// from this number.
 func schemaVersion(db *sql.DB) (int, error) {
 	var v sql.NullInt64
 	if err := db.QueryRow(`SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -172,3 +172,47 @@ func TestReservedVersionsAreFree(t *testing.T) {
 		}
 	}
 }
+
+// A migration registered below the highest applied version is still applied:
+// versions 003-006 belong to sibling packages, so a database can legitimately
+// reach 006 in a build that has no 005 linked in.
+func TestMigrateFillsAGapBelowTheHighestVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sonar.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Pretend a build with a later reserved migration has already run here.
+	if _, err := s.DB().Exec(
+		`INSERT INTO schema_version(version, name, applied_at) VALUES(?, 'later', ?)`,
+		VersionClaims, nowString()); err != nil {
+		t.Fatalf("recording a later version: %v", err)
+	}
+	// And that this build's migration 002 was never applied.
+	if _, err := s.DB().Exec(`DELETE FROM schema_version WHERE version = ?`, VersionIndexes); err != nil {
+		t.Fatalf("removing the 002 row: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopening: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+
+	applied, err := appliedVersions(reopened.DB())
+	if err != nil {
+		t.Fatalf("appliedVersions: %v", err)
+	}
+	if !applied[VersionIndexes] {
+		t.Errorf("migration %03d was not applied under a higher version: %v", VersionIndexes, applied)
+	}
+	if !applied[VersionClaims] {
+		t.Errorf("the pre-existing version row was lost: %v", applied)
+	}
+	if !tableExists(t, reopened.DB(), "known_roots") {
+		t.Error("migration 002 did not run")
+	}
+}

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// The sessions table (migration 005). The daemon's run registry is the
+// authority on which sessions are *live*; this table is the memory of the ones
+// that were, so an inactive session still has a tool, a worktree and a branch
+// to render for the seven days it is kept.
+
+// SessionRow is one persisted session. It deliberately mirrors state.Session
+// plus the two timestamps, without importing the wire package: the store's job
+// is rows, and the daemon maps them onto the collection.
+type SessionRow struct {
+	ID        string
+	Tool      string
+	Label     string
+	Worktree  string
+	Branch    string
+	Detected  bool
+	FirstSeen time.Time
+	LastSeen  time.Time
+}
+
+// SessionStore is the sessions table. Get one from Store.Sessions().
+type SessionStore struct{ s *Store }
+
+// Sessions returns the handle onto the sessions table.
+func (s *Store) Sessions() SessionStore { return SessionStore{s: s} }
+
+// Upsert records a session, or refreshes the mutable half of one already
+// recorded. first_seen is written once and never moved: it is when this
+// session first started something, which is what an audit of a port's history
+// asks for. last_seen always advances, because an upsert only happens when the
+// session is doing something.
+func (t SessionStore) Upsert(row SessionRow) error {
+	if row.ID == "" {
+		return fmt.Errorf("store: a session needs an id")
+	}
+	now := time.Now().UTC()
+	if row.FirstSeen.IsZero() {
+		row.FirstSeen = now
+	}
+	if row.LastSeen.IsZero() {
+		row.LastSeen = now
+	}
+	return t.s.exec(
+		`INSERT INTO sessions(id, tool, label, worktree, branch, detected, first_seen, last_seen)
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+		     tool      = excluded.tool,
+		     label     = excluded.label,
+		     worktree  = excluded.worktree,
+		     branch    = excluded.branch,
+		     detected  = excluded.detected,
+		     last_seen = excluded.last_seen`,
+		row.ID, row.Tool, row.Label, row.Worktree, row.Branch, boolInt(row.Detected),
+		timeToString(row.FirstSeen), timeToString(row.LastSeen),
+	)
+}
+
+// Touch moves a session's last_seen forward, which is what keeps a live
+// session out of the prune window. Touching an unknown session is a no-op:
+// only Upsert creates rows.
+func (t SessionStore) Touch(id string, at time.Time) error {
+	if id == "" {
+		return nil
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	return t.s.exec(`UPDATE sessions SET last_seen = ? WHERE id = ?`, timeToString(at), id)
+}
+
+// List returns every recorded session, most recently seen first.
+func (t SessionStore) List() ([]SessionRow, error) {
+	rows, err := t.s.db.Query(
+		`SELECT id, tool, label, worktree, branch, detected, first_seen, last_seen
+		   FROM sessions ORDER BY last_seen DESC, id`)
+	if err != nil {
+		return nil, fmt.Errorf("reading sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []SessionRow
+	for rows.Next() {
+		var (
+			r        SessionRow
+			detected int
+			first    string
+			last     string
+		)
+		if err := rows.Scan(&r.ID, &r.Tool, &r.Label, &r.Worktree, &r.Branch,
+			&detected, &first, &last); err != nil {
+			return nil, fmt.Errorf("reading sessions: %w", err)
+		}
+		r.Detected = detected != 0
+		r.FirstSeen = timeOrZero(first)
+		r.LastSeen = timeOrZero(last)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// Get returns one session.
+func (t SessionStore) Get(id string) (SessionRow, bool, error) {
+	all, err := t.List()
+	if err != nil {
+		return SessionRow{}, false, err
+	}
+	for _, r := range all {
+		if r.ID == id {
+			return r, true, nil
+		}
+	}
+	return SessionRow{}, false, nil
+}
+
+// Prune drops sessions last seen before cutoff and reports how many went.
+// The daemon calls it with now-sessions.Retention on a timer.
+func (t SessionStore) Prune(cutoff time.Time) (int, error) {
+	res, err := t.s.db.Exec(`DELETE FROM sessions WHERE last_seen < ?`, timeToString(cutoff))
+	if err != nil {
+		return 0, fmt.Errorf("pruning sessions: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, nil
+	}
+	return int(n), nil
+}
+
+func boolInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// timeOrZero parses a stored timestamp, yielding the zero time for a row
+// written by something that used a different layout.
+func timeOrZero(s string) time.Time {
+	t, err := timeFromString(s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,6 +6,13 @@
 // so CGO_ENABLED=0 release builds keep working.
 //
 // Only the daemon opens the store. The CLI's no-daemon path never touches it.
+//
+// Migrations are tracked per version, not by a high-water mark: schema_version
+// holds one row per applied migration and Open applies every registered
+// version that has no row. Versions 003-006 are reserved for sibling packages
+// (contract §8), so which of them a binary knows about depends on what it
+// links; a database that reached 006 without 005 registered still receives 005
+// the first time a build that owns it opens the file.
 package store
 
 import (


### PR DESCRIPTION
Roadmap step 2A.4.

- `internal/sessions`: detects the agent session from the environment (Claude Code via `CLAUDECODE` / `CLAUDE_CODE_SESSION_ID`, Cursor, Codex, generic `SONAR_SESSION`), reads worktree and branch from `.git` without a subprocess, falls back to the agent's ancestor pid on unix.
- `sonar start` / `runs.spawn` / `runs.register` carry the session; children inherit `SONAR_SESSION`; the scanner stamps `Port.session` and publishes the `sessions` collection as `SessionRecord` with counts and `active`.
- Migration 005 (`sessions` table) registered from the sessions package; the store now records one row per applied migration and applies every registered version not yet present, so 005 and 006 land in any order.
- Daemon methods `sessions.list {active_only?}`, `sessions.inspect {id}`, `sessions.kill {id, tree?, force?, dry_run?}` (kill envelope). Capability `sessions`. Sessions idle for 7 days are pruned.
- CLI: `sonar sessions [--all]`, `sonar sessions <id>`, `sonar list --session <id|current>`, `sonar kill --session <id|current>`.

Deferred: a `SESSION` column on `sonar list` (its row type lives in `internal/ports`, being changed by #57).