### PR TITLE
feat: add the mcp action tools kill, stop_group, rename_port, start_service and list_groups

### DIFF
--- a/internal/daemon/cwd_integration_test.go
+++ b/internal/daemon/cwd_integration_test.go
@@ -121,14 +121,15 @@ func TestCwdGroupsPortsUnderTheGitRoot(t *testing.T) {
 
 	// And the demo itself: the tree puts both under one heading named after the
 	// repository.
-	tree := e.command("list", "--tree")
-	tree.Dir = repo
-	treeOut, err := tree.CombinedOutput()
-	if err != nil {
-		t.Fatalf("sonar list --tree: %v\n%s", err, treeOut)
-	}
+	//
+	// The CLI's read is only as fresh as the daemon's last publish: `sonar
+	// list` is answered from the shared snapshot, so a listener ports.list has
+	// already reported can still be missing from a tree rendered a moment
+	// later, until the next scan tick lands. The render is therefore polled
+	// until both ports are under the heading, and the last output is what a
+	// failure prints.
+	treeOut, section := waitForTree(t, e, repo, repoName, rootPort, nestedPort)
 	t.Logf("sonar list --tree:\n%s", treeOut)
-	section := treeSection(string(treeOut), repoName)
 	if section == nil {
 		// The rows are in the daemon — waitForCwds proved it — so a group
 		// missing from the tree is the display filter, not the scan. `list`
@@ -143,6 +144,40 @@ func TestCwdGroupsPortsUnderTheGitRoot(t *testing.T) {
 			t.Errorf("port %d is not under the %q group:\n%s", port, repoName, treeOut)
 		}
 	}
+}
+
+// waitForTree renders `sonar list --tree` until the repository's heading holds
+// every wanted port, or the timeout expires. It returns the last output and the
+// section found in it, so the caller's assertions report the real thing rather
+// than a snapshot that was merely early.
+func waitForTree(t *testing.T, e *env, dir, name string, wanted ...int) ([]byte, []string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		tree := e.command("list", "--tree")
+		tree.Dir = dir
+		out, err := tree.CombinedOutput()
+		if err != nil {
+			t.Fatalf("sonar list --tree: %v\n%s", err, out)
+		}
+		section := treeSection(string(out), name)
+		if section != nil && hasAllPorts(section, wanted) {
+			return out, section
+		}
+		if !time.Now().Before(deadline) {
+			return out, section
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func hasAllPorts(section []string, ports []int) bool {
+	for _, port := range ports {
+		if !sectionHasPort(section, port) {
+			return false
+		}
+	}
+	return true
 }
 
 // reportPortRows prints everything about the spawned listeners that decides

--- a/internal/daemon/groups_read.go
+++ b/internal/daemon/groups_read.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// The read half of the groups namespace. A group is derived state — the
+// scanner resolves every port to a project and joins the `.sonar.yaml`
+// services onto it — so listing groups is reading the same snapshot the ports
+// read uses, not a second computation that could disagree with it.
+func init() {
+	RegisterHandler("groups.list", handleGroupsList)
+}
+
+func handleGroupsList(_ context.Context, req *Request) (any, error) {
+	groups, err := readGroups(req.Runtime)
+	if err != nil {
+		return nil, err
+	}
+	return rpc.GroupsListResult{Groups: groups}, nil
+}
+
+// readGroups is readPorts' twin: served from the cache while a subscriber
+// keeps it fresh, and from a scan otherwise (contract §20).
+func readGroups(rt *Runtime) ([]state.Group, error) {
+	if rt.Subscribers() > 0 {
+		if snap := rt.Scanner.Cached(); snap.Seq > 0 {
+			return orEmptyGroups(snap.Groups), nil
+		}
+	}
+	snap, err := rt.Scanner.Snapshot(scanner.Include{})
+	if err != nil {
+		return nil, rpc.NewError(rpc.CodeInternal, "scan failed: "+err.Error(),
+			"check `sonar daemon log` for the scanner error")
+	}
+	return orEmptyGroups(snap.Groups), nil
+}
+
+// orEmptyGroups keeps the collection an array on the wire, never null
+// (contract §6).
+func orEmptyGroups(groups []state.Group) []state.Group {
+	if groups == nil {
+		return []state.Group{}
+	}
+	return groups
+}

--- a/internal/daemon/groups_read_test.go
+++ b/internal/daemon/groups_read_test.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// TestGroupsListServesTheSnapshotsGroups: `groups.list` is the groups the scan
+// already resolved, so the list an agent reads and the groups a subscriber sees
+// cannot disagree.
+func TestGroupsListServesTheSnapshotsGroups(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newPortsHarness(t, ctx)
+
+	var res rpc.GroupsListResult
+	if e := c.call("groups.list", rpc.Empty{}, &res); e != nil {
+		t.Fatalf("groups.list: %v", e)
+	}
+	if res.Groups == nil {
+		t.Fatal("groups must always be an array, never null")
+	}
+
+	var snapshot struct {
+		Groups []state.Group `json:"groups"`
+	}
+	if e := c.call("state.snapshot", rpc.StateSnapshotParams{}, &snapshot); e != nil {
+		t.Fatalf("state.snapshot: %v", e)
+	}
+	if len(res.Groups) != len(snapshot.Groups) {
+		t.Fatalf("groups.list returned %d groups, the snapshot has %d",
+			len(res.Groups), len(snapshot.Groups))
+	}
+	for i := range res.Groups {
+		if res.Groups[i].Name != snapshot.Groups[i].Name {
+			t.Errorf("group %d = %q, snapshot says %q", i, res.Groups[i].Name, snapshot.Groups[i].Name)
+		}
+	}
+}

--- a/internal/daemon/ports.go
+++ b/internal/daemon/ports.go
@@ -229,11 +229,15 @@ func handlePortsInspect(_ context.Context, req *Request) (any, error) {
 		return nil, err
 	}
 
+	// Health goes on the wire as ok | fail | unknown, with the probe's own
+	// verdict in reason (contract §22); the raw probe vocabulary is internal.
 	probe := req.Runtime.Scanner.Probe(row.BindAddress, row.Port, "/", scanner.HealthTimeout)
+	status, reason := state.NormalizeHealth(probe.Status)
 	row.Health = &state.Health{
-		Status:    probe.Status,
+		Status:    status,
 		Code:      probe.StatusCode,
 		LatencyMs: probe.Latency.Milliseconds(),
+		Reason:    reason,
 	}
 
 	sources := []string{}

--- a/internal/daemon/ports_test.go
+++ b/internal/daemon/ports_test.go
@@ -258,6 +258,37 @@ func TestPortsInspectResolvesByBindAndPID(t *testing.T) {
 	}
 }
 
+// TestPortsInspectNormalisesHealth pins contract §22 on the inspect path: the
+// status is the published vocabulary and the probe's own word is the reason.
+// It used to publish the raw probe status, which no client's enum accepts.
+func TestPortsInspectNormalisesHealth(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newPortsHarness(t, ctx)
+
+	port := 9000
+	var res struct {
+		Port struct {
+			Health *state.Health `json:"health"`
+		} `json:"port"`
+	}
+	if e := c.call("ports.inspect", rpc.Selector{Port: &port}, &res); e != nil {
+		t.Fatalf("ports.inspect: %v", e)
+	}
+	if res.Port.Health == nil {
+		t.Fatal("ports.inspect returned no health")
+	}
+	switch res.Port.Health.Status {
+	case state.HealthOK, state.HealthFail, state.HealthUnknown:
+	default:
+		t.Errorf("health.status = %q, want ok, fail or unknown", res.Port.Health.Status)
+	}
+	// Nothing is listening on the fake row's port, so the probe is refused.
+	if res.Port.Health.Reason == "" {
+		t.Error("health.reason should carry the probe's verdict")
+	}
+}
+
 func TestPortsNextSkipsListeningPorts(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/mcpserver/fakedaemon/handlers_actions.go
+++ b/internal/mcpserver/fakedaemon/handlers_actions.go
@@ -1,0 +1,599 @@
+package fakedaemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// The write half of the fake daemon: the methods the MCP action tools call
+// (`ports.kill`, `groups.kill`, `sessions.kill`, `ports.rename`, `runs.spawn`,
+// `runs.list`, `ports.wait`). They are opt-in — RegisterActions installs them —
+// because a fake that can kill and spawn is a different thing from a fixture
+// that only answers reads, and a test should say which one it wants.
+//
+// The world they mutate is the fixture itself: a kill removes the rows it
+// killed, a rename rewrites the row's name, a spawned run's ports appear when
+// the test says they do (Actions.OpenPortForRun). So `kill` followed by
+// `list_ports` tells the same story here as against a real daemon.
+
+// Actions is the mutable state behind the write methods: the runs the fake has
+// spawned, the pids it refuses to signal, and the streams it is running. It is
+// returned by RegisterActions so a test can drive them.
+type Actions struct {
+	f *Fake
+
+	mu        sync.Mutex
+	runs      []rpc.RunRecord
+	denied    map[int]bool
+	streams   map[string]context.CancelFunc
+	seq       int
+	streamSeq int
+}
+
+// RegisterActions installs the write methods on f and returns the handle a test
+// drives them with. It is safe to call on a fake that is already serving.
+func (f *Fake) RegisterActions() *Actions {
+	a := &Actions{f: f, denied: map[int]bool{}, streams: map[string]context.CancelFunc{}}
+	f.Handle("ports.kill", a.portsKill)
+	f.Handle("groups.kill", a.groupsKill)
+	f.Handle("sessions.kill", a.sessionsKill)
+	f.Handle("ports.rename", a.portsRename)
+	f.Handle("runs.spawn", a.runsSpawn)
+	f.Handle("runs.list", a.runsList)
+	f.Handle("ports.wait", a.portsWait)
+	f.Handle(rpc.MethodStreamCancel, a.streamCancel)
+	return a
+}
+
+// DenyKill makes every attempt to signal pid come back as a failed row with the
+// killer's own permission_denied wording, the way a port owned by another user
+// behaves.
+func (a *Actions) DenyKill(pid int) {
+	a.mu.Lock()
+	a.denied[pid] = true
+	a.mu.Unlock()
+}
+
+// Runs lists what runs.spawn has started, newest last.
+func (a *Actions) Runs() []rpc.RunRecord {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]rpc.RunRecord{}, a.runs...)
+}
+
+// OpenPortForRun is the moment a spawned service starts listening: it adds a
+// port row attributed to the run, which is what makes a pending `ports.wait`
+// finish and what `wait_for_port: "auto"` polls runs.list for.
+func (a *Actions) OpenPortForRun(runID string, port int) state.Port {
+	a.mu.Lock()
+	var rec *rpc.RunRecord
+	for i := range a.runs {
+		if a.runs[i].ID == runID {
+			rec = &a.runs[i]
+		}
+	}
+	if rec != nil && !containsInt(rec.Ports, port) {
+		rec.Ports = append(rec.Ports, port)
+		rec.Status = "running"
+	}
+	var group, name string
+	var pid int
+	if rec != nil {
+		group, name, pid = rec.Group, rec.Name, rec.PID
+	}
+	a.mu.Unlock()
+
+	row := state.Port{
+		Port: port, BindAddress: "127.0.0.1", IPVersion: "IPv4",
+		URL: fmt.Sprintf("http://localhost:%d", port), PID: pid, PPID: 1,
+		Process: "python3", DisplayName: orDefault(name, "spawned"),
+		Command: "python3 -m http.server", Cwd: "/home/dev/shop",
+		Group: strp(group), GroupSource: srcp(state.SourceStart),
+		Type: state.TypeUser, User: "dev",
+		Run:         &state.Run{ID: runID, Group: group, Name: name, RootPID: pid},
+		ExposedURLs: []string{}, StartedAt: strp(FixtureTime),
+	}
+	if group == "" {
+		row.Group = nil
+	}
+	a.f.mu.Lock()
+	a.f.fixture.Ports = append(a.f.fixture.Ports, row)
+	a.f.mu.Unlock()
+	return row
+}
+
+// ------------------------------------------------------------------ kills ---
+
+func (a *Actions) portsKill(raw json.RawMessage) (any, error) {
+	var p rpc.PortsKillParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if len(p.Targets) == 0 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "targets is required",
+			`send {"targets": [{"port": 3000}]}`)
+	}
+
+	rows := []state.KillResult{}
+	for _, sel := range p.Targets {
+		if err := checkSelector(sel); err != nil {
+			return nil, err
+		}
+		matches := a.match(sel)
+		if len(matches) == 0 {
+			rows = append(rows, missingRow(sel))
+			continue
+		}
+		for _, row := range matches {
+			rows = append(rows, a.killRows(row, p.Tree, p.Force)...)
+		}
+	}
+	return a.finishKill(rows, p.DryRun), nil
+}
+
+func (a *Actions) groupsKill(raw json.RawMessage) (any, error) {
+	var p rpc.GroupsKillParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "name is required", `send {"name": "my-app"}`)
+	}
+	var matches []state.Port
+	for _, row := range a.f.Fixture().Ports {
+		if inGroupFold(row, p.Name) {
+			matches = append(matches, row)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, rpc.NewError(rpc.CodeNotFound,
+			"no listening port belongs to group "+p.Name,
+			"run `sonar groups` to see what is grouped right now")
+	}
+
+	rows := []state.KillResult{}
+	for _, row := range matches {
+		// A group kill is always a tree kill of each member (contract §17).
+		rows = append(rows, a.killRows(row, true, p.Force)...)
+	}
+	return a.finishKill(rows, p.DryRun), nil
+}
+
+func (a *Actions) sessionsKill(raw json.RawMessage) (any, error) {
+	var p rpc.SessionsKillParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(p.ID) == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "id is required", `send {"id": "claude-code:9f2c"}`)
+	}
+	var matches []state.Port
+	for _, row := range a.f.Fixture().Ports {
+		if row.Session != nil && (row.Session.ID == p.ID || row.Session.Label == p.ID) {
+			matches = append(matches, row)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, rpc.NewError(rpc.CodeNotFound,
+			"no live run belongs to session "+p.ID,
+			"run `sonar sessions` to see which sessions are active")
+	}
+
+	rows := []state.KillResult{}
+	for _, row := range matches {
+		rows = append(rows, a.killRows(row, p.Tree, p.Force)...)
+	}
+	return a.finishKill(rows, p.DryRun), nil
+}
+
+// killRows is what the killer would report for one listening row: a container
+// is stopped rather than signalled, and a tree kill of a `sonar start` run
+// signals the child before the run root (contract §17).
+func (a *Actions) killRows(row state.Port, tree, force bool) []state.KillResult {
+	if row.Docker != nil {
+		return []state.KillResult{{
+			Port: row.Port, BindAddress: row.BindAddress, PID: 0,
+			Name: row.Docker.Container, Method: state.MethodDockerStop, OK: true,
+		}}
+	}
+
+	method := state.MethodSIGTERM
+	if force {
+		method = state.MethodSIGKILL
+	}
+	pids := []int{row.PID}
+	if tree && row.Run != nil && row.Run.RootPID != 0 && row.Run.RootPID != row.PID {
+		pids = append(pids, row.Run.RootPID)
+	}
+
+	out := make([]state.KillResult, 0, len(pids))
+	for _, pid := range pids {
+		res := state.KillResult{
+			Port: row.Port, BindAddress: row.BindAddress, PID: pid,
+			Name: row.DisplayName, Method: method, OK: true,
+		}
+		if a.isDenied(pid) {
+			res.Method = state.MethodNone
+			res.OK = false
+			res.Error = fmt.Sprintf("not permitted to signal PID %d", pid)
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+// finishKill wraps the rows in the contract §3 envelope and, for a real kill,
+// takes the ports it killed out of the fixture — the rescan §22 requires,
+// played back at fixture speed.
+func (a *Actions) finishKill(rows []state.KillResult, dryRun bool) rpc.KillEnvelope {
+	env := rpc.KillEnvelope{Results: rows}
+	env.OK = true
+	env.Affected = []string{}
+	seen := map[string]bool{}
+	killed := map[string]bool{}
+	for _, r := range rows {
+		if !r.OK {
+			env.OK = false
+			continue
+		}
+		killed[r.Key()] = true
+		key := r.Key()
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		env.Affected = append(env.Affected, key)
+	}
+
+	if !dryRun && len(killed) > 0 {
+		kept := []state.Port{}
+		for _, row := range a.f.Fixture().Ports {
+			if !killed[row.Key()] {
+				kept = append(kept, row)
+			}
+		}
+		a.f.SetPorts(kept)
+	}
+	return env
+}
+
+// ----------------------------------------------------------------- rename ---
+
+func (a *Actions) portsRename(raw json.RawMessage) (any, error) {
+	var p rpc.PortsRenameParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	target, err := resolvePort(a.f.Fixture().Ports, p.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	a.f.mu.Lock()
+	for i := range a.f.fixture.Ports {
+		row := &a.f.fixture.Ports[i]
+		if row.Key() != target.Key() {
+			continue
+		}
+		if p.Name == nil || strings.TrimSpace(*p.Name) == "" {
+			row.Name = nil
+			row.DisplayName = row.Process
+			continue
+		}
+		name := strings.TrimSpace(*p.Name)
+		row.Name = &name
+		row.DisplayName = name
+	}
+	a.f.mu.Unlock()
+
+	return rpc.PortsRenameResult{
+		MutationResult: rpc.MutationResult{OK: true, Affected: []string{target.Key()}},
+		Key:            target.Key(),
+		Name:           p.Name,
+	}, nil
+}
+
+// ------------------------------------------------------------------- runs ---
+
+func (a *Actions) runsSpawn(raw json.RawMessage) (any, error) {
+	var p rpc.RunsSpawnParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if len(p.Argv) == 0 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "argv is required",
+			`send {"argv": ["npm", "run", "dev"], "cwd": "/path/to/repo"}`)
+	}
+	if strings.TrimSpace(p.Cwd) == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "cwd is required",
+			`send the absolute path the command should run in`)
+	}
+
+	a.mu.Lock()
+	a.seq++
+	rec := rpc.RunRecord{
+		ID:        fmt.Sprintf("run-fake-%d", a.seq),
+		PID:       31000 + a.seq,
+		Group:     orDefault(deref(p.Group), filepath.Base(p.Cwd)),
+		Name:      orDefault(deref(p.Name), p.Argv[0]),
+		Cmd:       strings.Join(p.Argv, " "),
+		Cwd:       p.Cwd,
+		StartedAt: FixtureTime,
+		Ports:     []int{},
+		Status:    "starting",
+	}
+	if p.PortHint != nil {
+		hint := *p.PortHint
+		rec.PortHint = &hint
+	}
+	a.runs = append(a.runs, rec)
+	a.mu.Unlock()
+
+	return rpc.RunsSpawnResult{
+		// Contract §19: a run has no ports at the moment it starts.
+		MutationResult: rpc.MutationResult{OK: true, Affected: []string{}},
+		RunID:          rec.ID,
+		PID:            rec.PID,
+		LogPath:        filepath.Join("/home/dev/.config/sonar/logs", rec.ID+".log"),
+	}, nil
+}
+
+func (a *Actions) runsList(json.RawMessage) (any, error) {
+	return rpc.RunsListResult{Runs: a.Runs()}, nil
+}
+
+// ------------------------------------------------------------------- wait ---
+
+// portsWait is the streaming half of the fake: it replies with a subscription
+// id and then polls its own fixture, pushing one chunk per port that starts
+// listening and ending with {ready, timed_out}.
+func (a *Actions) portsWait(raw json.RawMessage) (any, error) {
+	var p rpc.PortsWaitParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if len(p.Ports) == 0 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "ports is required",
+			`send {"ports": [3000], "timeout_ms": 30000}`)
+	}
+	if p.TimeoutMs <= 0 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "timeout_ms must be positive", "")
+	}
+	interval := 20 * time.Millisecond
+	if p.IntervalMs > 0 {
+		interval = time.Duration(p.IntervalMs) * time.Millisecond
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.mu.Lock()
+	a.streamSeq++
+	id := fmt.Sprintf("sub-%d", a.streamSeq)
+	a.streams[id] = cancel
+	a.mu.Unlock()
+
+	go a.pumpWait(ctx, id, p, interval)
+	return rpc.StreamStart{SubscriptionID: id}, nil
+}
+
+func (a *Actions) pumpWait(ctx context.Context, id string, p rpc.PortsWaitParams, interval time.Duration) {
+	defer a.endStream(id)
+
+	pending := map[int]bool{}
+	for _, port := range p.Ports {
+		pending[port] = true
+	}
+	ready := []int{}
+	deadline := time.NewTimer(time.Duration(p.TimeoutMs) * time.Millisecond)
+	defer deadline.Stop()
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+
+	for {
+		for _, port := range p.Ports {
+			if !pending[port] || !a.listening(port) {
+				continue
+			}
+			delete(pending, port)
+			ready = append(ready, port)
+			raw, _ := json.Marshal(rpc.PortsWaitChunk{Port: port, ReadyAt: FixtureTime})
+			a.f.broadcast(rpc.MethodStreamChunk, rpc.StreamChunk{ID: id, Data: raw})
+		}
+		if len(pending) == 0 || (p.Any && len(ready) > 0) {
+			a.finishStream(id, rpc.PortsWaitEnd{Ready: ready, TimedOut: []int{}})
+			return
+		}
+		select {
+		case <-ctx.Done():
+			a.finishStream(id, rpc.PortsWaitEnd{Ready: ready, TimedOut: stillPending(p.Ports, pending)})
+			return
+		case <-deadline.C:
+			a.finishStream(id, rpc.PortsWaitEnd{Ready: ready, TimedOut: stillPending(p.Ports, pending)})
+			return
+		case <-tick.C:
+		}
+	}
+}
+
+func (a *Actions) streamCancel(raw json.RawMessage) (any, error) {
+	var p rpc.StreamCancel
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	a.mu.Lock()
+	cancel, ok := a.streams[p.ID]
+	a.mu.Unlock()
+	if !ok {
+		return nil, rpc.NewError(rpc.CodeNotFound, "unknown stream "+p.ID, "")
+	}
+	cancel()
+	return rpc.OKResult{OK: true}, nil
+}
+
+func (a *Actions) finishStream(id string, end any) {
+	raw, _ := json.Marshal(end)
+	a.f.broadcast(rpc.MethodStreamEnd, rpc.StreamEnd{ID: id, Data: raw})
+}
+
+func (a *Actions) endStream(id string) {
+	a.mu.Lock()
+	if cancel, ok := a.streams[id]; ok {
+		cancel()
+		delete(a.streams, id)
+	}
+	a.mu.Unlock()
+}
+
+// broadcast pushes a notification to every open connection. Streams are
+// per-connection in the daemon; the fake serves one client per test, so
+// addressing them all is the same thing and keeps handlers connection-free.
+func (f *Fake) broadcast(method string, params any) {
+	f.mu.Lock()
+	conns := make([]*conn, 0, len(f.conns))
+	for c := range f.conns {
+		conns = append(conns, c)
+	}
+	f.mu.Unlock()
+	for _, c := range conns {
+		c.notify(method, params)
+	}
+}
+
+// ---------------------------------------------------------------- helpers ---
+
+func (a *Actions) listening(port int) bool {
+	for _, row := range a.f.Fixture().Ports {
+		if row.Port == port {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *Actions) isDenied(pid int) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.denied[pid]
+}
+
+// match resolves a kill selector against the fixture. Unlike ports.inspect a
+// kill is not ambiguous over several bind addresses: it kills them all.
+func (a *Actions) match(sel rpc.Selector) []state.Port {
+	var out []state.Port
+	for _, row := range a.f.Fixture().Ports {
+		switch {
+		case sel.Port != nil:
+			if row.Port != *sel.Port {
+				continue
+			}
+			if sel.BindAddress != nil && *sel.BindAddress != "" && row.BindAddress != *sel.BindAddress {
+				continue
+			}
+		case sel.PID != nil:
+			if row.PID != *sel.PID {
+				continue
+			}
+		case sel.RunID != nil:
+			if row.Run == nil || row.Run.ID != *sel.RunID {
+				continue
+			}
+		default:
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// missingRow is what the killer reports for a target nothing answers on: a
+// failed row, not a failed call, so one bad target does not lose the others.
+func missingRow(sel rpc.Selector) state.KillResult {
+	res := state.KillResult{Method: state.MethodNone}
+	switch {
+	case sel.Port != nil:
+		res.Port = *sel.Port
+		res.Error = fmt.Sprintf("no process found listening on port %d", *sel.Port)
+	case sel.PID != nil:
+		res.PID = *sel.PID
+		res.Error = fmt.Sprintf("no process found with pid %d", *sel.PID)
+	case sel.RunID != nil:
+		res.Error = "no live run " + *sel.RunID
+	}
+	return res
+}
+
+func checkSelector(sel rpc.Selector) error {
+	set := 0
+	for _, on := range []bool{sel.Port != nil, sel.PID != nil, sel.RunID != nil, sel.ProxyID != nil} {
+		if on {
+			set++
+		}
+	}
+	if set != 1 {
+		return rpc.NewError(rpc.CodeInvalidSelector,
+			"a selector sets exactly one of port, pid, run_id and proxy_id",
+			`bind_address only disambiguates port, for example {"port": 3000, "bind_address": "127.0.0.1"}`)
+	}
+	return nil
+}
+
+// inGroupFold is `sonar kill -g`'s matching: the resolved group, a run's group,
+// id or name, or a compose project, case-insensitively (contract §17).
+func inGroupFold(p state.Port, name string) bool {
+	candidates := []string{}
+	if p.Group != nil {
+		candidates = append(candidates, *p.Group)
+	}
+	if p.Run != nil {
+		candidates = append(candidates, p.Run.Group, p.Run.ID, p.Run.Name)
+	}
+	if p.Docker != nil {
+		candidates = append(candidates, p.Docker.ComposeProject)
+	}
+	for _, c := range candidates {
+		if c != "" && strings.EqualFold(c, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func stillPending(targets []int, pending map[int]bool) []int {
+	out := []int{}
+	for _, port := range targets {
+		if pending[port] {
+			out = append(out, port)
+		}
+	}
+	return out
+}
+
+func containsInt(xs []int, want int) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func orDefault(v, fallback string) string {
+	if strings.TrimSpace(v) == "" {
+		return fallback
+	}
+	return v
+}

--- a/internal/mcpserver/fakedaemon/schema_actions_test.go
+++ b/internal/mcpserver/fakedaemon/schema_actions_test.go
@@ -1,0 +1,145 @@
+package fakedaemon_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/mcpserver/fakedaemon"
+)
+
+// TestActionRepliesValidateAgainstTheProtocolSchema is the read half's test
+// applied to the write half: every reply the action methods produce is checked
+// against docs/schema/protocol.schema.json, so a tool tested against the fake
+// is tested against the published contract.
+func TestActionRepliesValidateAgainstTheProtocolSchema(t *testing.T) {
+	fake := start(t, fakedaemon.DefaultFixture())
+	fake.RegisterActions()
+	c := dial(t, fake)
+
+	cases := []struct {
+		method string
+		params any
+		def    string
+	}{
+		{"ports.kill", rpc.PortsKillParams{Targets: []rpc.Selector{{Port: intp(3000)}}, Tree: true, DryRun: true}, "KillEnvelope"},
+		{"ports.kill", rpc.PortsKillParams{Targets: []rpc.Selector{{Port: intp(5432)}}, DryRun: true}, "KillEnvelope"},
+		{"groups.kill", rpc.GroupsKillParams{Name: "shop", DryRun: true}, "KillEnvelope"},
+		{"sessions.kill", rpc.SessionsKillParams{ID: "claude-code:9f2c", DryRun: true}, "KillEnvelope"},
+		{"ports.rename", rpc.PortsRenameParams{Selector: rpc.Selector{Port: intp(5173)}, Name: strp("storefront")}, "PortsRenameResult"},
+		{"runs.spawn", rpc.RunsSpawnParams{Argv: []string{"npm", "run", "dev"}, Cwd: "/home/dev/shop"}, "RunsSpawnResult"},
+		{"runs.list", rpc.Empty{}, "RunsListResult"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method+"/"+tc.def, func(t *testing.T) {
+			var raw json.RawMessage
+			if err := c.Call(t.Context(), tc.method, tc.params, &raw); err != nil {
+				t.Fatalf("%s: %v", tc.method, err)
+			}
+			validate(t, tc.def, raw)
+		})
+	}
+}
+
+// TestPortsWaitStreamsLikeTheDaemon: the reply carries a subscription id, the
+// chunks and the end are the contract §1 envelope, and the end's payload is
+// PortsWaitEnd (contract §20).
+func TestPortsWaitStreamsLikeTheDaemon(t *testing.T) {
+	fake := start(t, fakedaemon.DefaultFixture())
+	actions := fake.RegisterActions()
+	c := dial(t, fake)
+
+	var spawned rpc.RunsSpawnResult
+	if err := c.Call(t.Context(), "runs.spawn", rpc.RunsSpawnParams{
+		Argv: []string{"python3", "-m", "http.server", "8000"}, Cwd: "/home/dev/shop",
+	}, &spawned); err != nil {
+		t.Fatalf("runs.spawn: %v", err)
+	}
+
+	stream, err := c.Stream(t.Context(), "ports.wait", rpc.PortsWaitParams{
+		Ports: []int{8000}, TimeoutMs: 5000, IntervalMs: 20,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ports.wait: %v", err)
+	}
+	if stream.ID() == "" {
+		t.Fatal("the reply carried no subscription id")
+	}
+	time.AfterFunc(50*time.Millisecond, func() { actions.OpenPortForRun(spawned.RunID, 8000) })
+
+	var chunks []rpc.PortsWaitChunk
+	for raw := range stream.Chunks() {
+		var chunk rpc.PortsWaitChunk
+		if err := json.Unmarshal(raw, &chunk); err != nil {
+			t.Fatalf("decoding a chunk: %v", err)
+		}
+		chunks = append(chunks, chunk)
+	}
+	end := <-stream.End()
+	if end.Err != nil {
+		t.Fatalf("the stream ended with an error: %v", end.Err)
+	}
+	var out rpc.PortsWaitEnd
+	if err := end.Decode(&out); err != nil {
+		t.Fatalf("decoding stream.end: %v", err)
+	}
+
+	if len(chunks) != 1 || chunks[0].Port != 8000 {
+		t.Errorf("chunks = %+v, want one for port 8000", chunks)
+	}
+	if len(out.Ready) != 1 || out.Ready[0] != 8000 || len(out.TimedOut) != 0 {
+		t.Errorf("end = %+v, want ready 8000", out)
+	}
+}
+
+func TestPortsWaitTimesOut(t *testing.T) {
+	fake := start(t, fakedaemon.DefaultFixture())
+	fake.RegisterActions()
+	c := dial(t, fake)
+
+	stream, err := c.Stream(t.Context(), "ports.wait", rpc.PortsWaitParams{
+		Ports: []int{8100}, TimeoutMs: 100, IntervalMs: 20,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ports.wait: %v", err)
+	}
+	for range stream.Chunks() {
+	}
+	var out rpc.PortsWaitEnd
+	if err := (<-stream.End()).Decode(&out); err != nil {
+		t.Fatalf("decoding stream.end: %v", err)
+	}
+	if len(out.Ready) != 0 || len(out.TimedOut) != 1 || out.TimedOut[0] != 8100 {
+		t.Errorf("end = %+v, want 8100 timed out", out)
+	}
+}
+
+// TestKillRemovesWhatItKilled is what makes the fake usable for a two-step
+// test: a kill is visible to the next read, as the daemon's rescan makes it.
+func TestKillRemovesWhatItKilled(t *testing.T) {
+	fake := start(t, fakedaemon.DefaultFixture())
+	fake.RegisterActions()
+	c := dial(t, fake)
+
+	var env rpc.KillEnvelope
+	if err := c.Call(t.Context(), "ports.kill", rpc.PortsKillParams{
+		Targets: []rpc.Selector{{Port: intp(5173)}},
+	}, &env); err != nil {
+		t.Fatalf("ports.kill: %v", err)
+	}
+	if !env.OK || len(env.Affected) != 1 {
+		t.Fatalf("envelope = %+v, want one affected key", env)
+	}
+
+	var list rpc.PortsListResult
+	if err := c.Call(t.Context(), "ports.list", rpc.PortsListParams{}, &list); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range list.Ports {
+		if p.Port == 5173 {
+			t.Fatal("the killed port is still listed")
+		}
+	}
+}

--- a/internal/mcpserver/integration_actions_test.go
+++ b/internal/mcpserver/integration_actions_test.go
@@ -1,0 +1,216 @@
+//go:build integration
+
+// Step 2A.2's acceptance demo in executable form: against a real daemon and a
+// real git repo, an agent starts a service through `start_service`, sees it in
+// `list_groups`, plans a `kill` with dry_run and then frees the port.
+//
+// Run with `go test -tags integration -run TestActionToolsDemo -v ./internal/mcpserver/...`.
+package mcpserver_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/mcpserver"
+)
+
+func TestActionToolsDemo(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 is not installed")
+	}
+
+	e := newRealEnv(t)
+	repo := e.gitRepo(t, "shop")
+	port := freePort(t)
+	session := e.connect(t)
+
+	// 1. Start a service under sonar and wait for it to accept connections.
+	started := callTool(t, session, "start_service", map[string]any{
+		"command":         []any{python, "-m", "http.server", strconv.Itoa(port)},
+		"cwd":             repo,
+		"name":            "docs",
+		"wait_for_port":   port,
+		"timeout_seconds": 30,
+	})
+	t.Logf("start_service →\n%s", textOf(started))
+	if started.IsError {
+		t.Fatalf("start_service failed: %s\nstderr:\n%s", textOf(started), e.stderr())
+	}
+	var svc mcpserver.StartServiceOutput
+	decodeStructured(t, started, &svc)
+	t.Cleanup(func() {
+		if isListening(port) {
+			e.run(t, "kill", "--force", strconv.Itoa(port))
+		}
+	})
+
+	if svc.RunID == "" || svc.PID == 0 {
+		t.Fatalf("start_service returned no run: %+v", svc)
+	}
+	if len(svc.Ports) != 1 || svc.Ports[0].Port != port {
+		t.Fatalf("start_service reported ports %+v, want the row for %d", svc.Ports, port)
+	}
+	if svc.Ports[0].Group == nil || *svc.Ports[0].Group != "shop" {
+		t.Errorf("the port was not attributed to the repo's group: %+v", svc.Ports[0])
+	}
+	if svc.LogPath == "" {
+		t.Error("start_service did not report where the logs went")
+	}
+
+	// 2. The group listing shows what was started.
+	groups := callTool(t, session, "list_groups", map[string]any{})
+	t.Logf("list_groups →\n%s", textOf(groups))
+	if groups.IsError {
+		t.Fatalf("list_groups failed: %s", textOf(groups))
+	}
+	var groupList mcpserver.ListGroupsOutput
+	decodeStructured(t, groups, &groupList)
+	found := false
+	for _, g := range groupList.Groups {
+		if g.Name == "shop" && containsInt(g.Members, port) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("group shop does not list port %d: %s", port, mustJSON(t, groupList.Groups))
+	}
+
+	// 3. Plan the kill before doing it.
+	dry := callTool(t, session, "kill", map[string]any{"port": port, "dry_run": true})
+	t.Logf("kill {port: %d, dry_run: true} →\n%s", port, textOf(dry))
+	if dry.IsError {
+		t.Fatalf("the dry run failed: %s", textOf(dry))
+	}
+	var plan mcpserver.KillOutput
+	decodeStructured(t, dry, &plan)
+	if !plan.DryRun || len(plan.Killed) == 0 {
+		t.Fatalf("dry run = %+v, want a plan", plan)
+	}
+	if !isListening(port) {
+		t.Fatal("the dry run stopped the service")
+	}
+
+	// 4. Free the port for real.
+	killed := callTool(t, session, "kill", map[string]any{"port": port})
+	t.Logf("kill {port: %d} →\n%s", port, textOf(killed))
+	if killed.IsError {
+		t.Fatalf("kill failed: %s", textOf(killed))
+	}
+	var out mcpserver.KillOutput
+	decodeStructured(t, killed, &out)
+	if len(out.Killed) == 0 || len(out.Failed) != 0 {
+		t.Fatalf("kill = %+v", out)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for isListening(port) {
+		if time.Now().After(deadline) {
+			t.Fatalf("port %d is still listening after kill", port)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Logf("port %d is free", port)
+}
+
+// TestRenamePortOverStdio names a port this test owns and reads the row back.
+func TestRenamePortOverStdio(t *testing.T) {
+	e := newRealEnv(t)
+	port := e.listen(t)
+	session := e.connect(t)
+
+	res := callTool(t, session, "rename_port", map[string]any{"port": port, "name": "itest-listener"})
+	t.Logf("rename_port →\n%s", textOf(res))
+	if res.IsError {
+		t.Fatalf("rename_port failed: %s\nstderr:\n%s", textOf(res), e.stderr())
+	}
+	var out mcpserver.RenamePortOutput
+	decodeStructured(t, res, &out)
+	if out.Port.Name == nil || *out.Port.Name != "itest-listener" {
+		t.Fatalf("the row does not carry the name: %+v", out.Port)
+	}
+}
+
+// TestKillNothingIsAFailedRow: an unused port is a result an agent can read,
+// not a protocol error.
+func TestKillNothingIsAFailedRow(t *testing.T) {
+	e := newRealEnv(t)
+	session := e.connect(t)
+
+	res := callTool(t, session, "kill", map[string]any{"port": freePort(t)})
+	if res.IsError {
+		t.Fatalf("kill of an unused port should not be an error result: %s", textOf(res))
+	}
+	var out mcpserver.KillOutput
+	decodeStructured(t, res, &out)
+	if len(out.Killed) != 0 || len(out.Failed) != 1 {
+		t.Fatalf("kill = %+v, want one failed row", out)
+	}
+	t.Logf("kill of an unused port →\n%s", textOf(res))
+}
+
+func callTool(t *testing.T, session *mcp.ClientSession, name string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf("%s: protocol error: %v", name, err)
+	}
+	return res
+}
+
+// gitRepo makes a repository inside the test's HOME, which is what sonar
+// resolves a group from — and what the daemon requires of a spawn's cwd.
+func (e *realEnv) gitRepo(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(e.home, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	return dir
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func isListening(port int) bool {
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:"+strconv.Itoa(port), time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func containsInt(xs []int, want int) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcpserver/integration_test.go
+++ b/internal/mcpserver/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -44,8 +45,10 @@ func TestRealDaemonToolsList(t *testing.T) {
 		t.Logf("%-13s readOnly=%v openWorld=%v", tool.Name,
 			tool.Annotations.ReadOnlyHint, *tool.Annotations.OpenWorldHint)
 	}
-	if len(names) != 2 || names[0] != "inspect_port" && names[0] != "list_ports" {
-		t.Fatalf("tools/list = %v, want list_ports and inspect_port", names)
+	for _, want := range []string{"list_ports", "inspect_port"} {
+		if !slices.Contains(names, want) {
+			t.Fatalf("tools/list = %v, want it to include %s", names, want)
+		}
 	}
 }
 

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -120,10 +120,8 @@ func TestToolsListAdvertisesTheReadTools(t *testing.T) {
 	for _, tool := range res.Tools {
 		byName[tool.Name] = tool
 	}
-	if len(byName) != 2 {
-		t.Fatalf("tools/list returned %d tools, want 2: %v", len(byName), byName)
-	}
-
+	// The tool set is the sum of the tools_*.go files, so this asserts what the
+	// read tools promise rather than how many tools the server has in total.
 	for _, name := range []string{"list_ports", "inspect_port"} {
 		tool, ok := byName[name]
 		if !ok {

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -98,8 +98,23 @@ func New(ctx context.Context, opts Options) (*Server, error) {
 		log:        log,
 		ownsDaemon: owns,
 	}
-	s.addReadTools()
+	for _, register := range toolRegistrars {
+		register(s)
+	}
 	return s, nil
+}
+
+// toolRegistrars holds one function per tools_*.go file, each adding that
+// file's tools to a new server. The list exists so a file can own its tools
+// end to end — schema, description, handler and registration — instead of
+// naming them here as well: the tool set is the sum of the files, and two
+// slices adding tools in parallel never touch the same line.
+var toolRegistrars []func(*Server)
+
+// registerTools adds a file's registrar. Call it from an init in the file that
+// declares the tools.
+func registerTools(register func(*Server)) {
+	toolRegistrars = append(toolRegistrars, register)
 }
 
 // MCP exposes the underlying server so later slices can add resources and

--- a/internal/mcpserver/tools_actions.go
+++ b/internal/mcpserver/tools_actions.go
@@ -1,0 +1,923 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/sessions"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// The action tools: the four that change something (`kill`, `stop_group`,
+// `rename_port`, `start_service`) and the group listing they are usually paired
+// with. Each is still one daemon call — or, for `start_service`, a spawn
+// followed by a wait — and the daemon does the work; what lives here is the
+// selector rule, the shape spec 2 §1.1 fixes for the result, and a sentence a
+// model can read without parsing JSON.
+
+func init() { registerTools((*Server).addActionTools) }
+
+// CapabilitySessions is the daemon capability behind `kill {session}`. Until
+// the daemon advertises it, the selector is answered with capability_missing
+// rather than a method-not-found from the wire (contract §21).
+const CapabilitySessions = "sessions"
+
+// defaultWaitSeconds and maxWaitSeconds bound start_service's readiness wait
+// (spec 2, "Concurrency and timeouts").
+const (
+	defaultWaitSeconds = 30
+	maxWaitSeconds     = 300
+)
+
+// autoPort is the wait_for_port value that means "whatever port the service
+// opens": the tool waits for the run's process tree to start listening and
+// reports the port it found.
+const autoPort = "auto"
+
+// ------------------------------------------------------------------- kill ---
+
+// KillInput is the argument set of kill. Exactly one selector must be set
+// (spec 2, "Error model"); there is deliberately no "all".
+type KillInput struct {
+	Port    int    `json:"port,omitempty" jsonschema:"Stop whatever is listening on this TCP port."`
+	PID     int    `json:"pid,omitempty" jsonschema:"Stop this process. Use it when a port is bound by more than one process and list_ports told you which pid you mean."`
+	Group   string `json:"group,omitempty" jsonschema:"Stop every port in this group: a project, a compose project or a sonar start run. Same as stop_group."`
+	Session string `json:"session,omitempty" jsonschema:"Stop everything an agent session started, by session id. Use it to clean up after yourself at the end of a task."`
+	RunID   string `json:"run_id,omitempty" jsonschema:"Stop the run with this id, as reported by start_service."`
+	Tree    *bool  `json:"tree,omitempty" jsonschema:"Kill the whole process tree, so npm to vite to esbuild chains leave no orphans. Defaults to true; set it to false only to signal the single process you named."`
+	Force   bool   `json:"force,omitempty" jsonschema:"Send SIGKILL instead of SIGTERM. Skips the process's own shutdown, so it can lose unsaved state; try without it first."`
+	DryRun  bool   `json:"dry_run,omitempty" jsonschema:"Report what would be stopped, and stop nothing. Use this first when you did not start the process yourself."`
+}
+
+// KilledProcess is one process (or container) that was stopped, or that a dry
+// run says would be stopped.
+type KilledProcess struct {
+	Port   int    `json:"port"`
+	PID    int    `json:"pid"`
+	Name   string `json:"name"`
+	Method string `json:"method"`
+}
+
+// FailedProcess is one target that could not be stopped, with the daemon's
+// reason: usually another user's process, or nothing listening at all.
+type FailedProcess struct {
+	Port  int    `json:"port"`
+	PID   int    `json:"pid"`
+	Error string `json:"error"`
+}
+
+// KillOutput is the shape spec 2 §1.1 gives kill and stop_group. It is the
+// daemon's kill envelope (contract §3) split by outcome, because that is the
+// question the caller has: what stopped, and what did not.
+type KillOutput struct {
+	Killed []KilledProcess `json:"killed"`
+	Failed []FailedProcess `json:"failed"`
+	// DryRun echoes the argument, so a result read on its own cannot be
+	// mistaken for a kill that happened.
+	DryRun bool `json:"dry_run"`
+}
+
+const killDescription = `Stop whatever is listening on a port, or an entire group or agent session.
+
+Kills the full process tree by default so ` + "`npm → vite → esbuild`" + ` chains do not leave orphans. Prefer dry_run: true first when you did not start the process yourself. Never use this to free a port you have not inspected.
+
+Pass exactly one of port, pid, group, session or run_id. There is no "kill everything": a port owned by another worktree, another agent session or a human is not yours to free — pick a different port and say so instead.`
+
+const stopGroupDescription = `Stop every service in one group: a project's api, web and workers in a single call.
+
+A group is what sonar attributes ports to — a .sonar.yaml project, a Docker Compose project, or a sonar start run. This is the cleanup you want at the end of a task that brought a project up; list_groups shows the names.
+
+Kills the process tree of every member. Pass dry_run: true first if you did not start the group yourself.`
+
+// ------------------------------------------------------------ rename_port ---
+
+// RenamePortInput is the argument set of rename_port.
+type RenamePortInput struct {
+	Port int    `json:"port,omitempty" jsonschema:"The listening port to rename."`
+	PID  int    `json:"pid,omitempty" jsonschema:"The pid to rename, when several processes answer on one port."`
+	Name string `json:"name" jsonschema:"The label to show for this port from now on, for example \"checkout-api\". An empty string removes a label set earlier."`
+}
+
+// RenamePortOutput is `{port: Port}`: the row as it now reads.
+type RenamePortOutput struct {
+	Port state.Port `json:"port"`
+}
+
+const renamePortDescription = `Give a port a lasting, human name, so it reads as "checkout-api" instead of "node" in every later listing.
+
+The name is stored by the daemon and survives restarts of the process and of the daemon. Use it when a process's own command line says nothing useful — a bare node, python or java — and you or the user will look at this machine's ports again.
+
+It renames a label, not a process: nothing is signalled and nothing restarts. Calling it twice with the same name changes nothing.`
+
+// ---------------------------------------------------------- start_service ---
+
+// StartServiceInput is the argument set of start_service. Command is argv, not
+// a shell line: the daemon never passes it through a shell (spec 2, §5).
+type StartServiceInput struct {
+	Command        []string          `json:"command" jsonschema:"The command as an argv array, for example [\"npm\", \"run\", \"dev\"]. It is executed directly, never through a shell, so pipes, redirections and && do not work here."`
+	Cwd            string            `json:"cwd,omitempty" jsonschema:"Directory to run in. Defaults to the directory this MCP server was started in, which is usually the repository root."`
+	Group          string            `json:"group,omitempty" jsonschema:"Group to attribute the service to. Defaults to the project sonar infers from cwd, which is normally what you want."`
+	Name           string            `json:"name,omitempty" jsonschema:"Short name for this service, shown in listings, for example \"api\"."`
+	Env            map[string]string `json:"env,omitempty" jsonschema:"Extra environment variables. They are added to the daemon's spawn environment, never replace it."`
+	WaitForPort    any               `json:"wait_for_port,omitempty" jsonschema:"Block until the service is accepting connections: a port number, or \"auto\" to wait for whatever port it opens. Leave it out to return as soon as the process has started."`
+	TimeoutSeconds int               `json:"timeout_seconds,omitempty" jsonschema:"How long to wait for wait_for_port, in seconds. Default 30, maximum 300."`
+}
+
+// StartServiceOutput is the shape spec 2 §1.1 gives start_service. Session is
+// the object every other tool reports (contract §5), null when nothing in this
+// server's environment names an agent. TimedOut and Error are set together
+// when wait_for_port ran out: the run is still there and its id, pid and log
+// path are how you go and look at it.
+type StartServiceOutput struct {
+	RunID    string         `json:"run_id"`
+	PID      int            `json:"pid"`
+	Group    string         `json:"group"`
+	Name     string         `json:"name"`
+	Session  *state.Session `json:"session"`
+	Ports    []state.Port   `json:"ports"`
+	LogPath  string         `json:"log_path"`
+	TimedOut bool           `json:"timed_out,omitempty"`
+	Error    *ErrorInfo     `json:"error,omitempty"`
+}
+
+// ErrorInfo is the {code, message, hint} object every failed tool result
+// carries. start_service embeds it beside the run it did start, so a timeout
+// does not cost the caller the run id it needs to investigate.
+type ErrorInfo struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Hint    string `json:"hint"`
+}
+
+const startServiceDescription = `Start a dev server or service under sonar's supervision instead of running it bare in a shell.
+
+The process survives this tool call, is attributed to your session and the repo's group, and its logs are captured for tail_logs. Pass wait_for_port to block until it is accepting connections.
+
+Use this instead of a background shell command: nothing here needs & or nohup, and a service started this way can be found and stopped later with list_ports, list_groups and kill. Pass the command as an argv array; it is not run through a shell.`
+
+// ------------------------------------------------------------ list_groups ---
+
+// ListGroupsOutput is `{groups: [Group]}`, the shape of groups.list.
+type ListGroupsOutput = rpc.GroupsListResult
+
+const listGroupsDescription = `List the projects sonar knows about: their ports, their status, and the services declared in each .sonar.yaml.
+
+A group is a project — a directory with a .sonar.yaml, a Docker Compose project, or a repo something was started in. Use it to see what a project is meant to run and what of that is up, and to learn the group names kill and stop_group take.
+
+The services list is what the project declares, with running and port_actual joined from what is listening now, so a service with running: false is one nobody has started.`
+
+func (s *Server) addActionTools() {
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "kill",
+		Title:       "Stop what is on a port, a group or a session",
+		Description: killDescription,
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  false,
+			OpenWorldHint:   boolPtr(false),
+		},
+		OutputSchema: outputSchema(KillOutput{}),
+	}, s.kill)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "stop_group",
+		Title:       "Stop a whole group",
+		Description: stopGroupDescription,
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(true),
+			IdempotentHint:  false,
+			OpenWorldHint:   boolPtr(false),
+		},
+		OutputSchema: outputSchema(KillOutput{}),
+	}, s.stopGroup)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "rename_port",
+		Title:       "Name a port",
+		Description: renamePortDescription,
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   boolPtr(false),
+		},
+		OutputSchema: outputSchema(RenamePortOutput{}),
+	}, s.renamePort)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "start_service",
+		Title:       "Start a service under sonar",
+		Description: startServiceDescription,
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			IdempotentHint:  false,
+			OpenWorldHint:   boolPtr(false),
+		},
+		OutputSchema: outputSchema(StartServiceOutput{}),
+	}, s.startService)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "list_groups",
+		Title:       "List groups and their services",
+		Description: listGroupsDescription,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
+		OutputSchema: outputSchema(ListGroupsOutput{}),
+	}, s.listGroups)
+}
+
+// kill routes one selector to the daemon method that owns it: ports.kill for a
+// port, a pid or a run, groups.kill for a group, sessions.kill for a session.
+func (s *Server) kill(ctx context.Context, _ *mcp.CallToolRequest, in KillInput) (*mcp.CallToolResult, any, error) {
+	target, derr := in.target()
+	if derr != nil {
+		return errorResult(derr), nil, nil
+	}
+	tree := true
+	if in.Tree != nil {
+		tree = *in.Tree
+	}
+
+	var env rpc.KillEnvelope
+	switch target.kind {
+	case "group":
+		params := rpc.GroupsKillParams{Name: in.Group, Force: in.Force, DryRun: in.DryRun}
+		if err := s.daemon.Call(ctx, "groups.kill", params, &env); err != nil {
+			return s.failed(err)
+		}
+	case "session":
+		if !s.daemon.Has(CapabilitySessions) {
+			return errorResult(Domain(CodeCapabilityMissing,
+				"this daemon does not track agent sessions",
+				"upgrade sonar, then `sonar daemon restart`; until then kill by group, port or run_id")), nil, nil
+		}
+		params := rpc.SessionsKillParams{ID: in.Session, Tree: tree, Force: in.Force, DryRun: in.DryRun}
+		if err := s.daemon.Call(ctx, "sessions.kill", params, &env); err != nil {
+			return s.failed(err)
+		}
+	default:
+		params := rpc.PortsKillParams{
+			Targets: []rpc.Selector{target.selector},
+			Tree:    tree, Force: in.Force, DryRun: in.DryRun,
+		}
+		if err := s.daemon.Call(ctx, "ports.kill", params, &env); err != nil {
+			return s.failed(err)
+		}
+	}
+
+	out := killOutput(env, in.DryRun)
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderKill(out, target.phrase)}},
+	}, out, nil
+}
+
+// StopGroupInput is the argument set of stop_group.
+type StopGroupInput struct {
+	Group  string `json:"group" jsonschema:"The group to stop, as listed by list_groups."`
+	Force  bool   `json:"force,omitempty" jsonschema:"Send SIGKILL instead of SIGTERM to every member. Try without it first."`
+	DryRun bool   `json:"dry_run,omitempty" jsonschema:"Report what would be stopped, and stop nothing."`
+}
+
+func (s *Server) stopGroup(ctx context.Context, _ *mcp.CallToolRequest, in StopGroupInput) (*mcp.CallToolResult, any, error) {
+	if strings.TrimSpace(in.Group) == "" {
+		return errorResult(invalidArguments(
+			"stop_group needs a group",
+			`pass {"group": "shop"}; list_groups shows the names`)), nil, nil
+	}
+
+	var env rpc.KillEnvelope
+	params := rpc.GroupsKillParams{Name: in.Group, Force: in.Force, DryRun: in.DryRun}
+	if err := s.daemon.Call(ctx, "groups.kill", params, &env); err != nil {
+		return s.failed(err)
+	}
+
+	out := killOutput(env, in.DryRun)
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderKill(out, "in group "+in.Group)}},
+	}, out, nil
+}
+
+// renamePort stores the label and then reads the row back, because the row is
+// what the caller wants to see and only the daemon knows how the rename
+// interacts with everything else on it (contract §19: display_name).
+func (s *Server) renamePort(ctx context.Context, _ *mcp.CallToolRequest, in RenamePortInput) (*mcp.CallToolResult, any, error) {
+	if in.Port <= 0 && in.PID <= 0 {
+		return errorResult(invalidArguments(
+			"rename_port needs a port or a pid",
+			`pass {"port": 3000, "name": "checkout-api"}`)), nil, nil
+	}
+
+	sel := rpc.Selector{}
+	if in.PID > 0 {
+		sel.PID = &in.PID
+	} else {
+		sel.Port = &in.Port
+	}
+
+	params := rpc.PortsRenameParams{Selector: sel}
+	name := strings.TrimSpace(in.Name)
+	if name != "" {
+		params.Name = &name
+	}
+	var renamed rpc.PortsRenameResult
+	if err := s.daemon.Call(ctx, "ports.rename", params, &renamed); err != nil {
+		return s.failed(err)
+	}
+
+	var inspected rpc.PortsInspectResult
+	if err := s.daemon.Call(ctx, "ports.inspect", sel, &inspected); err != nil {
+		return s.failed(err)
+	}
+
+	out := RenamePortOutput{Port: inspected.Port}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{
+			Text: renderRename(inspected.Port, name) + "\n\n" + renderPort(inspected.Port),
+		}},
+	}, out, nil
+}
+
+// startService spawns through the daemon so the service outlives this call,
+// then, if asked, waits for it to accept connections. A wait that runs out is
+// not a failed start: the run is reported with the timeout beside it.
+func (s *Server) startService(ctx context.Context, _ *mcp.CallToolRequest, in StartServiceInput) (*mcp.CallToolResult, any, error) {
+	if len(in.Command) == 0 || strings.TrimSpace(in.Command[0]) == "" {
+		return errorResult(invalidArguments(
+			"start_service needs a command",
+			`pass argv, for example {"command": ["npm", "run", "dev"]}`)), nil, nil
+	}
+	wantPort, auto, derr := parseWaitForPort(in.WaitForPort)
+	if derr != nil {
+		return errorResult(derr), nil, nil
+	}
+	cwd := strings.TrimSpace(in.Cwd)
+	if cwd == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return errorResult(invalidArguments(
+				"start_service needs a cwd: this server has no working directory of its own",
+				`pass {"cwd": "/path/to/repo"}`)), nil, nil
+		}
+		cwd = wd
+	}
+
+	params := rpc.RunsSpawnParams{Argv: in.Command, Cwd: cwd, Env: in.Env}
+	if g := strings.TrimSpace(in.Group); g != "" {
+		params.Group = &g
+	}
+	if n := strings.TrimSpace(in.Name); n != "" {
+		params.Name = &n
+	}
+	if wantPort > 0 {
+		params.PortHint = &wantPort
+	}
+	// The session is detected here, in the process the agent started: the
+	// daemon's own environment is a service manager's, not an agent's, so it
+	// could never detect this (spec 2 §3).
+	session, hasSession := sessions.Capture(cwd, sessions.Options{})
+	if hasSession {
+		params.Session = &session
+	}
+
+	var spawned rpc.RunsSpawnResult
+	if err := s.daemon.Call(ctx, "runs.spawn", params, &spawned); err != nil {
+		return s.failed(err)
+	}
+
+	out := StartServiceOutput{
+		RunID:   spawned.RunID,
+		PID:     spawned.PID,
+		Group:   strings.TrimSpace(in.Group),
+		Name:    strings.TrimSpace(in.Name),
+		Ports:   []state.Port{},
+		LogPath: spawned.LogPath,
+	}
+	if hasSession {
+		captured := session
+		out.Session = &captured
+	}
+	// The daemon resolves the group and the name from cwd and argv when the
+	// caller left them out, so they are read back rather than guessed here.
+	if rec, ok := s.runRecord(ctx, spawned.RunID); ok {
+		out.Group, out.Name = rec.Group, rec.Name
+	}
+
+	if wantPort <= 0 && !auto {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: renderStarted(out, in.Command)}},
+		}, out, nil
+	}
+
+	timeout := waitTimeout(in.TimeoutSeconds)
+	ready, err := s.waitForService(ctx, spawned.RunID, wantPort, auto, timeout)
+	if err != nil {
+		return s.failed(err)
+	}
+	out.Ports = s.servicePorts(ctx, spawned.RunID, ready)
+
+	if len(ready) == 0 {
+		out.TimedOut = true
+		out.Error = &ErrorInfo{
+			Code: CodeTimeout,
+			Message: fmt.Sprintf("%s started as run %s (pid %d) but %s within %s",
+				strings.Join(in.Command, " "), out.RunID, out.PID, notListening(wantPort, auto), timeout),
+			Hint: "the run is still alive: read its output with tail_logs, or stop it with kill {run_id}",
+		}
+		text := out.Error.Code + ": " + out.Error.Message + "\n" + out.Error.Hint
+		return &mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{&mcp.TextContent{Text: text}},
+		}, out, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderStarted(out, in.Command)}},
+	}, out, nil
+}
+
+func (s *Server) listGroups(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+	var res rpc.GroupsListResult
+	if err := s.daemon.Call(ctx, "groups.list", rpc.Empty{}, &res); err != nil {
+		return s.failed(err)
+	}
+	if res.Groups == nil {
+		res.Groups = []state.Group{}
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderGroups(res.Groups)}},
+	}, res, nil
+}
+
+// ------------------------------------------------------------- selectors ---
+
+// killTarget is the one selector a kill was given: which daemon method owns it,
+// the wire selector for ports.kill, and how to name it in a sentence.
+type killTarget struct {
+	kind     string
+	selector rpc.Selector
+	phrase   string
+}
+
+func (in KillInput) target() (killTarget, *DomainError) {
+	var set []killTarget
+	if in.Port > 0 {
+		port := in.Port
+		set = append(set, killTarget{"port", rpc.Selector{Port: &port}, fmt.Sprintf("on port %d", port)})
+	}
+	if in.PID > 0 {
+		pid := in.PID
+		set = append(set, killTarget{"pid", rpc.Selector{PID: &pid}, fmt.Sprintf("for pid %d", pid)})
+	}
+	if g := strings.TrimSpace(in.Group); g != "" {
+		set = append(set, killTarget{kind: "group", phrase: "in group " + g})
+	}
+	if sess := strings.TrimSpace(in.Session); sess != "" {
+		set = append(set, killTarget{kind: "session", phrase: "for session " + sess})
+	}
+	if run := strings.TrimSpace(in.RunID); run != "" {
+		id := run
+		set = append(set, killTarget{"run_id", rpc.Selector{RunID: &id}, "for run " + id})
+	}
+
+	switch len(set) {
+	case 1:
+		return set[0], nil
+	case 0:
+		return killTarget{}, invalidArguments(
+			"kill needs exactly one of port, pid, group, session or run_id",
+			`pass {"port": 3000}, or {"group": "shop"} for a whole project; there is no "kill everything"`)
+	default:
+		return killTarget{}, invalidArguments(
+			"kill takes exactly one selector, and got "+strconv.Itoa(len(set)),
+			"call it once per target: a kill acts on what you named, not on the union")
+	}
+}
+
+// parseWaitForPort reads the int-or-"auto" argument. A model that sends the
+// port as a string gets what it meant rather than an argument error; anything
+// else is refused, because guessing at a readiness check is worse than saying
+// what the two accepted forms are.
+func parseWaitForPort(v any) (port int, auto bool, err *DomainError) {
+	switch t := v.(type) {
+	case nil:
+		return 0, false, nil
+	case bool:
+		return 0, false, waitForPortError(fmt.Sprint(t))
+	case float64:
+		return checkedPort(int(t))
+	case int:
+		return checkedPort(t)
+	case json.Number:
+		n, cErr := t.Int64()
+		if cErr != nil {
+			return 0, false, waitForPortError(t.String())
+		}
+		return checkedPort(int(n))
+	case string:
+		if strings.EqualFold(strings.TrimSpace(t), autoPort) {
+			return 0, true, nil
+		}
+		if n, cErr := strconv.Atoi(strings.TrimSpace(t)); cErr == nil {
+			return checkedPort(n)
+		}
+		return 0, false, waitForPortError(t)
+	default:
+		return 0, false, waitForPortError(fmt.Sprint(t))
+	}
+}
+
+func checkedPort(n int) (int, bool, *DomainError) {
+	if n < 1 || n > 65535 {
+		return 0, false, waitForPortError(strconv.Itoa(n))
+	}
+	return n, false, nil
+}
+
+func waitForPortError(got string) *DomainError {
+	return invalidArguments(
+		fmt.Sprintf("wait_for_port must be a port number or \"auto\", and got %q", got),
+		`pass {"wait_for_port": 3000} for a known port, or {"wait_for_port": "auto"} to take whatever the service opens`)
+}
+
+func waitTimeout(seconds int) time.Duration {
+	if seconds <= 0 {
+		seconds = defaultWaitSeconds
+	}
+	if seconds > maxWaitSeconds {
+		seconds = maxWaitSeconds
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// ------------------------------------------------------------------ waits ---
+
+// waitForService blocks until the service is listening. A known port is waited
+// for with ports.wait, which the daemon probes for us; "auto" is polled from
+// runs.list, because the daemon does not take a run id in ports.wait yet
+// (contract §20). It returns the ports that came up, empty on a timeout.
+func (s *Server) waitForService(ctx context.Context, runID string, port int, auto bool, timeout time.Duration) ([]int, error) {
+	if auto {
+		return s.pollRunPorts(ctx, runID, timeout)
+	}
+	end, err := s.awaitPorts(ctx, rpc.PortsWaitParams{
+		Ports:     []int{port},
+		TimeoutMs: int(timeout / time.Millisecond),
+	}, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return end.Ready, nil
+}
+
+// awaitPorts runs one ports.wait stream to its end. The stream's own timeout is
+// what stops it; the context here is the outer bound, and cancelling it (an MCP
+// client going away mid-wait) cancels the daemon's side too.
+func (s *Server) awaitPorts(ctx context.Context, params rpc.PortsWaitParams, timeout time.Duration) (rpc.PortsWaitEnd, error) {
+	var out rpc.PortsWaitEnd
+
+	c := s.daemon.current()
+	if c == nil {
+		return out, s.daemon.unavailable()
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout+DefaultTimeout)
+	defer cancel()
+
+	stream, err := c.Stream(waitCtx, "ports.wait", params, nil)
+	if err != nil {
+		if _, ok := asDomain(err); ok {
+			return out, err
+		}
+		return out, s.daemon.unavailable()
+	}
+	defer stream.Close()
+
+	// Chunks are progress, not the answer: the end carries {ready, timed_out}.
+	go func() {
+		for range stream.Chunks() {
+		}
+	}()
+
+	select {
+	case end, ok := <-stream.End():
+		if !ok {
+			return out, s.daemon.unavailable()
+		}
+		if end.Err != nil {
+			return out, end.Err
+		}
+		if err := end.Decode(&out); err != nil {
+			return out, Domain(CodeDaemonUnavailable, "the daemon's wait result could not be read: "+err.Error(),
+				"retry; if it keeps happening, check `sonar daemon status`")
+		}
+		return out, nil
+	case <-waitCtx.Done():
+		cancelCtx, cancelWait := context.WithTimeout(context.Background(), DefaultTimeout)
+		defer cancelWait()
+		_ = stream.Cancel(cancelCtx)
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		return out, Domain(CodeTimeout, "the daemon did not finish waiting for the port",
+			"retry with a smaller timeout_seconds, or check `sonar daemon status`")
+	}
+}
+
+// pollRunPorts is wait_for_port: "auto" — the run's process tree opening any
+// listener. It polls runs.list, whose rows carry the ports attributed to each
+// run, because that attribution is what "the port this service opened" means.
+func (s *Server) pollRunPorts(ctx context.Context, runID string, timeout time.Duration) ([]int, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		rec, ok := s.runRecord(ctx, runID)
+		if ok && len(rec.Ports) > 0 {
+			return rec.Ports, nil
+		}
+		if !time.Now().Before(deadline) {
+			return nil, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval(deadline)):
+		}
+	}
+}
+
+// pollInterval is the run poll's cadence, shortened so the last poll lands on
+// the deadline rather than after it.
+func pollInterval(deadline time.Time) time.Duration {
+	const cadence = 250 * time.Millisecond
+	if left := time.Until(deadline); left < cadence {
+		return max(left, 10*time.Millisecond)
+	}
+	return cadence
+}
+
+// runRecord reads one run back from runs.list. A daemon without the runs
+// capability, or a run that has already exited, is not an error here: the
+// caller falls back to what it already knows.
+func (s *Server) runRecord(ctx context.Context, runID string) (rpc.RunRecord, bool) {
+	var res rpc.RunsListResult
+	if err := s.daemon.Call(ctx, "runs.list", rpc.Empty{}, &res); err != nil {
+		s.log.Debug("runs.list failed while reporting a spawn", "run_id", runID, "error", err)
+		return rpc.RunRecord{}, false
+	}
+	for _, rec := range res.Runs {
+		if rec.ID == runID {
+			return rec, true
+		}
+	}
+	return rpc.RunRecord{}, false
+}
+
+// servicePorts is the port rows for a run that has just come up. The daemon
+// attributes a port to its run on the next scan, so the read is retried for a
+// moment before falling back to inspecting the port that was waited for.
+func (s *Server) servicePorts(ctx context.Context, runID string, ready []int) []state.Port {
+	if len(ready) == 0 {
+		return []state.Port{}
+	}
+	for attempt := range 4 {
+		var res rpc.PortsListResult
+		if err := s.daemon.Call(ctx, "ports.list", rpc.PortsListParams{Group: &runID}, &res); err == nil {
+			if rows := keepPorts(res.Ports, ready); len(rows) > 0 {
+				return rows
+			}
+		}
+		if attempt == 3 || ctx.Err() != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return []state.Port{}
+		case <-time.After(400 * time.Millisecond):
+		}
+	}
+
+	// Attribution has not caught up (or the run is not the port's owner):
+	// report the row the caller waited for rather than nothing.
+	rows := []state.Port{}
+	for _, port := range ready {
+		p := port
+		var res rpc.PortsInspectResult
+		if err := s.daemon.Call(ctx, "ports.inspect", rpc.Selector{Port: &p}, &res); err == nil {
+			rows = append(rows, res.Port)
+		}
+	}
+	return rows
+}
+
+// keepPorts narrows a run's ports to the ones that just became ready, so a run
+// that owns several ports reports the one the caller asked about first.
+func keepPorts(rows []state.Port, ready []int) []state.Port {
+	want := map[int]bool{}
+	for _, port := range ready {
+		want[port] = true
+	}
+	out := []state.Port{}
+	for _, row := range rows {
+		if want[row.Port] {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+// --------------------------------------------------------------- results ---
+
+// killOutput splits the daemon's envelope into the tool's two lists. Rows that
+// failed keep the daemon's own message, which is where permission_denied and
+// "nothing was listening" arrive.
+func killOutput(env rpc.KillEnvelope, dryRun bool) KillOutput {
+	out := KillOutput{Killed: []KilledProcess{}, Failed: []FailedProcess{}, DryRun: dryRun}
+	for _, row := range env.Results {
+		if row.OK {
+			out.Killed = append(out.Killed, KilledProcess{
+				Port: row.Port, PID: row.PID, Name: row.Name, Method: string(row.Method),
+			})
+			continue
+		}
+		out.Failed = append(out.Failed, FailedProcess{
+			Port: row.Port, PID: row.PID, Error: row.Error,
+		})
+	}
+	return out
+}
+
+// renderKill is the action tools' one sentence: what stopped, where, and how.
+func renderKill(out KillOutput, phrase string) string {
+	verb := "Stopped"
+	if out.DryRun {
+		verb = "Dry run: would stop"
+	}
+
+	var b strings.Builder
+	if len(out.Killed) == 0 {
+		fmt.Fprintf(&b, "%s nothing %s", verb, phrase)
+	} else {
+		fmt.Fprintf(&b, "%s %d %s %s (%s)", verb, len(out.Killed),
+			plural(len(out.Killed), "process", "processes"), phrase, killMethods(out.Killed))
+	}
+	if len(out.Failed) > 0 {
+		fmt.Fprintf(&b, "; %d failed: %s", len(out.Failed), failureReasons(out.Failed))
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+// killMethods lists the distinct methods used, so "sigterm" or
+// "sigterm/docker_stop" says whether anything was escalated or stopped as a
+// container.
+func killMethods(rows []KilledProcess) string {
+	seen := map[string]bool{}
+	var methods []string
+	for _, row := range rows {
+		if row.Method == "" || seen[row.Method] {
+			continue
+		}
+		seen[row.Method] = true
+		methods = append(methods, row.Method)
+	}
+	if len(methods) == 0 {
+		return string(state.MethodNone)
+	}
+	return strings.Join(methods, "/")
+}
+
+func failureReasons(rows []FailedProcess) string {
+	seen := map[string]bool{}
+	var reasons []string
+	for _, row := range rows {
+		if row.Error == "" || seen[row.Error] {
+			continue
+		}
+		seen[row.Error] = true
+		reasons = append(reasons, row.Error)
+	}
+	return strings.Join(reasons, "; ")
+}
+
+func renderRename(p state.Port, name string) string {
+	if name == "" {
+		return fmt.Sprintf("Cleared the name of port %d; it now reads as %s.", p.Port, dash(p.DisplayName))
+	}
+	return fmt.Sprintf("Port %d is now called %q.", p.Port, name)
+}
+
+// renderStarted is start_service's sentence: what was started, where it landed,
+// and the URL if it is listening yet.
+func renderStarted(out StartServiceOutput, argv []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Started `%s` as run %s (pid %d)", strings.Join(argv, " "), out.RunID, out.PID)
+	if out.Group != "" {
+		fmt.Fprintf(&b, " in group %s", out.Group)
+	}
+	switch {
+	case len(out.Ports) == 1:
+		fmt.Fprintf(&b, ", listening on %s", portTarget(out.Ports[0]))
+	case len(out.Ports) > 1:
+		fmt.Fprintf(&b, ", listening on %s", strings.Join(portNumbers(out.Ports), ", "))
+	}
+	if out.LogPath != "" {
+		fmt.Fprintf(&b, "; logs at %s", out.LogPath)
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+func portTarget(p state.Port) string {
+	if p.URL != "" {
+		return p.URL
+	}
+	return "port " + strconv.Itoa(p.Port)
+}
+
+func portNumbers(rows []state.Port) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, strconv.Itoa(row.Port))
+	}
+	return out
+}
+
+func notListening(port int, auto bool) string {
+	if auto {
+		return "opened no port"
+	}
+	return fmt.Sprintf("nothing was listening on port %d", port)
+}
+
+// renderGroups is the list rendering for list_groups: one row per project, with
+// its members and the services its config declares.
+func renderGroups(groups []state.Group) string {
+	if len(groups) == 0 {
+		return "no groups: nothing sonar can attribute to a project is running"
+	}
+
+	shown := groups
+	truncated := false
+	if len(shown) > MaxRows {
+		shown, truncated = shown[:MaxRows], true
+	}
+
+	header := []string{"GROUP", "STATUS", "SOURCE", "PORTS", "SERVICES", "ROOT"}
+	rows := make([][]string, 0, len(shown))
+	for _, g := range shown {
+		rows = append(rows, []string{
+			g.Name,
+			dash(g.Status),
+			dash(string(g.Source)),
+			dash(joinInts(g.Members)),
+			dash(serviceSummary(g.Services)),
+			dash(deref(g.RootDir)),
+		})
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %s\n\n", len(groups), plural(len(groups), "group", "groups"))
+	b.WriteString(table(header, rows))
+	if truncated {
+		b.WriteString("\n" + truncationNote(len(shown), len(groups)))
+	}
+	return b.String()
+}
+
+// serviceSummary names the declared services, marking the ones that are not
+// running — the difference between "this project has a worker" and "the worker
+// is up" is the reason to read this column.
+func serviceSummary(services []state.Service) string {
+	if len(services) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(services))
+	for _, svc := range services {
+		if svc.Running {
+			out = append(out, svc.Name)
+			continue
+		}
+		out = append(out, svc.Name+" (stopped)")
+	}
+	return strings.Join(out, ", ")
+}
+
+func joinInts(xs []int) string {
+	if len(xs) == 0 {
+		return ""
+	}
+	sorted := append([]int{}, xs...)
+	sort.Ints(sorted)
+	out := make([]string, 0, len(sorted))
+	for _, x := range sorted {
+		out = append(out, strconv.Itoa(x))
+	}
+	return strings.Join(out, ", ")
+}

--- a/internal/mcpserver/tools_actions.go
+++ b/internal/mcpserver/tools_actions.go
@@ -132,8 +132,9 @@ type StartServiceInput struct {
 }
 
 // StartServiceOutput is the shape spec 2 §1.1 gives start_service. Session is
-// the object every other tool reports (contract §5), null when nothing in this
-// server's environment names an agent. TimedOut and Error are set together
+// the object every other tool reports (contract §5) and is null — like
+// Port.session — when nothing in this server's environment names an agent,
+// which is the normal case outside a coding agent. TimedOut and Error are set together
 // when wait_for_port ran out: the run is still there and its id, pid and log
 // path are how you go and look at it.
 type StartServiceOutput struct {
@@ -141,7 +142,7 @@ type StartServiceOutput struct {
 	PID      int            `json:"pid"`
 	Group    string         `json:"group"`
 	Name     string         `json:"name"`
-	Session  *state.Session `json:"session"`
+	Session  *state.Session `json:"session" jsonschema:"nullable"`
 	Ports    []state.Port   `json:"ports"`
 	LogPath  string         `json:"log_path"`
 	TimedOut bool           `json:"timed_out,omitempty"`

--- a/internal/mcpserver/tools_actions_test.go
+++ b/internal/mcpserver/tools_actions_test.go
@@ -386,6 +386,7 @@ func TestRenamePortUnknownPort(t *testing.T) {
 
 func TestStartServiceWithoutWaitingReturnsTheRun(t *testing.T) {
 	h, actions := actionHarness(t)
+	clearAgentEnv(t)
 
 	res := h.call("start_service", map[string]any{
 		"command": []any{"python3", "-m", "http.server", "8000"},
@@ -415,6 +416,7 @@ func TestStartServiceWithoutWaitingReturnsTheRun(t *testing.T) {
 // starts listening a moment after the spawn, and the tool returns its row.
 func TestStartServiceWaitsForAKnownPort(t *testing.T) {
 	h, actions := actionHarness(t)
+	clearAgentEnv(t)
 	openWhenSpawned(t, actions, 8000)
 
 	res := h.call("start_service", map[string]any{
@@ -444,6 +446,7 @@ func TestStartServiceWaitsForAKnownPort(t *testing.T) {
 // does not know the port, and finds it through the run's attribution.
 func TestStartServiceAutoTakesWhateverPortOpens(t *testing.T) {
 	h, actions := actionHarness(t)
+	clearAgentEnv(t)
 	openWhenSpawned(t, actions, 8123)
 
 	res := h.call("start_service", map[string]any{
@@ -470,6 +473,7 @@ func TestStartServiceAutoTakesWhateverPortOpens(t *testing.T) {
 // still carries the run, because the next thing to do is read its log.
 func TestStartServiceTimesOutWithTheRunIntact(t *testing.T) {
 	h, _ := actionHarness(t)
+	clearAgentEnv(t)
 
 	res := h.call("start_service", map[string]any{
 		"command":         []any{"python3", "-m", "http.server", "8100"},
@@ -494,6 +498,69 @@ func TestStartServiceTimesOutWithTheRunIntact(t *testing.T) {
 	}
 	if payload.Error.Hint == "" {
 		t.Error("a timeout must say what to do next")
+	}
+}
+
+// TestStartServiceWithoutAnAgentEnvironmentHasNoSession: outside a coding
+// agent there is no session to attribute a run to, and the field is null
+// rather than an invented object — the same shape Port.session has.
+func TestStartServiceWithoutAnAgentEnvironmentHasNoSession(t *testing.T) {
+	h, _ := actionHarness(t)
+	clearAgentEnv(t)
+
+	res := h.call("start_service", map[string]any{
+		"command": []any{"npm", "run", "dev"},
+		"cwd":     "/home/dev/shop",
+	})
+	if res.IsError {
+		t.Fatalf("start_service failed: %s", textOf(res))
+	}
+	out := structured[mcpserver.StartServiceOutput](t, res)
+	if out.Session != nil {
+		t.Errorf("session = %+v, want null with no agent in the environment", out.Session)
+	}
+}
+
+// TestStartServiceAttributesTheAgentSession is the other half: the session is
+// detected in this process, because the daemon's own environment is a service
+// manager's and never an agent's (spec 2 §3).
+func TestStartServiceAttributesTheAgentSession(t *testing.T) {
+	h, _ := actionHarness(t)
+	clearAgentEnv(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "9f2c")
+	t.Setenv("CLAUDECODE", "1")
+
+	res := h.call("start_service", map[string]any{
+		"command": []any{"npm", "run", "dev"},
+		"cwd":     "/home/dev/shop",
+	})
+	if res.IsError {
+		t.Fatalf("start_service failed: %s", textOf(res))
+	}
+	out := structured[mcpserver.StartServiceOutput](t, res)
+	if out.Session == nil {
+		t.Fatal("start_service dropped the agent session")
+	}
+	if out.Session.ID != "9f2c" || out.Session.Tool != "claude-code" {
+		t.Errorf("session = %+v, want the claude-code session", out.Session)
+	}
+	if !out.Session.Detected {
+		t.Error("a session read off CLAUDECODE is detected, not declared")
+	}
+}
+
+// clearAgentEnv removes every marker sessions.Detect reads, so a test asserting
+// on attribution says the same thing on a laptop inside a coding agent and on a
+// bare CI runner.
+func clearAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"SONAR_SESSION", "SONAR_SESSION_ID", "SONAR_SESSION_TOOL", "SONAR_SESSION_LABEL",
+		"CLAUDECODE", "CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID",
+		"CODEX_SANDBOX", "CODEX_THREAD_ID",
+		"CURSOR_AGENT", "CURSOR_AGENT_SESSION_ID",
+	} {
+		t.Setenv(key, "")
 	}
 }
 

--- a/internal/mcpserver/tools_actions_test.go
+++ b/internal/mcpserver/tools_actions_test.go
@@ -1,0 +1,633 @@
+package mcpserver_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/mcpserver"
+	"github.com/raskrebs/sonar/internal/mcpserver/fakedaemon"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// actionHarness is the read harness plus the fake daemon's write half: a fake
+// that can kill, rename, spawn and wait.
+func actionHarness(t *testing.T) (*harness, *fakedaemon.Actions) {
+	t.Helper()
+	return actionHarnessWith(t, fakedaemon.DefaultFixture())
+}
+
+func actionHarnessWith(t *testing.T, fx fakedaemon.Fixture) (*harness, *fakedaemon.Actions) {
+	t.Helper()
+	h := newHarnessWith(t, fx)
+	return h, h.fake.RegisterActions()
+}
+
+func TestToolsListAdvertisesTheActionTools(t *testing.T) {
+	h := newHarness(t)
+
+	res, err := h.client.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	byName := map[string]*mcp.Tool{}
+	for _, tool := range res.Tools {
+		byName[tool.Name] = tool
+	}
+
+	// The annotations spec 2 §1.1 fixes for each tool, which is what a client
+	// gates a confirmation prompt on.
+	want := map[string]struct{ readOnly, destructive, idempotent bool }{
+		"kill":          {false, true, false},
+		"stop_group":    {false, true, false},
+		"rename_port":   {false, false, true},
+		"start_service": {false, false, false},
+		"list_groups":   {true, false, false},
+	}
+	for name, expect := range want {
+		tool, ok := byName[name]
+		if !ok {
+			t.Fatalf("tools/list is missing %s", name)
+		}
+		if tool.Description == "" {
+			t.Errorf("%s has no description", name)
+		}
+		if tool.OutputSchema == nil {
+			t.Errorf("%s has no output schema", name)
+		}
+		if tool.Annotations == nil {
+			t.Fatalf("%s has no annotations", name)
+		}
+		if tool.Annotations.ReadOnlyHint != expect.readOnly {
+			t.Errorf("%s readOnly = %v, want %v", name, tool.Annotations.ReadOnlyHint, expect.readOnly)
+		}
+		if !expect.readOnly {
+			if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint != expect.destructive {
+				t.Errorf("%s destructive = %v, want %v", name, tool.Annotations.DestructiveHint, expect.destructive)
+			}
+		}
+		if tool.Annotations.IdempotentHint != expect.idempotent {
+			t.Errorf("%s idempotent = %v, want %v", name, tool.Annotations.IdempotentHint, expect.idempotent)
+		}
+		if tool.Annotations.OpenWorldHint == nil || *tool.Annotations.OpenWorldHint {
+			t.Errorf("%s should be closed-world: it only talks to the local daemon", name)
+		}
+	}
+
+	if desc := byName["kill"].Description; !strings.Contains(desc, "dry_run") {
+		t.Errorf("kill's description does not teach dry_run:\n%s", desc)
+	}
+	if desc := byName["start_service"].Description; !strings.Contains(desc, "wait_for_port") {
+		t.Errorf("start_service's description does not teach wait_for_port:\n%s", desc)
+	}
+}
+
+// TestKillPortStopsTheTree is the golden test for kill: the tree of the run
+// behind port 3000 is two processes, and both come back as killed rows.
+func TestKillPortStopsTheTree(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("kill", map[string]any{"port": 3000})
+	out := structured[mcpserver.KillOutput](t, res)
+
+	if len(out.Killed) != 2 || len(out.Failed) != 0 {
+		t.Fatalf("killed %d, failed %d, want 2 and 0: %+v", len(out.Killed), len(out.Failed), out)
+	}
+	if out.DryRun {
+		t.Error("a real kill reported itself as a dry run")
+	}
+	for _, row := range out.Killed {
+		if row.Port != 3000 || row.Method != string(state.MethodSIGTERM) || row.Name == "" {
+			t.Errorf("kill row is missing its port, name or method: %+v", row)
+		}
+	}
+	if got, want := textOf(res), "Stopped 2 processes on port 3000 (sigterm)."; got != want {
+		t.Errorf("text = %q, want %q", got, want)
+	}
+
+	// The kill is visible to the next read, the way the daemon's rescan makes
+	// it (contract §22).
+	ports := structured[mcpserver.ListPortsOutput](t, h.call("list_ports", map[string]any{}))
+	for _, p := range ports.Ports {
+		if p.Port == 3000 {
+			t.Errorf("port 3000 is still listed after a kill")
+		}
+	}
+}
+
+func TestKillDryRunPlansAndActsOnNothing(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("kill", map[string]any{"port": 3000, "dry_run": true})
+	out := structured[mcpserver.KillOutput](t, res)
+
+	if len(out.Killed) != 2 || !out.DryRun {
+		t.Fatalf("dry run = %+v, want two planned rows marked dry_run", out)
+	}
+	if got, want := textOf(res), "Dry run: would stop 2 processes on port 3000 (sigterm)."; got != want {
+		t.Errorf("text = %q, want %q", got, want)
+	}
+
+	ports := structured[mcpserver.ListPortsOutput](t, h.call("list_ports", map[string]any{}))
+	if !containsPort(ports.Ports, 3000) {
+		t.Error("a dry run stopped something")
+	}
+}
+
+// TestKillReportsAPermissionDeniedRow: a process this user may not signal is a
+// failed row, not a failed call, so the rest of the kill still reports.
+func TestKillReportsAPermissionDeniedRow(t *testing.T) {
+	h, actions := actionHarness(t)
+	actions.DenyKill(4101)
+	actions.DenyKill(4100)
+
+	res := h.call("kill", map[string]any{"port": 3000})
+	if res.IsError {
+		t.Fatalf("a failed row must not fail the call: %s", textOf(res))
+	}
+	out := structured[mcpserver.KillOutput](t, res)
+	if len(out.Killed) != 0 || len(out.Failed) != 2 {
+		t.Fatalf("killed %d, failed %d, want 0 and 2: %+v", len(out.Killed), len(out.Failed), out)
+	}
+	if !strings.Contains(out.Failed[0].Error, "not permitted to signal PID 4101") {
+		t.Errorf("the daemon's reason was dropped: %+v", out.Failed[0])
+	}
+	if text := textOf(res); !strings.HasPrefix(text, "Stopped nothing on port 3000; 2 failed:") {
+		t.Errorf("text = %q", text)
+	}
+
+	ports := structured[mcpserver.ListPortsOutput](t, h.call("list_ports", map[string]any{}))
+	if !containsPort(ports.Ports, 3000) {
+		t.Error("a port that could not be signalled disappeared from the list")
+	}
+}
+
+// TestKillAPortNobodyIsOn: the daemon reports a failed row rather than an
+// error, so one bad target in a batch does not lose the others.
+func TestKillAPortNobodyIsOn(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	out := structured[mcpserver.KillOutput](t, h.call("kill", map[string]any{"port": 9999}))
+	if len(out.Killed) != 0 || len(out.Failed) != 1 {
+		t.Fatalf("want one failed row: %+v", out)
+	}
+	if !strings.Contains(out.Failed[0].Error, "9999") {
+		t.Errorf("the failed row does not name the port: %+v", out.Failed[0])
+	}
+}
+
+func TestKillAnUnknownGroupIsNotFound(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("kill", map[string]any{"group": "nope"})
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	if payload.Error.Code != "not_found" {
+		t.Errorf("code = %q, want not_found", payload.Error.Code)
+	}
+	if payload.Error.Hint == "" {
+		t.Error("the daemon's hint was dropped")
+	}
+}
+
+func TestKillBySessionNeedsTheCapability(t *testing.T) {
+	h, _ := actionHarness(t) // the default fixture has no sessions capability
+
+	res := h.call("kill", map[string]any{"session": "claude-code:9f2c"})
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	if payload.Error.Code != mcpserver.CodeCapabilityMissing {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeCapabilityMissing)
+	}
+	if payload.Error.Hint == "" {
+		t.Error("a capability_missing error must say what to do about it")
+	}
+	if n := h.fake.Calls("sessions.kill"); n != 0 {
+		t.Errorf("the daemon was called %d times for a capability it does not have", n)
+	}
+}
+
+func TestKillBySessionRoutesToSessionsKill(t *testing.T) {
+	fx := fakedaemon.DefaultFixture()
+	fx.Capabilities = append(fx.Capabilities, mcpserver.CapabilitySessions)
+	h, _ := actionHarnessWith(t, fx)
+
+	res := h.call("kill", map[string]any{"session": "claude-code:9f2c"})
+	out := structured[mcpserver.KillOutput](t, res)
+
+	if len(out.Killed) != 2 {
+		t.Fatalf("killed %d rows, want the two processes of the session's run: %+v", len(out.Killed), out)
+	}
+	if n := h.fake.Calls("sessions.kill"); n != 1 {
+		t.Errorf("sessions.kill was called %d times, want 1", n)
+	}
+	if text := textOf(res); !strings.Contains(text, "for session claude-code:9f2c") {
+		t.Errorf("text = %q, want it to name the session", text)
+	}
+}
+
+func TestKillDockerStopsTheContainer(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	out := structured[mcpserver.KillOutput](t, h.call("kill", map[string]any{"port": 5432}))
+	if len(out.Killed) != 1 || out.Killed[0].Method != string(state.MethodDockerStop) {
+		t.Fatalf("want one docker_stop row: %+v", out)
+	}
+	if out.Killed[0].Name != "shop-db-1" {
+		t.Errorf("the row does not name the container: %+v", out.Killed[0])
+	}
+}
+
+func TestKillNeedsExactlyOneSelector(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	for name, args := range map[string]map[string]any{
+		"none": {},
+		"two":  {"port": 3000, "group": "shop"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			res := h.call("kill", args)
+			payload, ok := mcpserver.DecodeError(res)
+			if !ok {
+				t.Fatalf("expected an error result, got %s", textOf(res))
+			}
+			if payload.Error.Code != mcpserver.CodeInvalidArguments {
+				t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+			}
+			if n := h.fake.Calls("ports.kill"); n != 0 {
+				t.Errorf("the daemon was called for an argument error")
+			}
+		})
+	}
+}
+
+func TestKillWithoutTreeSignalsOneProcess(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	out := structured[mcpserver.KillOutput](t, h.call("kill", map[string]any{"port": 3000, "tree": false}))
+	if len(out.Killed) != 1 {
+		t.Fatalf("tree: false killed %d rows, want 1: %+v", len(out.Killed), out)
+	}
+	if out.Killed[0].PID != 4101 {
+		t.Errorf("killed pid %d, want the listener 4101", out.Killed[0].PID)
+	}
+}
+
+func TestStopGroupStopsEveryMember(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("stop_group", map[string]any{"group": "shop"})
+	out := structured[mcpserver.KillOutput](t, res)
+
+	// api (a run: two processes) plus vite (one).
+	if len(out.Killed) != 3 {
+		t.Fatalf("killed %d rows, want 3: %+v", len(out.Killed), out)
+	}
+	if got, want := textOf(res), "Stopped 3 processes in group shop (sigterm)."; got != want {
+		t.Errorf("text = %q, want %q", got, want)
+	}
+
+	ports := structured[mcpserver.ListPortsOutput](t, h.call("list_ports", map[string]any{"group": "shop"}))
+	if len(ports.Ports) != 0 {
+		t.Errorf("group shop still has %d ports listening", len(ports.Ports))
+	}
+}
+
+func TestStopGroupDryRunAndUnknownGroup(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	dry := structured[mcpserver.KillOutput](t, h.call("stop_group", map[string]any{"group": "shop", "dry_run": true}))
+	if !dry.DryRun || len(dry.Killed) != 3 {
+		t.Fatalf("dry run = %+v", dry)
+	}
+
+	res := h.call("stop_group", map[string]any{"group": "nope"})
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	if payload.Error.Code != "not_found" {
+		t.Errorf("code = %q, want not_found", payload.Error.Code)
+	}
+}
+
+func TestStopGroupNeedsAGroup(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("stop_group", map[string]any{"group": "   "})
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	if payload.Error.Code != mcpserver.CodeInvalidArguments {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+	}
+}
+
+func TestRenamePortNamesTheRow(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("rename_port", map[string]any{"port": 5173, "name": "storefront"})
+	out := structured[mcpserver.RenamePortOutput](t, res)
+
+	if out.Port.Name == nil || *out.Port.Name != "storefront" {
+		t.Fatalf("the row does not carry the new name: %+v", out.Port)
+	}
+	if out.Port.DisplayName != "storefront" {
+		t.Errorf("display_name = %q, want storefront", out.Port.DisplayName)
+	}
+	if text := textOf(res); !strings.HasPrefix(text, `Port 5173 is now called "storefront".`) {
+		t.Errorf("text = %q", text)
+	}
+	// The single-object rendering is still there under the sentence.
+	if text := textOf(res); !strings.Contains(text, "project_root") {
+		t.Errorf("the row was not rendered under the sentence:\n%s", text)
+	}
+
+	// Idempotent: the same call again reports the same row.
+	again := structured[mcpserver.RenamePortOutput](t, h.call("rename_port", map[string]any{"port": 5173, "name": "storefront"}))
+	if again.Port.DisplayName != "storefront" {
+		t.Errorf("a repeated rename changed the row: %+v", again.Port)
+	}
+}
+
+func TestRenamePortNeedsASelector(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("rename_port", map[string]any{"name": "api"})
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	if payload.Error.Code != mcpserver.CodeInvalidArguments {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+	}
+}
+
+func TestRenamePortUnknownPort(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("rename_port", map[string]any{"port": 9999, "name": "api"})
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	if payload.Error.Code != "not_found" {
+		t.Errorf("code = %q, want not_found", payload.Error.Code)
+	}
+}
+
+func TestStartServiceWithoutWaitingReturnsTheRun(t *testing.T) {
+	h, actions := actionHarness(t)
+
+	res := h.call("start_service", map[string]any{
+		"command": []any{"python3", "-m", "http.server", "8000"},
+		"cwd":     "/home/dev/shop",
+		"name":    "docs",
+	})
+	out := structured[mcpserver.StartServiceOutput](t, res)
+
+	if out.RunID == "" || out.PID == 0 || out.LogPath == "" {
+		t.Fatalf("start_service dropped the run it started: %+v", out)
+	}
+	if out.Name != "docs" || out.Group != "shop" {
+		t.Errorf("group/name = %q/%q, want shop/docs as the daemon resolved them", out.Group, out.Name)
+	}
+	if len(out.Ports) != 0 {
+		t.Errorf("a start without wait_for_port cannot know a port yet: %+v", out.Ports)
+	}
+	if runs := actions.Runs(); len(runs) != 1 || runs[0].Cmd != "python3 -m http.server 8000" {
+		t.Errorf("the daemon was asked for %+v", runs)
+	}
+	if text := textOf(res); !strings.Contains(text, "Started `python3 -m http.server 8000` as run ") {
+		t.Errorf("text = %q", text)
+	}
+}
+
+// TestStartServiceWaitsForAKnownPort drives the ports.wait stream: the service
+// starts listening a moment after the spawn, and the tool returns its row.
+func TestStartServiceWaitsForAKnownPort(t *testing.T) {
+	h, actions := actionHarness(t)
+	openWhenSpawned(t, actions, 8000)
+
+	res := h.call("start_service", map[string]any{
+		"command":         []any{"python3", "-m", "http.server", "8000"},
+		"cwd":             "/home/dev/shop",
+		"name":            "docs",
+		"wait_for_port":   8000,
+		"timeout_seconds": 10,
+	})
+	out := structured[mcpserver.StartServiceOutput](t, res)
+
+	if res.IsError || out.TimedOut {
+		t.Fatalf("the wait failed: %s", textOf(res))
+	}
+	if len(out.Ports) != 1 || out.Ports[0].Port != 8000 {
+		t.Fatalf("ports = %+v, want the row for 8000", out.Ports)
+	}
+	if out.Ports[0].Run == nil || out.Ports[0].Run.ID != out.RunID {
+		t.Errorf("the port row is not attributed to the run: %+v", out.Ports[0])
+	}
+	if text := textOf(res); !strings.Contains(text, "listening on http://localhost:8000") {
+		t.Errorf("text = %q, want it to report the URL", text)
+	}
+}
+
+// TestStartServiceAutoTakesWhateverPortOpens is wait_for_port: "auto": the tool
+// does not know the port, and finds it through the run's attribution.
+func TestStartServiceAutoTakesWhateverPortOpens(t *testing.T) {
+	h, actions := actionHarness(t)
+	openWhenSpawned(t, actions, 8123)
+
+	res := h.call("start_service", map[string]any{
+		"command":         []any{"npm", "run", "dev"},
+		"cwd":             "/home/dev/shop",
+		"wait_for_port":   "auto",
+		"timeout_seconds": 10,
+	})
+	out := structured[mcpserver.StartServiceOutput](t, res)
+
+	if res.IsError || out.TimedOut {
+		t.Fatalf("the wait failed: %s", textOf(res))
+	}
+	if len(out.Ports) != 1 || out.Ports[0].Port != 8123 {
+		t.Fatalf("ports = %+v, want the port the run opened", out.Ports)
+	}
+	// "auto" is polled from runs.list, not from ports.wait (contract §20).
+	if n := h.fake.Calls("ports.wait"); n != 0 {
+		t.Errorf("ports.wait was called %d times for an auto wait", n)
+	}
+}
+
+// TestStartServiceTimesOutWithTheRunIntact: a timeout is an IsError result that
+// still carries the run, because the next thing to do is read its log.
+func TestStartServiceTimesOutWithTheRunIntact(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("start_service", map[string]any{
+		"command":         []any{"python3", "-m", "http.server", "8100"},
+		"cwd":             "/home/dev/shop",
+		"wait_for_port":   8100,
+		"timeout_seconds": 1,
+	})
+	if !res.IsError {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok || payload.Error.Code != mcpserver.CodeTimeout {
+		t.Fatalf("error payload = %+v, want a timeout", payload)
+	}
+
+	out := decodeOutput[mcpserver.StartServiceOutput](t, res)
+	if !out.TimedOut || out.RunID == "" || out.PID == 0 || out.LogPath == "" {
+		t.Fatalf("a timed-out start lost the run: %+v", out)
+	}
+	if !strings.Contains(textOf(res), "nothing was listening on port 8100") {
+		t.Errorf("text = %q", textOf(res))
+	}
+	if payload.Error.Hint == "" {
+		t.Error("a timeout must say what to do next")
+	}
+}
+
+func TestStartServiceRejectsABadWaitForPort(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	for name, value := range map[string]any{
+		"a word":   "later",
+		"a bool":   true,
+		"too high": 70000,
+	} {
+		t.Run(name, func(t *testing.T) {
+			res := h.call("start_service", map[string]any{
+				"command":       []any{"npm", "run", "dev"},
+				"cwd":           "/home/dev/shop",
+				"wait_for_port": value,
+			})
+			payload, ok := mcpserver.DecodeError(res)
+			if !ok {
+				t.Fatalf("expected an error result, got %s", textOf(res))
+			}
+			if payload.Error.Code != mcpserver.CodeInvalidArguments {
+				t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+			}
+			if n := h.fake.Calls("runs.spawn"); n != 0 {
+				t.Errorf("a service was spawned despite the bad argument")
+			}
+		})
+	}
+}
+
+func TestStartServiceNeedsACommand(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("start_service", map[string]any{"command": []any{}})
+	payload, ok := mcpserver.DecodeError(res)
+	if !ok {
+		t.Fatalf("expected an error result, got %s", textOf(res))
+	}
+	if payload.Error.Code != mcpserver.CodeInvalidArguments {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+	}
+}
+
+// TestListGroupsMatchesGroupsList is the golden test: the structured content is
+// what groups.list returned, field for field.
+func TestListGroupsMatchesGroupsList(t *testing.T) {
+	h, _ := actionHarness(t)
+
+	res := h.call("list_groups", map[string]any{})
+	out := structured[mcpserver.ListGroupsOutput](t, res)
+
+	want := h.fake.Fixture().Groups
+	if !jsonEqual(t, out.Groups, want) {
+		t.Fatalf("list_groups returned\n%s\nwant\n%s", mustJSON(t, out.Groups), mustJSON(t, want))
+	}
+
+	text := textOf(res)
+	if !strings.HasPrefix(text, "2 groups\n\nGROUP") {
+		t.Errorf("the text block is not a table:\n%s", text)
+	}
+	for _, want := range []string{"shop", "shop-infra", "3000, 5173", "api, web"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("the table omits %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestListGroupsMarksStoppedServices(t *testing.T) {
+	fx := fakedaemon.DefaultFixture()
+	fx.Groups[0].Services[1].Running = false
+	h, _ := actionHarnessWith(t, fx)
+
+	text := textOf(h.call("list_groups", map[string]any{}))
+	if !strings.Contains(text, "web (stopped)") {
+		t.Errorf("a service nobody started is not marked:\n%s", text)
+	}
+}
+
+func TestListGroupsWhenThereAreNone(t *testing.T) {
+	fx := fakedaemon.DefaultFixture()
+	fx.Groups = nil
+	h, _ := actionHarnessWith(t, fx)
+
+	res := h.call("list_groups", map[string]any{})
+	out := structured[mcpserver.ListGroupsOutput](t, res)
+	if out.Groups == nil || len(out.Groups) != 0 {
+		t.Errorf("groups = %+v, want an empty array", out.Groups)
+	}
+	if !strings.HasPrefix(textOf(res), "no groups") {
+		t.Errorf("text = %q", textOf(res))
+	}
+}
+
+// openWhenSpawned plays the service coming up: as soon as runs.spawn has
+// recorded a run, the port it was going to open starts listening.
+func openWhenSpawned(t *testing.T, actions *fakedaemon.Actions, port int) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if runs := actions.Runs(); len(runs) > 0 {
+				time.Sleep(50 * time.Millisecond)
+				actions.OpenPortForRun(runs[0].ID, port)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	t.Cleanup(func() { <-done })
+}
+
+// decodeOutput reads structured content off a result the tool marked as an
+// error: start_service's timeout carries the run beside the error object.
+func decodeOutput[T any](t *testing.T, res *mcp.CallToolResult) T {
+	t.Helper()
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out T
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decoding structured content: %v\n%s", err, raw)
+	}
+	return out
+}
+
+func containsPort(ports []state.Port, want int) bool {
+	for _, p := range ports {
+		if p.Port == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcpserver/tools_read.go
+++ b/internal/mcpserver/tools_read.go
@@ -50,6 +50,8 @@ Call this before you act on a port you did not start. It answers the only questi
 
 If the port is bound by more than one process the call reports it as ambiguous; pass the pid from list_ports to pick one.`
 
+func init() { registerTools((*Server).addReadTools) }
+
 func (s *Server) addReadTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name:        "list_ports",


### PR DESCRIPTION
Roadmap step 2A.2.

- Tools: `kill` (one of port/pid/group/session/run_id; tree default true, force, dry_run) → `{killed, failed, dry_run}` routed to `ports.kill` / `groups.kill` / `sessions.kill` (capability-gated); `stop_group`; `rename_port` → `{port}`; `start_service` (argv, cwd, group, name, env, `wait_for_port` int|"auto", timeout) → run info plus the port rows, `IsError` with the run kept on timeout; `list_groups`.
- Tools register from a package-level registrar list so later tool files do not edit `server.go`.
- Fake daemon gains kill, rename, spawn, runs.list and a streaming `ports.wait`, all schema-validated.
- Daemon fixes found on the way: `groups.list` was declared in the contract and schema but had no handler (added, served from the snapshot); `ports.inspect` published raw probe health instead of the §22 `ok|fail|unknown` + `reason` (normalised).

Demo over stdio against a real daemon: `start_service` started an http.server with `wait_for_port`, `list_groups` showed it, `kill dry_run` planned one sigterm, `kill` freed the port.