### PR TITLE
feat: add the mcp query tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,10 +514,13 @@ other server and key in the file alone; running it twice changes nothing, and
 `--uninstall` removes exactly what sonar wrote.
 
 `sonar mcp` is that server: a stdio MCP server built into the binary that gives
-an agent the daemon's view of the machine, with `list_ports` and `inspect_port`
-today and actions and resources next. It starts a daemon if none is running and
-reconnects on its own if one goes away; its logs go to stderr, because stdout
-carries the protocol.
+an agent the daemon's view of the machine. It reads with `list_ports` and
+`inspect_port`, waits with `wait_for_port`, picks and reserves ports with
+`next_free_port` and `claim_port`, and answers the rest of an agent's questions
+with `tail_logs`, `health_check`, `dependency_graph`, `port_history` and
+`list_sessions`; actions and resources come next. It starts a daemon if none is
+running and reconnects on its own if one goes away; its logs go to stderr,
+because stdout carries the protocol.
 
 `install skills` writes the bundled skill, which teaches an agent to start
 servers with `sonar start --`, to `sonar wait` instead of sleeping, and to

--- a/internal/claims/identity.go
+++ b/internal/claims/identity.go
@@ -1,0 +1,52 @@
+package claims
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/groups"
+)
+
+// Identity derives the project and worktree a claim belongs to from a working
+// directory, letting an explicit project or worktree win over what the
+// directory says (spec 2 §4).
+//
+// It lives here rather than in the CLI because two callers ask the same
+// question from two different working directories: `sonar claim`, from the
+// shell's cwd, and the `claim_port` MCP tool, from the directory the agent
+// started the MCP server in. A key that differed between them would hand the
+// same worktree two sets of ports, which is exactly what claims exist to
+// prevent.
+//
+// A directory outside any git checkout claims under the directory's own name;
+// a directory that is not a checkout and has no name at all claims under
+// "sonar", so a key is never empty.
+func Identity(cwd, project, worktree string) (string, string) {
+	root, wt, ok := groups.Find(cwd)
+	switch {
+	case !ok:
+		if project == "" {
+			project = filepath.Base(cwd)
+		}
+	case wt != "":
+		// groups.Find spells a linked worktree "<repo>@<name>".
+		repo, name, _ := strings.Cut(wt, "@")
+		if project == "" {
+			project = repo
+		}
+		if worktree == "" {
+			worktree = name
+		}
+	default:
+		if project == "" {
+			project = filepath.Base(root)
+		}
+	}
+	if project == "" {
+		project = "sonar"
+	}
+	if worktree == "" {
+		worktree = DefaultWorktree
+	}
+	return project, worktree
+}

--- a/internal/claims/identity_test.go
+++ b/internal/claims/identity_test.go
@@ -1,0 +1,71 @@
+package claims_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/claims"
+)
+
+// TestIdentityFromACheckout covers the three shapes a working directory can
+// have: a plain checkout, a linked worktree, and no repository at all.
+func TestIdentityFromACheckout(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "myapp")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "web")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	project, worktree := claims.Identity(sub, "", "")
+	if project != "myapp" || worktree != claims.DefaultWorktree {
+		t.Errorf("Identity(checkout) = %q/%q, want myapp/%s", project, worktree, claims.DefaultWorktree)
+	}
+
+	// Explicit arguments win over the directory.
+	if p, w := claims.Identity(sub, "other", "feature"); p != "other" || w != "feature" {
+		t.Errorf("Identity with arguments = %q/%q, want other/feature", p, w)
+	}
+}
+
+func TestIdentityOutsideARepository(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "loose")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	project, worktree := claims.Identity(dir, "", "")
+	if project != "loose" || worktree != claims.DefaultWorktree {
+		t.Errorf("Identity(no repo) = %q/%q, want loose/%s", project, worktree, claims.DefaultWorktree)
+	}
+}
+
+// A linked worktree keeps the repository as the project and the checkout as
+// the worktree, so sibling worktrees of one repo get different keys.
+func TestIdentityInALinkedWorktree(t *testing.T) {
+	root := t.TempDir()
+	main := filepath.Join(root, "myapp")
+	if err := os.MkdirAll(filepath.Join(main, ".git", "worktrees", "feature-x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linked := filepath.Join(root, "myapp-feature-x")
+	if err := os.MkdirAll(linked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitfile := "gitdir: " + filepath.Join(main, ".git", "worktrees", "feature-x") + "\n"
+	if err := os.WriteFile(filepath.Join(linked, ".git"), []byte(gitfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// groups.Find names a linked worktree "<repo>@<checkout dir>", so the
+	// worktree half is the directory the agent is working in.
+	project, worktree := claims.Identity(linked, "", "")
+	if project != "myapp" || worktree != "myapp-feature-x" {
+		t.Errorf("Identity(linked worktree) = %q/%q, want myapp/myapp-feature-x", project, worktree)
+	}
+	if key := claims.Key(project, worktree); key != "myapp/myapp-feature-x" {
+		t.Errorf("key = %q, want myapp/myapp-feature-x", key)
+	}
+}

--- a/internal/cmd/claim.go
+++ b/internal/cmd/claim.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/raskrebs/sonar/internal/daemon/client"
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/display"
-	"github.com/raskrebs/sonar/internal/groups"
 	"github.com/raskrebs/sonar/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -215,40 +213,12 @@ func claimTTL() (time.Duration, error) {
 
 // claimIdentity derives the project and worktree from the current directory:
 // the git checkout's name, and the worktree name for a linked worktree (spec 2
-// §4). A directory outside any repository claims under its own name.
+// §4). The flags win over both. The derivation itself lives in internal/claims
+// so `sonar claim` and the `claim_port` MCP tool compute the same key.
 func claimIdentity() (project, worktree string) {
-	if claimProject != "" || claimWorktree != "" {
-		project, worktree = claimProject, claimWorktree
-	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = ""
 	}
-	root, wt, ok := groups.Find(cwd)
-	switch {
-	case !ok:
-		if project == "" {
-			project = filepath.Base(cwd)
-		}
-	case wt != "":
-		// groups.Find spells a linked worktree "<repo>@<name>".
-		repo, name, _ := strings.Cut(wt, "@")
-		if project == "" {
-			project = repo
-		}
-		if worktree == "" {
-			worktree = name
-		}
-	default:
-		if project == "" {
-			project = filepath.Base(root)
-		}
-	}
-	if project == "" {
-		project = "sonar"
-	}
-	if worktree == "" {
-		worktree = claims.DefaultWorktree
-	}
-	return project, worktree
+	return claims.Identity(cwd, claimProject, claimWorktree)
 }

--- a/internal/mcpserver/daemonstream.go
+++ b/internal/mcpserver/daemonstream.go
@@ -1,0 +1,45 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+)
+
+// Stream calls a streaming daemon method (contract §1) and hands back the open
+// stream. Only the request/reply half is bounded by the per-call timeout: the
+// chunks that follow are the caller's to drain for as long as its own context
+// allows, which is what makes a 300-second `ports.wait` possible on a
+// connection whose ordinary calls give up after ten.
+//
+// The caller owns the stream: drain it to its end, Cancel it when the client
+// goes away, and Close it when done.
+func (d *Daemon) Stream(ctx context.Context, method string, params any) (*client.Stream, error) {
+	c := d.current()
+	if c == nil {
+		return nil, d.unavailable()
+	}
+	callCtx, cancel := context.WithTimeout(ctx, d.opts.Timeout)
+	defer cancel()
+
+	st, err := c.Stream(callCtx, method, params, nil)
+	if err == nil {
+		return st, nil
+	}
+	switch {
+	case ctx.Err() != nil:
+		// The MCP client went away or cancelled; not a daemon fault.
+		return nil, ctx.Err()
+	case errors.Is(err, context.DeadlineExceeded):
+		return nil, Domain(CodeTimeout,
+			fmt.Sprintf("the daemon did not answer %s within %s", method, d.opts.Timeout),
+			"the daemon may be scanning a busy machine; retry, or check `sonar daemon status`")
+	}
+	if _, ok := asDomain(err); ok {
+		return nil, err // a daemon error object: pass the contract code through
+	}
+	d.log.Warn("daemon stream failed on a dropped connection", "method", method, "error", err)
+	return nil, d.unavailable()
+}

--- a/internal/mcpserver/fakedaemon/conn.go
+++ b/internal/mcpserver/fakedaemon/conn.go
@@ -18,9 +18,10 @@ type conn struct {
 	nc  net.Conn
 	enc *rpc.Encoder
 
-	mu     sync.Mutex
-	subbed bool
-	closed bool
+	mu      sync.Mutex
+	subbed  bool
+	closed  bool
+	streams map[string]*Stream
 }
 
 func newConn(f *Fake, nc net.Conn) *conn {
@@ -47,6 +48,11 @@ func (c *conn) serve() {
 }
 
 func (c *conn) answer(msg rpc.Message) {
+	if h, ok := c.f.streamHandler(msg.Method); ok {
+		c.f.count(msg.Method)
+		c.answerStream(msg, h)
+		return
+	}
 	result, err := c.handle(msg.Method, msg.Params)
 	resp := rpc.Response{JSONRPC: rpc.Version, ID: msg.ID}
 	if err != nil {
@@ -76,6 +82,9 @@ func (c *conn) handle(method string, params json.RawMessage) (any, error) {
 		c.f.count(method)
 		c.setSubscribed(false)
 		return rpc.OKResult{OK: true}, nil
+	case rpc.MethodStreamCancel:
+		c.f.count(method)
+		return c.cancelStream(params)
 	}
 	return c.f.dispatch(method, params)
 }

--- a/internal/mcpserver/fakedaemon/fakedaemon.go
+++ b/internal/mcpserver/fakedaemon/fakedaemon.go
@@ -39,11 +39,14 @@ type Fake struct {
 	mu       sync.Mutex
 	fixture  Fixture
 	handlers map[string]Handler
-	conns    map[*conn]struct{}
-	ln       net.Listener
-	addr     string
-	seq      uint64
-	closed   bool
+	// streamHandlers holds the methods answered with a subscription id and a
+	// run of chunks (see stream.go).
+	streamHandlers map[string]StreamHandler
+	conns          map[*conn]struct{}
+	ln             net.Listener
+	addr           string
+	seq            uint64
+	closed         bool
 
 	// Calls counts every request the fake has answered, by method. Tests use
 	// it to assert that a read was served once, not once per retry.
@@ -55,21 +58,24 @@ type Fake struct {
 // New builds a fake serving fixture. Call Start to bind an address.
 func New(fixture Fixture) *Fake {
 	f := &Fake{
-		fixture:  fixture,
-		handlers: map[string]Handler{},
-		conns:    map[*conn]struct{}{},
-		seq:      1,
+		fixture:        fixture,
+		handlers:       map[string]Handler{},
+		streamHandlers: map[string]StreamHandler{},
+		conns:          map[*conn]struct{}{},
+		seq:            1,
 	}
 	f.registerCore()
 	return f
 }
 
 // Handle registers or replaces the handler for a method. Later slices add
-// their own methods this way.
+// their own methods this way. Replacing a streaming method makes it unary
+// again, so a test can stub one out with a plain reply.
 func (f *Fake) Handle(method string, h Handler) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.handlers[method] = h
+	delete(f.streamHandlers, method)
 }
 
 // ResetHandlers restores the built-in method set, dropping anything a test
@@ -77,6 +83,7 @@ func (f *Fake) Handle(method string, h Handler) {
 func (f *Fake) ResetHandlers() {
 	f.mu.Lock()
 	f.handlers = map[string]Handler{}
+	f.streamHandlers = map[string]StreamHandler{}
 	f.mu.Unlock()
 	f.registerCore()
 }

--- a/internal/mcpserver/fakedaemon/handlers.go
+++ b/internal/mcpserver/fakedaemon/handlers.go
@@ -22,6 +22,7 @@ func (f *Fake) registerCore() {
 	f.Handle("groups.list", func(json.RawMessage) (any, error) {
 		return rpc.GroupsListResult{Groups: f.Fixture().Groups}, nil
 	})
+	f.registerQuery()
 }
 
 func (f *Fake) handleHello(raw json.RawMessage) (any, error) {

--- a/internal/mcpserver/fakedaemon/handlers.go
+++ b/internal/mcpserver/fakedaemon/handlers.go
@@ -113,6 +113,9 @@ func (f *Fake) handlePortsList(raw json.RawMessage) (any, error) {
 		if p.Group != nil && *p.Group != "" && !inGroup(row, *p.Group) {
 			continue
 		}
+		if p.Session != nil && *p.Session != "" && !inSession(row, *p.Session) {
+			continue
+		}
 		out = append(out, filterPort(row, include))
 	}
 	return rpc.PortsListResult{Ports: out}, nil
@@ -185,6 +188,15 @@ func resolvePort(rows []state.Port, sel rpc.Selector) (state.Port, error) {
 			fmt.Sprintf("port %d is bound to multiple addresses: %s", *sel.Port, strings.Join(addrs, ", ")),
 			fmt.Sprintf("pass a bind address (e.g. --ip %s)", addrs[0]))
 	}
+}
+
+// inSession is the daemon's session filter: the id, or a unique prefix of it
+// (contract §29), never the label.
+func inSession(p state.Port, id string) bool {
+	if p.Session == nil {
+		return false
+	}
+	return strings.HasPrefix(p.Session.ID, id)
 }
 
 func inGroup(p state.Port, group string) bool {

--- a/internal/mcpserver/fakedaemon/handlers_query.go
+++ b/internal/mcpserver/fakedaemon/handlers_query.go
@@ -1,0 +1,521 @@
+package fakedaemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/claims"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// The methods behind the MCP query tools (step 2A.5): waiting, free ports,
+// claims, logs, health, the connection graph, history and sessions.
+//
+// Each one mirrors the daemon's own handler — the same defaults, the same
+// argument validation, the same error codes — over the fixture instead of over
+// a scan. Where the daemon probes the machine (a TCP connect, an HTTP GET, a
+// `tail`), the fake answers from the fixture: a port is ready when the fixture
+// says something is listening on it, healthy when the fixture row says so, and
+// its log backlog is generated from its name.
+
+// waitPollInterval is how often the fake re-reads the fixture while a
+// ports.wait stream is open. It is far below the daemon's 1 s so a test that
+// makes a port appear does not pay for a real poll cadence.
+const waitPollInterval = 5 * time.Millisecond
+
+// logBacklog is how many lines the fake pretends every process has written. It
+// sits between the tool's default (100) and its maximum (2000) so both the
+// truncated and the untruncated case are reachable.
+const logBacklog = 250
+
+// registerQuery installs the query half of the protocol.
+func (f *Fake) registerQuery() {
+	f.Handle("ports.health", f.handlePortsHealth)
+	f.Handle("ports.logs", f.handlePortsLogs)
+	f.Handle("ports.graph", f.handlePortsGraph)
+	f.Handle("ports.history", f.handlePortsHistory)
+	f.Handle("sessions.list", f.handleSessionsList)
+	f.HandleStream("ports.wait", f.handlePortsWait)
+
+	// One claim book per fake, held by the handlers rather than by the Fake:
+	// resetting the handlers resets the book with them.
+	book := claims.New(newMemClaims(), claims.Options{Listening: f.listeningSet})
+	f.Handle("ports.next", func(raw json.RawMessage) (any, error) {
+		return f.portsNext(raw, book)
+	})
+	f.Handle("claims.acquire", func(raw json.RawMessage) (any, error) {
+		var p rpc.ClaimsAcquireParams
+		if err := unmarshal(raw, &p); err != nil {
+			return nil, err
+		}
+		ttl := time.Duration(p.TTLSeconds) * time.Second
+		if p.TTLSeconds == 0 && p.TTLMs > 0 {
+			ttl = time.Duration(p.TTLMs) * time.Millisecond
+		}
+		res, err := book.Acquire(claims.Request{
+			Key: p.Key, Project: p.Project, Worktree: p.Worktree,
+			Count: p.Count, TTL: ttl,
+		})
+		if err != nil {
+			return nil, claimsError(err)
+		}
+		affected := make([]string, 0, len(res.Ports))
+		for _, port := range res.Ports {
+			affected = append(affected, fmt.Sprintf("%d:", port))
+		}
+		return rpc.ClaimsAcquireResult{
+			MutationResult: rpc.MutationResult{OK: true, Affected: affected},
+			Key:            res.Key,
+			Ports:          res.Ports,
+			ExpiresAt:      res.ExpiresAt.UTC().Format(time.RFC3339),
+		}, nil
+	})
+	f.Handle("claims.release", func(raw json.RawMessage) (any, error) {
+		var p rpc.ClaimsReleaseParams
+		if err := unmarshal(raw, &p); err != nil {
+			return nil, err
+		}
+		if p.Key == "" {
+			return nil, rpc.NewError(rpc.CodeInvalidParams, "key is required",
+				`release the key claims.acquire returned, e.g. {"key": "sonar/main"}`)
+		}
+		n, err := book.Release(p.Key)
+		if err != nil {
+			return nil, claimsError(err)
+		}
+		return rpc.ClaimsReleaseResult{OK: true, Released: n}, nil
+	})
+	f.Handle("claims.list", func(json.RawMessage) (any, error) {
+		live, err := book.List()
+		if err != nil {
+			return nil, claimsError(err)
+		}
+		if live == nil {
+			live = []state.Claim{}
+		}
+		return rpc.ClaimsListResult{Claims: live}, nil
+	})
+}
+
+// listeningSet is the fixture as the set of ports something is bound to, which
+// is what a claim probe and `ports.next` step over.
+func (f *Fake) listeningSet() (map[int]bool, error) {
+	out := map[int]bool{}
+	for _, row := range f.Fixture().Ports {
+		out[row.Port] = true
+	}
+	return out, nil
+}
+
+// handlePortsNext mirrors the daemon: defaults of 3000/65535/1, a run of
+// consecutive free ports, and foreign claims counted as occupied.
+func (f *Fake) portsNext(raw json.RawMessage, book *claims.Manager) (any, error) {
+	var p rpc.PortsNextParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	start, end, count := p.Start, p.End, p.Count
+	if start == 0 {
+		start = 3000
+	}
+	if end == 0 {
+		end = 65535
+	}
+	if count == 0 {
+		count = 1
+	}
+	if start < 1 || end > 65535 || start > end {
+		return nil, rpc.NewError(rpc.CodeInvalidParams,
+			fmt.Sprintf("invalid port range %d-%d", start, end), "")
+	}
+	if count < 1 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "count must be at least 1", "")
+	}
+
+	occupied, _ := f.listeningSet()
+	held, err := book.Held()
+	if err != nil {
+		return nil, claimsError(err)
+	}
+	for port, key := range held {
+		if p.ClaimKey == nil || *p.ClaimKey != key {
+			occupied[port] = true
+		}
+	}
+
+	free := make([]int, 0, count)
+	for port := start; port <= end; port++ {
+		if occupied[port] {
+			free = free[:0]
+			continue
+		}
+		free = append(free, port)
+		if len(free) == count {
+			return rpc.PortsNextResult{Ports: free}, nil
+		}
+	}
+	return nil, rpc.NewError(rpc.CodeNotFound,
+		fmt.Sprintf("no %d consecutive free port(s) in range %d-%d", count, start, end),
+		"widen the range")
+}
+
+// handlePortsWait streams one chunk per port that becomes ready and ends with
+// {ready, timed_out}. Readiness is "the fixture has this port"; with an http
+// path, the fixture row must also be healthy, which is how a test asks for the
+// difference between a socket that accepts and a server that answers.
+func (f *Fake) handlePortsWait(raw json.RawMessage, s *Stream) (any, error) {
+	var p rpc.PortsWaitParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if len(p.Ports) == 0 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "ports is required",
+			`send {"ports": [3000], "timeout_ms": 30000}`)
+	}
+	if p.TimeoutMs <= 0 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "timeout_ms must be positive", "")
+	}
+	wantHTTP := p.HTTP != nil && *p.HTTP != ""
+
+	targets := append([]int{}, p.Ports...)
+	sort.Ints(targets)
+	pending := map[int]bool{}
+	for _, port := range targets {
+		pending[port] = true
+	}
+
+	ready := []int{}
+	deadline := time.NewTimer(time.Duration(p.TimeoutMs) * time.Millisecond)
+	defer deadline.Stop()
+	tick := time.NewTicker(waitPollInterval)
+	defer tick.Stop()
+
+	for {
+		live := f.Fixture().Ports
+		for _, port := range targets {
+			if !pending[port] || !f.portReady(live, port, wantHTTP) {
+				continue
+			}
+			delete(pending, port)
+			ready = append(ready, port)
+			s.Chunk(rpc.PortsWaitChunk{Port: port, ReadyAt: FixtureTime})
+		}
+		if len(pending) == 0 || (p.Any && len(ready) > 0) {
+			return rpc.PortsWaitEnd{Ready: ready, TimedOut: []int{}}, nil
+		}
+
+		select {
+		case <-s.Cancelled():
+			return rpc.PortsWaitEnd{Ready: ready, TimedOut: stillPending(targets, pending)}, nil
+		case <-deadline.C:
+			return rpc.PortsWaitEnd{Ready: ready, TimedOut: stillPending(targets, pending)}, nil
+		case <-tick.C:
+		}
+	}
+}
+
+func (f *Fake) portReady(rows []state.Port, port int, wantHTTP bool) bool {
+	for _, row := range rows {
+		if row.Port != port {
+			continue
+		}
+		if !wantHTTP {
+			return true
+		}
+		return row.Health != nil && row.Health.Status == state.HealthOK
+	}
+	return false
+}
+
+func stillPending(targets []int, pending map[int]bool) []int {
+	out := []int{}
+	for _, port := range targets {
+		if pending[port] {
+			out = append(out, port)
+		}
+	}
+	return out
+}
+
+// handlePortsHealth answers from each row's fixture health. A port nothing is
+// listening on still gets a row — the daemon's rule, so a caller asking about a
+// fixed list never has to match up indexes — and it reads as a refused probe.
+func (f *Fake) handlePortsHealth(raw json.RawMessage) (any, error) {
+	var p rpc.PortsHealthParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	rows := f.Fixture().Ports
+	byPort := map[int]state.Port{}
+	order := []int{}
+	for _, row := range rows {
+		if _, seen := byPort[row.Port]; !seen {
+			byPort[row.Port] = row
+			order = append(order, row.Port)
+		}
+	}
+	if len(p.Ports) > 0 {
+		order = p.Ports
+	}
+
+	results := make([]rpc.PortHealth, 0, len(order))
+	for _, port := range order {
+		row, listening := byPort[port]
+		switch {
+		case !listening:
+			results = append(results, rpc.PortHealth{Port: port, Status: state.HealthFail, Reason: "refused"})
+		case row.Health == nil:
+			results = append(results, rpc.PortHealth{Port: port, Status: state.HealthUnknown})
+		default:
+			results = append(results, rpc.PortHealth{
+				Port:      port,
+				Status:    row.Health.Status,
+				Code:      row.Health.Code,
+				LatencyMs: int64(row.Health.LatencyMs),
+				Reason:    row.Health.Reason,
+			})
+		}
+	}
+	return rpc.PortsHealthResult{Results: results}, nil
+}
+
+// handlePortsLogs is the unary half of ports.logs (contract §20): flat
+// selector params, `{source, lines, truncated}` back. `follow` is refused
+// rather than faked, because nothing above the daemon uses it yet.
+func (f *Fake) handlePortsLogs(raw json.RawMessage) (any, error) {
+	var p rpc.PortsLogsParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if p.Follow {
+		return nil, rpc.NewError(rpc.CodeUnsupported, "the fake daemon does not follow logs", "")
+	}
+	row, err := resolvePort(f.Fixture().Ports, p.Selector)
+	if err != nil {
+		return nil, err
+	}
+	lines := p.Lines
+	if lines <= 0 {
+		lines = 100
+	}
+
+	backlog := LogLines(row, logBacklog)
+	if len(backlog) > lines {
+		backlog = backlog[len(backlog)-lines:]
+	}
+	return rpc.PortsLogsResult{
+		Source:    LogSource(row),
+		Lines:     backlog,
+		Truncated: len(backlog) >= lines,
+	}, nil
+}
+
+// LogSource is where the fake says a port's output comes from: a container log
+// for a docker row, a file for everything else, the way the daemon's own
+// ladder labels them.
+func LogSource(row state.Port) string {
+	if row.Docker != nil && row.Docker.Container != "" {
+		return "docker:" + row.Docker.Container
+	}
+	return fmt.Sprintf("/tmp/sonar/%s-%d.log", row.DisplayName, row.PID)
+}
+
+// LogLines generates n deterministic log lines for a port, oldest first.
+func LogLines(row state.Port, n int) []string {
+	out := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		out = append(out, fmt.Sprintf("%s[%d] line %d", row.DisplayName, row.PID, i))
+	}
+	return out
+}
+
+// handlePortsGraph returns the fixture's connection graph. DefaultGraphEdges
+// carries a duplicated edge on purpose: aggregating repeats into a connection
+// count is the tool's job, not the daemon's.
+func (f *Fake) handlePortsGraph(json.RawMessage) (any, error) {
+	return rpc.PortsGraphResult{Connections: DefaultGraphEdges()}, nil
+}
+
+// DefaultGraphEdges is the fixture's graph: the vite dev server proxying to
+// the api twice, the api talking to postgres, and the gateway in front of the
+// api.
+func DefaultGraphEdges() []rpc.GraphEdge {
+	return []rpc.GraphEdge{
+		{FromPort: 5173, FromPID: 4210, FromProcess: "vite", ToPort: 3000, ToPID: 4101, ToProcess: "api"},
+		{FromPort: 5173, FromPID: 4210, FromProcess: "vite", ToPort: 3000, ToPID: 4101, ToProcess: "api"},
+		{FromPort: 3000, FromPID: 4101, FromProcess: "api", ToPort: 5432, ToPID: 3300, ToProcess: "shop-db"},
+		{FromPort: 8080, FromPID: 3301, FromProcess: "shop-gateway", ToPort: 3000, ToPID: 4101, ToProcess: "api"},
+	}
+}
+
+// handlePortsHistory answers from a generated ring, newest first, honouring
+// the daemon's `since` grammar (a duration or an RFC 3339 timestamp) and its
+// port and limit filters.
+func (f *Fake) handlePortsHistory(raw json.RawMessage) (any, error) {
+	var p rpc.PortsHistoryParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	since, err := parseSince(p.Since)
+	if err != nil {
+		return nil, err
+	}
+
+	events := []rpc.HistoryEvent{}
+	for _, e := range HistoryEvents(time.Now()) {
+		at, perr := time.Parse(time.RFC3339, e.At)
+		if perr != nil {
+			continue
+		}
+		if !since.IsZero() && at.Before(since) {
+			continue
+		}
+		if p.Port != nil && *p.Port != 0 && e.Port != *p.Port {
+			continue
+		}
+		events = append(events, e)
+	}
+	if p.Limit > 0 && len(events) > p.Limit {
+		events = events[:p.Limit]
+	}
+	return rpc.PortsHistoryResult{Events: events}, nil
+}
+
+// HistoryEvents is the fixture's history ring, newest first and stamped
+// relative to now so a `since` window means the same thing whenever the tests
+// run: one event an hour old, one two hours old, one from the day before.
+func HistoryEvents(now time.Time) []rpc.HistoryEvent {
+	stamp := func(d time.Duration) string { return now.Add(-d).UTC().Format(time.RFC3339) }
+	return []rpc.HistoryEvent{
+		{At: stamp(time.Hour), Kind: "opened", Port: 3000, PID: 4101, DisplayName: "api", Group: "shop"},
+		{At: stamp(2 * time.Hour), Kind: "closed", Port: 5173, PID: 4209, DisplayName: "vite", Group: "shop"},
+		{At: stamp(30 * time.Hour), Kind: "opened", Port: 5432, PID: 3300, DisplayName: "shop-db", Group: "shop-infra"},
+	}
+}
+
+// parseSince is the daemon's grammar for the history window (contract §22).
+func parseSince(since *string) (time.Time, error) {
+	if since == nil || strings.TrimSpace(*since) == "" {
+		return time.Time{}, nil
+	}
+	raw := strings.TrimSpace(*since)
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t, nil
+	}
+	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+		return time.Now().Add(-d), nil
+	}
+	return time.Time{}, rpc.NewError(rpc.CodeInvalidParams,
+		"since must be an RFC 3339 timestamp or a duration like 24h, got "+raw, "")
+}
+
+func (f *Fake) handleSessionsList(raw json.RawMessage) (any, error) {
+	var p rpc.SessionsListParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	out := []state.SessionRecord{}
+	for _, s := range f.Fixture().Sessions {
+		if p.ActiveOnly && !s.Active {
+			continue
+		}
+		out = append(out, s)
+	}
+	return rpc.SessionsListResult{Sessions: out}, nil
+}
+
+// claimsError maps the manager's failures onto the contract §2 codes, the same
+// way the daemon's handler does (contract §28).
+func claimsError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case strings.Contains(err.Error(), claims.ErrExhausted.Error()):
+		return rpc.NewError(rpc.CodeNotFound, err.Error(),
+			"release stale claims with `sonar claim --release` or widen the range")
+	case strings.Contains(err.Error(), claims.ErrNoProject.Error()):
+		return rpc.NewError(rpc.CodeInvalidParams, err.Error(),
+			`send {"project": "myapp", "worktree": "main"} or {"key": "myapp/main"}`)
+	default:
+		return rpc.NewError(rpc.CodeInternal, err.Error(), "")
+	}
+}
+
+// memClaims is claims.Table in memory: the fake's stand-in for the SQLite
+// table, so the claim behaviour under test is the real manager's.
+type memClaims struct {
+	mu   sync.Mutex
+	rows map[int]store.ClaimRow
+}
+
+func newMemClaims() *memClaims { return &memClaims{rows: map[int]store.ClaimRow{}} }
+
+func (m *memClaims) Put(rows ...store.ClaimRow) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, r := range rows {
+		if held, ok := m.rows[r.Port]; ok && held.Key != r.Key {
+			return store.ErrClaimed
+		}
+	}
+	for _, r := range rows {
+		m.rows[r.Port] = r
+	}
+	return nil
+}
+
+func (m *memClaims) Get(key string) ([]store.ClaimRow, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := []store.ClaimRow{}
+	for _, r := range m.rows {
+		if r.Key == key {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Port < out[j].Port })
+	return out, nil
+}
+
+func (m *memClaims) List() ([]store.ClaimRow, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]store.ClaimRow, 0, len(m.rows))
+	for _, r := range m.rows {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Port < out[j].Port })
+	return out, nil
+}
+
+func (m *memClaims) Delete(key string) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for port, r := range m.rows {
+		if r.Key == key {
+			delete(m.rows, port)
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (m *memClaims) Expire(now time.Time) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for port, r := range m.rows {
+		if !r.ExpiresAt.IsZero() && r.ExpiresAt.Before(now) {
+			delete(m.rows, port)
+			n++
+		}
+	}
+	return n, nil
+}

--- a/internal/mcpserver/fakedaemon/handlers_query.go
+++ b/internal/mcpserver/fakedaemon/handlers_query.go
@@ -233,15 +233,6 @@ func (f *Fake) portReady(rows []state.Port, port int, wantHTTP bool) bool {
 	return false
 }
 
-func stillPending(targets []int, pending map[int]bool) []int {
-	out := []int{}
-	for _, port := range targets {
-		if pending[port] {
-			out = append(out, port)
-		}
-	}
-	return out
-}
 
 // handlePortsHealth answers from each row's fixture health. A port nothing is
 // listening on still gets a row — the daemon's rule, so a caller asking about a

--- a/internal/mcpserver/fakedaemon/schema_test.go
+++ b/internal/mcpserver/fakedaemon/schema_test.go
@@ -36,6 +36,15 @@ func TestRepliesValidateAgainstTheProtocolSchema(t *testing.T) {
 		{"ports.list", rpc.PortsListParams{Include: rpc.Include{"stats", "health"}}, "PortsListResult"},
 		{"ports.inspect", rpc.Selector{Port: intp(3000)}, "PortsInspectResult"},
 		{"groups.list", rpc.Empty{}, "GroupsListResult"},
+		{"ports.next", rpc.PortsNextParams{Start: 3001}, "PortsNextResult"},
+		{"ports.health", rpc.PortsHealthParams{Ports: []int{3000, 9999}}, "PortsHealthResult"},
+		{"ports.logs", rpc.PortsLogsParams{Selector: rpc.Selector{Port: intp(3000)}}, "PortsLogsResult"},
+		{"ports.graph", rpc.Empty{}, "PortsGraphResult"},
+		{"ports.history", rpc.PortsHistoryParams{Since: strp("48h")}, "PortsHistoryResult"},
+		{"sessions.list", rpc.SessionsListParams{}, "SessionsListResult"},
+		{"claims.acquire", rpc.ClaimsAcquireParams{Project: "shop"}, "ClaimsAcquireResult"},
+		{"claims.list", rpc.Empty{}, "ClaimsListResult"},
+		{"claims.release", rpc.ClaimsReleaseParams{Key: "shop/main"}, "ClaimsReleaseResult"},
 	}
 
 	for _, tc := range cases {
@@ -46,6 +55,69 @@ func TestRepliesValidateAgainstTheProtocolSchema(t *testing.T) {
 			}
 			validate(t, tc.def, raw)
 		})
+	}
+}
+
+// TestWaitStreamValidates covers the streaming half: ports.wait chunks and its
+// end payload are the shapes the contract publishes, and the stream ends even
+// when the client cancels it.
+func TestWaitStreamValidates(t *testing.T) {
+	c := connect(t, fakedaemon.DefaultFixture())
+
+	st, err := c.Stream(t.Context(), "ports.wait", rpc.PortsWaitParams{
+		Ports: []int{3000, 65000}, TimeoutMs: 200,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ports.wait: %v", err)
+	}
+	chunks := 0
+	for raw := range st.Chunks() {
+		validate(t, "PortsWaitChunk", raw)
+		chunks++
+	}
+	if chunks != 1 {
+		t.Errorf("got %d chunks, want one for the listening port", chunks)
+	}
+	end := <-st.End()
+	if end.Err != nil {
+		t.Fatalf("the stream ended with an error: %v", end.Err)
+	}
+	validate(t, "PortsWaitEnd", end.Data)
+
+	var payload rpc.PortsWaitEnd
+	if err := end.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Ready) != 1 || payload.Ready[0] != 3000 {
+		t.Errorf("ready = %v, want [3000]", payload.Ready)
+	}
+	if len(payload.TimedOut) != 1 || payload.TimedOut[0] != 65000 {
+		t.Errorf("timed_out = %v, want [65000]", payload.TimedOut)
+	}
+}
+
+// TestWaitStreamCancels is contract §20: a cancelled stream still ends, with
+// no error and with whatever it had.
+func TestWaitStreamCancels(t *testing.T) {
+	c := connect(t, fakedaemon.DefaultFixture())
+
+	st, err := c.Stream(t.Context(), "ports.wait", rpc.PortsWaitParams{
+		Ports: []int{65000}, TimeoutMs: 60_000,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ports.wait: %v", err)
+	}
+	if err := st.Cancel(t.Context()); err != nil {
+		t.Fatalf("stream.cancel: %v", err)
+	}
+	select {
+	case end := <-st.End():
+		if end.Err != nil {
+			t.Fatalf("a cancelled stream ended with an error: %v", end.Err)
+		}
+		validate(t, "PortsWaitEnd", end.Data)
+	case <-time.After(5 * time.Second):
+		t.Fatal("a cancelled stream never ended")
 	}
 }
 

--- a/internal/mcpserver/fakedaemon/stream.go
+++ b/internal/mcpserver/fakedaemon/stream.go
@@ -1,0 +1,137 @@
+package fakedaemon
+
+import (
+	"encoding/json"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+)
+
+// The fake's half of the streaming convention (contract §1): the reply carries
+// a `subscription_id`, `stream.chunk` notifications follow it, and exactly one
+// `stream.end` closes it — including when the client cancels, which ends the
+// stream with the data it has rather than with an error.
+//
+// A streaming handler runs after its reply has been written, on the same
+// goroutine that answered the request, so a test can drive `ports.wait` and
+// change the fixture underneath it without racing the reply.
+
+// StreamHandler produces one stream's chunks and its end payload. Returning a
+// *rpc.Error ends the stream with that error; the fake sends the end either
+// way, so a caller draining the stream always finishes.
+type StreamHandler func(params json.RawMessage, s *Stream) (any, error)
+
+// HandleStream registers a streaming method. It replaces any unary handler
+// registered for the same name.
+func (f *Fake) HandleStream(method string, h StreamHandler) {
+	f.Handle(method, func(json.RawMessage) (any, error) {
+		// Unary dispatch is never reached: conn.answer routes a streaming
+		// method to the handler below. This entry exists so the method is
+		// known to dispatch (and counted) like any other.
+		return nil, rpc.NewError(rpc.CodeInternal, method+" is a streaming method", "")
+	})
+	f.mu.Lock()
+	if f.streamHandlers == nil {
+		f.streamHandlers = map[string]StreamHandler{}
+	}
+	f.streamHandlers[method] = h
+	f.mu.Unlock()
+}
+
+// streamHandler looks up a streaming method.
+func (f *Fake) streamHandler(method string) (StreamHandler, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	h, ok := f.streamHandlers[method]
+	return h, ok
+}
+
+// Stream is one open stream, handed to a StreamHandler.
+type Stream struct {
+	id string
+	c  *conn
+
+	once      sync.Once
+	cancelled chan struct{}
+}
+
+// streamSeq numbers subscription ids the way the daemon does ("sub-<n>",
+// contract §20), across every fake in the process so an id is never reused.
+var streamSeq atomic.Int64
+
+// ID is the subscription id the client was told.
+func (s *Stream) ID() string { return s.id }
+
+// Chunk sends one stream.chunk.
+func (s *Stream) Chunk(v any) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	s.c.notify(rpc.MethodStreamChunk, rpc.StreamChunk{ID: s.id, Data: raw})
+}
+
+// Cancelled closes when the client sends stream.cancel. A handler that waits
+// should select on it and return the result it has so far.
+func (s *Stream) Cancelled() <-chan struct{} { return s.cancelled }
+
+func (s *Stream) cancel() { s.once.Do(func() { close(s.cancelled) }) }
+
+// answerStream replies with the subscription id, runs the handler, and ends
+// the stream with what it returned.
+func (c *conn) answerStream(msg rpc.Message, h StreamHandler) {
+	s := &Stream{
+		id:        "sub-" + strconv.FormatInt(streamSeq.Add(1), 10),
+		c:         c,
+		cancelled: make(chan struct{}),
+	}
+
+	c.mu.Lock()
+	if c.streams == nil {
+		c.streams = map[string]*Stream{}
+	}
+	c.streams[s.id] = s
+	c.mu.Unlock()
+
+	reply, err := json.Marshal(struct {
+		SubscriptionID string `json:"subscription_id"`
+	}{s.id})
+	if err != nil {
+		return
+	}
+	_ = c.enc.Encode(rpc.Response{JSONRPC: rpc.Version, ID: msg.ID, Result: reply})
+
+	data, hErr := h(msg.Params, s)
+	end := rpc.StreamEnd{ID: s.id}
+	if hErr != nil {
+		end.Error = asRPCError(hErr)
+	} else if data != nil {
+		if raw, mErr := json.Marshal(data); mErr == nil {
+			end.Data = raw
+		}
+	}
+	c.notify(rpc.MethodStreamEnd, end)
+
+	c.mu.Lock()
+	delete(c.streams, s.id)
+	c.mu.Unlock()
+}
+
+// cancelStream serves stream.cancel: the stream is told to stop, and its
+// handler still sends the final stream.end (contract §20).
+func (c *conn) cancelStream(params json.RawMessage) (any, error) {
+	var p rpc.StreamCancel
+	if err := unmarshal(params, &p); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	s, ok := c.streams[p.ID]
+	c.mu.Unlock()
+	if !ok {
+		return nil, rpc.NewError(rpc.CodeNotFound, "unknown subscription "+p.ID, "")
+	}
+	s.cancel()
+	return rpc.OKResult{OK: true}, nil
+}

--- a/internal/mcpserver/integration_test.go
+++ b/internal/mcpserver/integration_test.go
@@ -20,7 +20,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -39,16 +38,144 @@ func TestRealDaemonToolsList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tools/list: %v", err)
 	}
-	names := []string{}
+	names := map[string]bool{}
 	for _, tool := range res.Tools {
-		names = append(names, tool.Name)
-		t.Logf("%-13s readOnly=%v openWorld=%v", tool.Name,
+		names[tool.Name] = true
+		t.Logf("%-16s readOnly=%v openWorld=%v", tool.Name,
 			tool.Annotations.ReadOnlyHint, *tool.Annotations.OpenWorldHint)
 	}
-	for _, want := range []string{"list_ports", "inspect_port"} {
-		if !slices.Contains(names, want) {
-			t.Fatalf("tools/list = %v, want it to include %s", names, want)
+	for _, want := range []string{
+		"list_ports", "inspect_port", "wait_for_port", "next_free_port", "claim_port",
+		"tail_logs", "health_check", "dependency_graph", "port_history", "list_sessions",
+	} {
+		if !names[want] {
+			t.Errorf("tools/list is missing %s: %v", want, names)
 		}
+	}
+}
+
+// TestQueryToolsAgainstARealDaemon is step 2A.5's demo in executable form:
+// claim a port, bind it, wait for it, probe it, and read the machine's history
+// and sessions — all through the tools, against a real daemon.
+func TestQueryToolsAgainstARealDaemon(t *testing.T) {
+	e := newRealEnv(t)
+	session := e.connect(t)
+	ctx := context.Background()
+
+	callTool := func(name string, args map[string]any) *mcp.CallToolResult {
+		t.Helper()
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+		if err != nil {
+			t.Fatalf("%s: protocol error: %v\nstderr:\n%s", name, err, e.stderr())
+		}
+		if res.IsError {
+			t.Fatalf("%s failed: %s", name, textOf(res))
+		}
+		return res
+	}
+
+	// A port of our own, reserved the way an agent would reserve one.
+	var claim struct {
+		Key       string `json:"key"`
+		Ports     []int  `json:"ports"`
+		ExpiresAt string `json:"expires_at"`
+		Released  int    `json:"released"`
+	}
+	decodeStructured(t, callTool("claim_port", map[string]any{
+		"project": "mcp-itest", "worktree": "main",
+	}), &claim)
+	if len(claim.Ports) != 1 || claim.Key != "mcp-itest/main" {
+		t.Fatalf("claim_port = %+v, want one port under mcp-itest/main", claim)
+	}
+	t.Logf("claim_port → %s holds %v until %s", claim.Key, claim.Ports, claim.ExpiresAt)
+	port := claim.Ports[0]
+
+	// Claiming again is idempotent, which is the promise the annotation makes.
+	var again struct {
+		Ports []int `json:"ports"`
+	}
+	decodeStructured(t, callTool("claim_port", map[string]any{
+		"project": "mcp-itest", "worktree": "main",
+	}), &again)
+	if len(again.Ports) != 1 || again.Ports[0] != port {
+		t.Errorf("claiming again = %v, want the same port %d", again.Ports, port)
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Skipf("the claimed port %d could not be bound: %v", port, err)
+	}
+	defer ln.Close()
+
+	var wait struct {
+		Ready     []int `json:"ready"`
+		TimedOut  []int `json:"timed_out"`
+		ElapsedMs int64 `json:"elapsed_ms"`
+	}
+	decodeStructured(t, callTool("wait_for_port", map[string]any{
+		"ports": []any{port}, "timeout_seconds": 15,
+	}), &wait)
+	if len(wait.Ready) != 1 || wait.Ready[0] != port {
+		t.Fatalf("wait_for_port = %+v, want %d ready", wait, port)
+	}
+	t.Logf("wait_for_port → ready %v in %dms", wait.Ready, wait.ElapsedMs)
+
+	var health struct {
+		Status    string `json:"status"`
+		Code      int    `json:"code"`
+		LatencyMs int64  `json:"latency_ms"`
+		URL       string `json:"url"`
+		Reason    string `json:"reason"`
+	}
+	decodeStructured(t, callTool("health_check", map[string]any{"port": port}), &health)
+	switch health.Status {
+	case "ok", "fail", "unknown":
+	default:
+		t.Errorf("health_check status = %q, want ok, fail or unknown", health.Status)
+	}
+	if health.URL != fmt.Sprintf("http://localhost:%d/", port) {
+		t.Errorf("health_check url = %q", health.URL)
+	}
+	t.Logf("health_check → %s (%s)", health.Status, health.Reason)
+
+	// A free port is never the one we are holding.
+	var next struct {
+		Ports []int `json:"ports"`
+	}
+	decodeStructured(t, callTool("next_free_port", map[string]any{"start": port}), &next)
+	if len(next.Ports) != 1 || next.Ports[0] == port {
+		t.Errorf("next_free_port from %d = %v, want it to step over our claim", port, next.Ports)
+	}
+
+	// The read-only tools that need nothing of ours.
+	callTool("dependency_graph", map[string]any{})
+	var history struct {
+		Events []map[string]any `json:"events"`
+	}
+	decodeStructured(t, callTool("port_history", map[string]any{"since": "24h"}), &history)
+	t.Logf("port_history → %d events", len(history.Events))
+
+	var sessions struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	decodeStructured(t, callTool("list_sessions", map[string]any{"active_only": false}), &sessions)
+	t.Logf("list_sessions → %d sessions", len(sessions.Sessions))
+
+	// tail_logs against a process that writes nowhere is allowed to fail, but
+	// it must fail as a domain result the model can read.
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "tail_logs", Arguments: map[string]any{"port": port, "lines": 5},
+	})
+	if err != nil {
+		t.Fatalf("tail_logs: protocol error: %v", err)
+	}
+	t.Logf("tail_logs → isError=%v\n%s", res.IsError, clip(textOf(res), 200))
+
+	decodeStructured(t, callTool("claim_port", map[string]any{
+		"project": "mcp-itest", "worktree": "main", "release": true,
+	}), &claim)
+	if claim.Released < 1 {
+		t.Errorf("release freed %d ports, want at least one", claim.Released)
 	}
 }
 

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -120,8 +120,8 @@ func TestToolsListAdvertisesTheReadTools(t *testing.T) {
 	for _, tool := range res.Tools {
 		byName[tool.Name] = tool
 	}
-	// The tool set is the sum of the tools_*.go files, so this asserts what the
-	// read tools promise rather than how many tools the server has in total.
+	// Other slices add their own tools to the same server, so this asserts
+	// what the read tools promise rather than how many tools exist.
 	for _, name := range []string{"list_ports", "inspect_port"} {
 		tool, ok := byName[name]
 		if !ok {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -185,6 +185,7 @@ func TestListPortsFilters(t *testing.T) {
 		{"type system", map[string]any{"type": "system"}, []int{22}},
 		{"include apps", map[string]any{"include_apps": true}, []int{3000, 5173, 5432, 8080, 22, 7000}},
 		{"session", map[string]any{"session": "claude-code:9f2c"}, []int{3000}},
+		{"session prefix", map[string]any{"session": "claude-code"}, []int{3000}},
 		{"unknown session", map[string]any{"session": "codex:nope"}, []int{}},
 	}
 	for _, tt := range tests {

--- a/internal/mcpserver/tools_query.go
+++ b/internal/mcpserver/tools_query.go
@@ -1,0 +1,982 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/claims"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// The query tools (spec 2 §1.1): the questions an agent asks between starting
+// something and acting on it — is it up yet, which port may I use, is that port
+// mine, what did it print, is it healthy, what talks to what, what happened
+// here, and who else is working on this machine.
+//
+// Every one of them is a single daemon call whose structured content is the
+// daemon's own JSON, except where the spec fixes a different shape for the
+// tool: `wait_for_port` adds the elapsed time it measured, `health_check`
+// flattens one row and names the URL it probed, and `dependency_graph` folds
+// repeated edges into a connection count.
+
+func init() { registerTools((*Server).addQueryTools) }
+
+// Waiting is the one thing an agent asks the daemon to do slowly, so it has
+// its own budget rather than the connection's ten seconds (spec 2 §1).
+const (
+	// DefaultWaitSeconds is `wait_for_port`'s timeout when the caller omits one.
+	DefaultWaitSeconds = 30
+	// MaxWaitSeconds is the longest wait the tool accepts.
+	MaxWaitSeconds = 300
+	// waitCancelGrace is how long a cancelled wait is given to end politely
+	// before the tool gives up on the daemon's final answer.
+	waitCancelGrace = 2 * time.Second
+)
+
+// Log tails are capped twice: the daemon is asked for at most MaxLogLines, and
+// the text block shows at most MaxRows of them. Structured content carries
+// every line the daemon returned.
+const (
+	// DefaultLogLines is the backlog `tail_logs` reads when asked for no size.
+	DefaultLogLines = 100
+	// MaxLogLines is the most lines the tool will ask the daemon for.
+	MaxLogLines = 2000
+)
+
+// DefaultHistorySince and DefaultHistoryLimit are `port_history`'s window.
+const (
+	DefaultHistorySince = "24h"
+	DefaultHistoryLimit = 50
+)
+
+// DefaultClaimTTLSeconds is `claim_port`'s reservation life: one day (spec 2 §4).
+const DefaultClaimTTLSeconds = 86400
+
+// ---------------------------------------------------------------- inputs ---
+
+// WaitForPortInput is the argument set of wait_for_port.
+type WaitForPortInput struct {
+	Ports          []int `json:"ports" jsonschema:"The ports to wait for. All of them must become ready before the tool returns, unless the timeout expires first."`
+	TimeoutSeconds int   `json:"timeout_seconds,omitempty" jsonschema:"How long to wait, in seconds. Defaults to 30; 300 is the maximum."`
+	HTTP           any   `json:"http,omitempty" jsonschema:"How ready is defined. false (the default) accepts the port when a TCP connection succeeds; true requires an HTTP response on /; a string like \"/health\" requires an HTTP response on that path."`
+}
+
+// WaitForPortOutput is `{ready, timed_out, elapsed_ms}`.
+type WaitForPortOutput struct {
+	Ready     []int `json:"ready"`
+	TimedOut  []int `json:"timed_out"`
+	ElapsedMs int64 `json:"elapsed_ms"`
+}
+
+// NextFreePortInput is the argument set of next_free_port.
+type NextFreePortInput struct {
+	Start int    `json:"start,omitempty" jsonschema:"The lowest port to consider. Defaults to 3000."`
+	Count int    `json:"count,omitempty" jsonschema:"How many consecutive free ports to return. Defaults to 1."`
+	Range string `json:"range,omitempty" jsonschema:"A window to search instead of start, written \"3000-3999\". It overrides start."`
+}
+
+// NextFreePortOutput is `{ports: [int]}`, the shape of ports.next.
+type NextFreePortOutput = rpc.PortsNextResult
+
+// ClaimPortInput is the argument set of claim_port.
+type ClaimPortInput struct {
+	Project    string `json:"project,omitempty" jsonschema:"The project the ports belong to. Defaults to the git checkout containing this server's working directory."`
+	Worktree   string `json:"worktree,omitempty" jsonschema:"The worktree the ports belong to. Defaults to this checkout's worktree, or main for a primary checkout."`
+	Count      int    `json:"count,omitempty" jsonschema:"How many ports to reserve. Defaults to 1."`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty" jsonschema:"How long the reservation lives, in seconds. Defaults to 86400 (one day). Claiming again refreshes it."`
+	Release    bool   `json:"release,omitempty" jsonschema:"Give this key's ports back instead of claiming. Do this when the work is finished."`
+}
+
+// ClaimPortOutput is `{key, ports, expires_at}`; a release also reports how
+// many ports it gave back.
+type ClaimPortOutput struct {
+	Key       string `json:"key"`
+	Ports     []int  `json:"ports"`
+	ExpiresAt string `json:"expires_at"`
+	Released  int    `json:"released,omitempty"`
+}
+
+// TailLogsInput is the argument set of tail_logs.
+type TailLogsInput struct {
+	Port  int    `json:"port,omitempty" jsonschema:"The listening port whose process to read."`
+	PID   int    `json:"pid,omitempty" jsonschema:"The pid whose process to read, when you have that instead of a port."`
+	RunID string `json:"run_id,omitempty" jsonschema:"The run id sonar reported when the service was started."`
+	Lines int    `json:"lines,omitempty" jsonschema:"How many lines from the end of the log to read. Defaults to 100; 2000 is the maximum."`
+}
+
+// TailLogsOutput is `{source, lines, truncated}`, the unary shape of ports.logs.
+type TailLogsOutput struct {
+	Source    string   `json:"source"`
+	Lines     []string `json:"lines"`
+	Truncated bool     `json:"truncated"`
+}
+
+// HealthCheckInput is the argument set of health_check.
+type HealthCheckInput struct {
+	Port int    `json:"port" jsonschema:"The port to probe."`
+	Path string `json:"path,omitempty" jsonschema:"The path to request. Only \"/\" is supported; use wait_for_port with http set to a path to probe anything else."`
+}
+
+// HealthCheckOutput is `{status, code, latency_ms, url}` plus the probe's own
+// verdict when it has one (contract §22).
+type HealthCheckOutput struct {
+	Status    string `json:"status" jsonschema:"enum=ok,enum=fail,enum=unknown"`
+	Code      int    `json:"code"`
+	LatencyMs int64  `json:"latency_ms"`
+	URL       string `json:"url"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// DependencyGraphInput has no arguments; the graph is the whole machine.
+type DependencyGraphInput struct{}
+
+// DependencyEdge is one aggregated edge: how many established connections run
+// from one listening port to another.
+type DependencyEdge struct {
+	FromPort    int    `json:"from_port"`
+	ToPort      int    `json:"to_port"`
+	FromName    string `json:"from_name"`
+	ToName      string `json:"to_name"`
+	Connections int    `json:"connections"`
+}
+
+// DependencyGraphOutput is `{edges: [...]}`.
+type DependencyGraphOutput struct {
+	Edges []DependencyEdge `json:"edges"`
+}
+
+// PortHistoryInput is the argument set of port_history.
+type PortHistoryInput struct {
+	Port  int    `json:"port,omitempty" jsonschema:"Only events for this port. Leave it out for everything."`
+	Since string `json:"since,omitempty" jsonschema:"How far back to look: a duration like \"24h\" or \"30m\", or an RFC 3339 timestamp. Defaults to 24h."`
+	Limit int    `json:"limit,omitempty" jsonschema:"How many events to return, newest first. Defaults to 50."`
+}
+
+// PortHistoryOutput is `{events: [...]}`, the shape of ports.history.
+type PortHistoryOutput = rpc.PortsHistoryResult
+
+// ListSessionsInput is the argument set of list_sessions.
+type ListSessionsInput struct {
+	ActiveOnly *bool `json:"active_only,omitempty" jsonschema:"Only sessions that still have something running. Defaults to true; pass false to include finished ones."`
+}
+
+// ListSessionsOutput is `{sessions: [SessionRecord]}`, the shape of sessions.list.
+type ListSessionsOutput = rpc.SessionsListResult
+
+// ---------------------------------------------------------- descriptions ---
+
+const waitForPortDescription = `Wait until one or more ports accept connections, then return which became ready and which did not.
+
+Use this after starting a dev server instead of sleeping, polling with curl in a loop, or guessing how long a build takes. It returns as soon as every port is up, so the common case costs a second, not the full timeout.
+
+Pass http: true (or a path like "/health") when "accepting TCP" is not enough — a server that has bound the port but is still compiling answers the socket and not the request. The tool never starts anything: a port that is not ready comes back in timed_out.`
+
+const nextFreePortDescription = `Pick a port nothing is listening on and nothing else has claimed.
+
+Use this instead of hardcoding 3000 or retrying after "address already in use". The daemon checks the live scan and every unexpired claim from other agents and worktrees, so two agents asking at the same time get different answers.
+
+This is a suggestion, not a reservation: nothing stops another process taking the port a second later. When you want the same ports every time and want them held, use claim_port.`
+
+const claimPortDescription = `Reserve ports for this project and worktree, so this checkout gets the same ports every time and parallel agents never collide.
+
+Use it once at the start of work: the ports come back derived from the project and worktree names, so re-running the tool returns the same ports rather than new ones, and next_free_port steps over every claim but yours. Pass release: true when the work is done.
+
+A claim is sonar's book-keeping, not an OS-level bind: a process outside sonar can still take the port, so still start your server on it and wait for it. Project and worktree default to the git checkout this MCP server was started in.`
+
+const tailLogsDescription = `Read the last lines a listening process wrote — a container's log, the file its output was redirected to, or the file descriptors it holds open.
+
+Use this to see why a service is failing before killing or restarting it, and prefer it to guessing at log paths or attaching to the terminal that started the process. Identify the service by port, by pid, or by the run id sonar returned when it started it.
+
+The reply says which source it read, so you can tell "the log is empty" from "there is no log for this process".`
+
+const healthCheckDescription = `Probe one listening port over HTTP and report whether it answers, with the status code and the round-trip time.
+
+Use it to tell a port that is bound from a service that works: "address in use" and "the app is up" are different claims, and a proxy or a half-started dev server can bind long before it serves. status is ok, fail or unknown, with the probe's own verdict (refused, timeout, non-http) in reason.
+
+It only probes "/". To check a specific endpoint, call wait_for_port with http set to that path.`
+
+const dependencyGraphDescription = `Show which listening ports on this machine are talking to which, with the number of established connections on each edge.
+
+Use it to work out what a service depends on before stopping it — a database with four connections from the api is not a safe thing to kill — and to see the shape of a stack you did not start yourself.
+
+Edges come from the machine's current connections, so an idle dependency that has opened no socket yet does not appear.`
+
+const portHistoryDescription = `List what has happened on this machine's ports: services that appeared, and services that went away.
+
+Use it to answer "what was running on 3000 an hour ago" and "did my server die or did something take its port", which a live listing cannot tell you. Filter by port, and set since to the window you care about ("24h", "30m", or an RFC 3339 timestamp).
+
+Events are newest first and come from the daemon's own record, so they include what other tools and other agents did.`
+
+const listSessionsDescription = `List the agent sessions that have started services on this machine, with their tool, worktree, branch and how much each has running.
+
+Use it before touching a port you did not start: a port belonging to another session is another agent's or another worktree's, and the answer to a conflict is a different port, not a kill. The ids here are the ones list_ports accepts as its session filter.
+
+Sessions with nothing running are hidden unless you pass active_only: false.`
+
+// ------------------------------------------------------------ registration ---
+
+func (s *Server) addQueryTools() {
+	readOnly := func() *mcp.ToolAnnotations {
+		return &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: boolPtr(false)}
+	}
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:         "wait_for_port",
+		Title:        "Wait for ports to accept connections",
+		Description:  waitForPortDescription,
+		Annotations:  readOnly(),
+		OutputSchema: outputSchema(WaitForPortOutput{}),
+	}, s.waitForPort)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:         "next_free_port",
+		Title:        "Find a free port",
+		Description:  nextFreePortDescription,
+		Annotations:  readOnly(),
+		OutputSchema: outputSchema(NextFreePortOutput{}),
+	}, s.nextFreePort)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:        "claim_port",
+		Title:       "Reserve ports for this worktree",
+		Description: claimPortDescription,
+		Annotations: &mcp.ToolAnnotations{
+			// Claiming the same key twice returns the same ports, and
+			// releasing twice is a no-op.
+			IdempotentHint: true,
+			OpenWorldHint:  boolPtr(false),
+		},
+		OutputSchema: outputSchema(ClaimPortOutput{}),
+	}, s.claimPort)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:         "tail_logs",
+		Title:        "Read a service's log",
+		Description:  tailLogsDescription,
+		Annotations:  readOnly(),
+		OutputSchema: outputSchema(TailLogsOutput{}),
+	}, s.tailLogs)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:         "health_check",
+		Title:        "Probe a port over HTTP",
+		Description:  healthCheckDescription,
+		Annotations:  readOnly(),
+		OutputSchema: outputSchema(HealthCheckOutput{}),
+	}, s.healthCheck)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:         "dependency_graph",
+		Title:        "Show which ports talk to which",
+		Description:  dependencyGraphDescription,
+		Annotations:  readOnly(),
+		OutputSchema: outputSchema(DependencyGraphOutput{}),
+	}, s.dependencyGraph)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:         "port_history",
+		Title:        "List past port events",
+		Description:  portHistoryDescription,
+		Annotations:  readOnly(),
+		OutputSchema: outputSchema(PortHistoryOutput{}),
+	}, s.portHistory)
+
+	mcp.AddTool(s.mcp, &mcp.Tool{
+		Name:         "list_sessions",
+		Title:        "List agent sessions",
+		Description:  listSessionsDescription,
+		Annotations:  readOnly(),
+		OutputSchema: outputSchema(ListSessionsOutput{}),
+	}, s.listSessions)
+}
+
+// --------------------------------------------------------------- handlers ---
+
+// waitForPort is the ports.wait stream, drained to its end. The stream is
+// cancelled when the MCP client goes away, so a 300-second wait does not
+// outlive the request that asked for it.
+func (s *Server) waitForPort(ctx context.Context, _ *mcp.CallToolRequest, in WaitForPortInput) (*mcp.CallToolResult, any, error) {
+	if len(in.Ports) == 0 {
+		return errorResult(invalidArguments(
+			"wait_for_port needs at least one port",
+			`pass {"ports": [3000]}; next_free_port picks one if you do not have it yet`)), nil, nil
+	}
+	for _, port := range in.Ports {
+		if port < 1 || port > 65535 {
+			return errorResult(invalidArguments(
+				fmt.Sprintf("%d is not a port number", port),
+				"ports are 1-65535")), nil, nil
+		}
+	}
+	seconds := in.TimeoutSeconds
+	switch {
+	case seconds == 0:
+		seconds = DefaultWaitSeconds
+	case seconds < 0 || seconds > MaxWaitSeconds:
+		return errorResult(invalidArguments(
+			fmt.Sprintf("timeout_seconds must be between 1 and %d, got %d", MaxWaitSeconds, seconds),
+			"a longer wait belongs in your own loop, so you can report progress")), nil, nil
+	}
+	path, derr := waitHTTPPath(in.HTTP)
+	if derr != nil {
+		return errorResult(derr), nil, nil
+	}
+
+	started := time.Now()
+	st, err := s.daemon.Stream(ctx, "ports.wait", rpc.PortsWaitParams{
+		Ports:     in.Ports,
+		HTTP:      path,
+		TimeoutMs: seconds * 1000,
+	})
+	if err != nil {
+		return s.failed(err)
+	}
+	defer st.Close()
+
+	end, err := drainWait(ctx, st)
+	if err != nil {
+		return s.failed(err)
+	}
+	out := WaitForPortOutput{
+		Ready:     orEmptyInts(end.Ready),
+		TimedOut:  orEmptyInts(end.TimedOut),
+		ElapsedMs: time.Since(started).Milliseconds(),
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderWait(out, path)}},
+	}, out, nil
+}
+
+// nextFreePort is ports.next. It is a suggestion, not a reservation: the
+// description says so, and claim_port is the tool that holds a port.
+func (s *Server) nextFreePort(ctx context.Context, _ *mcp.CallToolRequest, in NextFreePortInput) (*mcp.CallToolResult, any, error) {
+	params := rpc.PortsNextParams{Start: in.Start, Count: in.Count}
+	if in.Range != "" {
+		start, end, derr := parseRange(in.Range)
+		if derr != nil {
+			return errorResult(derr), nil, nil
+		}
+		params.Start, params.End = start, end
+	}
+	if params.Count < 0 {
+		return errorResult(invalidArguments(
+			fmt.Sprintf("count must be at least 1, got %d", params.Count), "")), nil, nil
+	}
+
+	var res rpc.PortsNextResult
+	if err := s.daemon.Call(ctx, "ports.next", params, &res); err != nil {
+		return s.failed(err)
+	}
+	if res.Ports == nil {
+		res.Ports = []int{}
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderFreePorts(res.Ports)}},
+	}, res, nil
+}
+
+// claimPort is claims.acquire, or claims.release when the caller is done. The
+// key is derived from the MCP server's own working directory, which is the
+// agent's checkout: the daemon cannot see it, so the identity is computed here
+// exactly as `sonar claim` computes it.
+func (s *Server) claimPort(ctx context.Context, _ *mcp.CallToolRequest, in ClaimPortInput) (*mcp.CallToolResult, any, error) {
+	if !s.daemon.Has("claims") {
+		return errorResult(capabilityMissing("claims",
+			"claim_port needs a daemon that keeps port claims")), nil, nil
+	}
+	if in.Count < 0 {
+		return errorResult(invalidArguments(
+			fmt.Sprintf("count must be at least 1, got %d", in.Count), "")), nil, nil
+	}
+	if in.TTLSeconds < 0 {
+		return errorResult(invalidArguments(
+			fmt.Sprintf("ttl_seconds must be positive, got %d", in.TTLSeconds), "")), nil, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	project, worktree := claims.Identity(cwd, in.Project, in.Worktree)
+	key := claims.Key(project, worktree)
+
+	if in.Release {
+		var res rpc.ClaimsReleaseResult
+		if err := s.daemon.Call(ctx, "claims.release", rpc.ClaimsReleaseParams{Key: key}, &res); err != nil {
+			return s.failed(err)
+		}
+		out := ClaimPortOutput{Key: key, Ports: []int{}, Released: res.Released}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: renderRelease(out)}},
+		}, out, nil
+	}
+
+	ttl := in.TTLSeconds
+	if ttl == 0 {
+		ttl = DefaultClaimTTLSeconds
+	}
+	var res rpc.ClaimsAcquireResult
+	if err := s.daemon.Call(ctx, "claims.acquire", rpc.ClaimsAcquireParams{
+		Project:    project,
+		Worktree:   worktree,
+		Count:      in.Count,
+		TTLSeconds: ttl,
+	}, &res); err != nil {
+		return s.failed(err)
+	}
+	out := ClaimPortOutput{Key: res.Key, Ports: orEmptyInts(res.Ports), ExpiresAt: res.ExpiresAt}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderClaim(out)}},
+	}, out, nil
+}
+
+// tailLogs is the unary half of ports.logs. run_id is resolved here, through
+// runs.list, because the daemon's log selector takes a port or a pid.
+func (s *Server) tailLogs(ctx context.Context, _ *mcp.CallToolRequest, in TailLogsInput) (*mcp.CallToolResult, any, error) {
+	selectors := 0
+	for _, given := range []bool{in.Port > 0, in.PID > 0, in.RunID != ""} {
+		if given {
+			selectors++
+		}
+	}
+	if selectors != 1 {
+		return errorResult(invalidArguments(
+			"tail_logs needs exactly one of port, pid and run_id",
+			`pass {"port": 3000}; list_ports shows the port, pid and run of everything listening`)), nil, nil
+	}
+
+	lines, capped := in.Lines, false
+	switch {
+	case lines <= 0:
+		lines = DefaultLogLines
+	case lines > MaxLogLines:
+		lines, capped = MaxLogLines, true
+	}
+
+	sel := rpc.Selector{}
+	switch {
+	case in.Port > 0:
+		sel.Port = &in.Port
+	case in.PID > 0:
+		sel.PID = &in.PID
+	default:
+		resolved, err := s.selectorForRun(ctx, in.RunID)
+		if err != nil {
+			return s.failed(err)
+		}
+		sel = resolved
+	}
+
+	var res rpc.PortsLogsResult
+	if err := s.daemon.Call(ctx, "ports.logs", rpc.PortsLogsParams{
+		Selector: sel,
+		Lines:    lines,
+	}, &res); err != nil {
+		return s.failed(err)
+	}
+	out := TailLogsOutput{Source: res.Source, Lines: res.Lines, Truncated: res.Truncated}
+	if out.Lines == nil {
+		out.Lines = []string{}
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderLogs(out, lines, capped)}},
+	}, out, nil
+}
+
+// healthCheck is ports.health for one port, flattened to the single row the
+// tool promises.
+func (s *Server) healthCheck(ctx context.Context, _ *mcp.CallToolRequest, in HealthCheckInput) (*mcp.CallToolResult, any, error) {
+	if in.Port < 1 || in.Port > 65535 {
+		return errorResult(invalidArguments(
+			"health_check needs a port",
+			`pass {"port": 3000}; list_ports shows what is listening`)), nil, nil
+	}
+	path := strings.TrimSpace(in.Path)
+	if path != "" && path != "/" {
+		return errorResult(invalidArguments(
+			fmt.Sprintf("health_check probes \"/\", not %q", path),
+			`call wait_for_port with {"ports": [`+strconv.Itoa(in.Port)+`], "http": "`+path+`"} to probe another path`)), nil, nil
+	}
+
+	var res rpc.PortsHealthResult
+	if err := s.daemon.Call(ctx, "ports.health", rpc.PortsHealthParams{Ports: []int{in.Port}}, &res); err != nil {
+		return s.failed(err)
+	}
+
+	out := HealthCheckOutput{
+		Status: state.HealthUnknown,
+		URL:    fmt.Sprintf("http://localhost:%d/", in.Port),
+	}
+	for _, row := range res.Results {
+		if row.Port != in.Port {
+			continue
+		}
+		out.Status, out.Code, out.LatencyMs, out.Reason = normalizeHealth(row.Status), row.Code, row.LatencyMs, row.Reason
+		break
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderHealth(in.Port, out)}},
+	}, out, nil
+}
+
+// dependencyGraph is ports.graph with its repeated edges folded into counts:
+// the daemon reports one row per established connection, and what an agent
+// wants to know is how many there are between two services.
+func (s *Server) dependencyGraph(ctx context.Context, _ *mcp.CallToolRequest, _ DependencyGraphInput) (*mcp.CallToolResult, any, error) {
+	var res rpc.PortsGraphResult
+	if err := s.daemon.Call(ctx, "ports.graph", rpc.Empty{}, &res); err != nil {
+		return s.failed(err)
+	}
+	out := DependencyGraphOutput{Edges: aggregateEdges(res.Connections)}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderGraph(out.Edges)}},
+	}, out, nil
+}
+
+// portHistory is ports.history. `since` is passed through untouched: the
+// daemon owns the grammar (a duration or an RFC 3339 timestamp, contract §22)
+// and rejecting it here would be a second, drifting copy of that rule.
+func (s *Server) portHistory(ctx context.Context, _ *mcp.CallToolRequest, in PortHistoryInput) (*mcp.CallToolResult, any, error) {
+	if in.Limit < 0 {
+		return errorResult(invalidArguments(
+			fmt.Sprintf("limit must be positive, got %d", in.Limit), "")), nil, nil
+	}
+	since := strings.TrimSpace(in.Since)
+	if since == "" {
+		since = DefaultHistorySince
+	}
+	limit := in.Limit
+	if limit == 0 {
+		limit = DefaultHistoryLimit
+	}
+
+	params := rpc.PortsHistoryParams{Since: &since, Limit: limit}
+	if in.Port > 0 {
+		params.Port = &in.Port
+	}
+
+	var res rpc.PortsHistoryResult
+	if err := s.daemon.Call(ctx, "ports.history", params, &res); err != nil {
+		return s.failed(err)
+	}
+	if res.Events == nil {
+		res.Events = []rpc.HistoryEvent{}
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderHistory(res.Events, since)}},
+	}, res, nil
+}
+
+// listSessions is sessions.list.
+func (s *Server) listSessions(ctx context.Context, _ *mcp.CallToolRequest, in ListSessionsInput) (*mcp.CallToolResult, any, error) {
+	if !s.daemon.Has("sessions") {
+		return errorResult(capabilityMissing("sessions",
+			"list_sessions needs a daemon that records agent sessions")), nil, nil
+	}
+	activeOnly := true
+	if in.ActiveOnly != nil {
+		activeOnly = *in.ActiveOnly
+	}
+
+	var res rpc.SessionsListResult
+	if err := s.daemon.Call(ctx, "sessions.list",
+		rpc.SessionsListParams{ActiveOnly: activeOnly}, &res); err != nil {
+		return s.failed(err)
+	}
+	if res.Sessions == nil {
+		res.Sessions = []state.SessionRecord{}
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: renderSessions(res.Sessions, activeOnly)}},
+	}, res, nil
+}
+
+// ---------------------------------------------------------------- helpers ---
+
+// drainWait reads a ports.wait stream to its end. A cancelled MCP request
+// cancels the stream at the daemon (contract §20: a cancelled stream still
+// ends) rather than abandoning it, so the daemon stops probing as soon as the
+// agent stops caring.
+func drainWait(ctx context.Context, st *client.Stream) (rpc.PortsWaitEnd, error) {
+	chunks := st.Chunks()
+	done := ctx.Done()
+	var giveUp <-chan time.Time
+
+	for {
+		select {
+		case <-done:
+			done = nil
+			cancelCtx, cancel := context.WithTimeout(context.Background(), waitCancelGrace)
+			_ = st.Cancel(cancelCtx)
+			cancel()
+			giveUp = time.After(waitCancelGrace)
+		case <-giveUp:
+			return rpc.PortsWaitEnd{}, ctx.Err()
+		case _, ok := <-chunks:
+			// Chunks are progress, not results: the end carries the answer.
+			if !ok {
+				chunks = nil
+			}
+		case end := <-st.End():
+			if end.Err != nil {
+				return rpc.PortsWaitEnd{}, end.Err
+			}
+			var out rpc.PortsWaitEnd
+			if err := end.Decode(&out); err != nil {
+				return rpc.PortsWaitEnd{}, err
+			}
+			return out, nil
+		}
+	}
+}
+
+// waitHTTPPath reads the `http` argument's three forms: false (a TCP connect),
+// true ("/"), or a path.
+func waitHTTPPath(v any) (*string, *DomainError) {
+	switch t := v.(type) {
+	case nil:
+		return nil, nil
+	case bool:
+		if !t {
+			return nil, nil
+		}
+		path := "/"
+		return &path, nil
+	case string:
+		path := strings.TrimSpace(t)
+		if path == "" {
+			return nil, nil
+		}
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		return &path, nil
+	default:
+		return nil, invalidArguments(
+			fmt.Sprintf("http must be true, false or a path, got %v", v),
+			`use {"http": true} for a request to "/" or {"http": "/health"} for a path`)
+	}
+}
+
+// parseRange reads the "3000-3999" form of next_free_port's range argument.
+func parseRange(raw string) (start, end int, derr *DomainError) {
+	bad := func() *DomainError {
+		return invalidArguments(
+			fmt.Sprintf("range %q is not a port window", raw),
+			`write it as "3000-3999"`)
+	}
+	lo, hi, found := strings.Cut(strings.TrimSpace(raw), "-")
+	if !found {
+		return 0, 0, bad()
+	}
+	start, err := strconv.Atoi(strings.TrimSpace(lo))
+	if err != nil {
+		return 0, 0, bad()
+	}
+	end, err = strconv.Atoi(strings.TrimSpace(hi))
+	if err != nil {
+		return 0, 0, bad()
+	}
+	if start < 1 || end > 65535 || start > end {
+		return 0, 0, invalidArguments(
+			fmt.Sprintf("range %q is not a usable port window", raw),
+			"ports are 1-65535 and the low end comes first")
+	}
+	return start, end, nil
+}
+
+// selectorForRun turns a run id into the log selector the daemon understands:
+// the run's listening port, or its pid while it has none.
+func (s *Server) selectorForRun(ctx context.Context, runID string) (rpc.Selector, error) {
+	if !s.daemon.Has("runs") {
+		return rpc.Selector{}, capabilityMissing("runs",
+			"this daemon does not keep a run registry, so run_id cannot be resolved")
+	}
+	var res rpc.RunsListResult
+	if err := s.daemon.Call(ctx, "runs.list", rpc.Empty{}, &res); err != nil {
+		return rpc.Selector{}, err
+	}
+	for _, run := range res.Runs {
+		if run.ID != runID && run.Name != runID && !strings.HasPrefix(run.ID, runID) {
+			continue
+		}
+		if len(run.Ports) > 0 {
+			port := run.Ports[0]
+			return rpc.Selector{Port: &port}, nil
+		}
+		pid := run.PID
+		return rpc.Selector{PID: &pid}, nil
+	}
+	return rpc.Selector{}, Domain("not_found",
+		"no run matches "+runID,
+		"list_ports shows the run behind every port it started")
+}
+
+// capabilityMissing is the answer of a tool whose daemon capability is absent.
+// The tool stays registered so the client's tool list can be cached (spec 2 §1).
+func capabilityMissing(capability, what string) *DomainError {
+	return Domain(CodeCapabilityMissing, what,
+		fmt.Sprintf("this daemon does not advertise %q; upgrade sonar and run `sonar daemon restart`", capability))
+}
+
+// normalizeHealth keeps the wire's three-value vocabulary (contract §22) even
+// if an older daemon publishes a probe verdict where a status belongs.
+func normalizeHealth(status string) string {
+	switch status {
+	case state.HealthOK, state.HealthFail, state.HealthUnknown:
+		return status
+	case "healthy":
+		return state.HealthOK
+	case "unhealthy", "refused", "timeout", "non-http":
+		return state.HealthFail
+	case "":
+		return state.HealthUnknown
+	default:
+		return state.HealthUnknown
+	}
+}
+
+// aggregateEdges folds the daemon's per-connection rows into one edge per
+// (from, to) pair, ordered by port so the same graph renders the same way
+// twice.
+func aggregateEdges(rows []rpc.GraphEdge) []DependencyEdge {
+	type key struct{ from, to int }
+	index := map[key]*DependencyEdge{}
+	order := []key{}
+	for _, row := range rows {
+		k := key{row.FromPort, row.ToPort}
+		edge, ok := index[k]
+		if !ok {
+			index[k] = &DependencyEdge{
+				FromPort: row.FromPort, ToPort: row.ToPort,
+				FromName: row.FromProcess, ToName: row.ToProcess,
+			}
+			order = append(order, k)
+			edge = index[k]
+		}
+		edge.Connections++
+		// A later row may know a name an earlier one did not.
+		if edge.FromName == "" {
+			edge.FromName = row.FromProcess
+		}
+		if edge.ToName == "" {
+			edge.ToName = row.ToProcess
+		}
+	}
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].from != order[j].from {
+			return order[i].from < order[j].from
+		}
+		return order[i].to < order[j].to
+	})
+	out := make([]DependencyEdge, 0, len(order))
+	for _, k := range order {
+		out = append(out, *index[k])
+	}
+	return out
+}
+
+func orEmptyInts(v []int) []int {
+	if v == nil {
+		return []int{}
+	}
+	return v
+}
+
+// -------------------------------------------------------------- rendering ---
+
+func renderWait(out WaitForPortOutput, path *string) string {
+	how := "accepting connections"
+	if path != nil {
+		how = "answering HTTP on " + *path
+	}
+	elapsed := time.Duration(out.ElapsedMs) * time.Millisecond
+
+	total := len(out.Ready) + len(out.TimedOut)
+	if total == 1 {
+		if len(out.Ready) == 1 {
+			return fmt.Sprintf("port %d is %s after %s", out.Ready[0], how, elapsed)
+		}
+		return fmt.Sprintf("port %d is still not %s after %s", out.TimedOut[0], how, elapsed)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d of %d %s %s after %s\n", len(out.Ready), total,
+		plural(total, "port is", "ports are"), how, elapsed)
+	if len(out.Ready) > 0 {
+		fmt.Fprintf(&b, "ready: %s\n", joinInts(out.Ready))
+	}
+	if len(out.TimedOut) > 0 {
+		fmt.Fprintf(&b, "timed out: %s\n", joinInts(out.TimedOut))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderFreePorts(ports []int) string {
+	if len(ports) == 0 {
+		return "no free port was found in that range"
+	}
+	if len(ports) == 1 {
+		return fmt.Sprintf("port %d is free", ports[0])
+	}
+	return fmt.Sprintf("ports %s are free", joinInts(ports))
+}
+
+func renderClaim(out ClaimPortOutput) string {
+	if len(out.Ports) == 0 {
+		return "no ports are claimed for " + out.Key
+	}
+	return fmt.Sprintf("%s claims %s until %s",
+		out.Key, joinInts(out.Ports), dash(out.ExpiresAt))
+}
+
+func renderRelease(out ClaimPortOutput) string {
+	return fmt.Sprintf("released %d %s held by %s",
+		out.Released, plural(out.Released, "port", "ports"), out.Key)
+}
+
+func renderLogs(out TailLogsOutput, asked int, capped bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %s from %s", len(out.Lines), plural(len(out.Lines), "line", "lines"), dash(out.Source))
+	if out.Truncated {
+		b.WriteString(" (older lines were not read)")
+	}
+	if capped {
+		fmt.Fprintf(&b, " (capped at %d lines)", asked)
+	}
+	b.WriteString("\n")
+	if len(out.Lines) == 0 {
+		return strings.TrimRight(b.String(), "\n")
+	}
+
+	shown := out.Lines
+	// The text block keeps the newest lines, which are the ones a failure is
+	// explained by; structured content still carries every line.
+	if len(shown) > MaxRows {
+		shown = shown[len(shown)-MaxRows:]
+		fmt.Fprintf(&b, "showing the last %d of %d lines\n", MaxRows, len(out.Lines))
+	}
+	b.WriteString("\n")
+	b.WriteString(strings.Join(shown, "\n"))
+	return b.String()
+}
+
+func renderHealth(port int, out HealthCheckOutput) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "port %d is %s", port, out.Status)
+	if out.Reason != "" && out.Reason != out.Status {
+		fmt.Fprintf(&b, " (%s)", out.Reason)
+	}
+	if out.Code != 0 {
+		fmt.Fprintf(&b, ", http %d", out.Code)
+	}
+	if out.LatencyMs != 0 {
+		fmt.Fprintf(&b, ", %dms", out.LatencyMs)
+	}
+	fmt.Fprintf(&b, " — %s", out.URL)
+	return b.String()
+}
+
+func renderGraph(edges []DependencyEdge) string {
+	if len(edges) == 0 {
+		return "no port on this machine is connected to another"
+	}
+	shown, truncated := edges, false
+	if len(shown) > MaxRows {
+		shown, truncated = shown[:MaxRows], true
+	}
+
+	rows := make([][]string, 0, len(shown))
+	for _, e := range shown {
+		rows = append(rows, []string{
+			strconv.Itoa(e.FromPort), dash(e.FromName),
+			strconv.Itoa(e.ToPort), dash(e.ToName),
+			strconv.Itoa(e.Connections),
+		})
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %s\n\n", len(edges), plural(len(edges), "edge", "edges"))
+	b.WriteString(table([]string{"FROM", "NAME", "TO", "NAME", "CONNECTIONS"}, rows))
+	if truncated {
+		b.WriteString("\n" + truncationNote(len(shown), len(edges)))
+	}
+	return b.String()
+}
+
+func renderHistory(events []rpc.HistoryEvent, since string) string {
+	if len(events) == 0 {
+		return "nothing has happened on these ports since " + since
+	}
+	shown, truncated := events, false
+	if len(shown) > MaxRows {
+		shown, truncated = shown[:MaxRows], true
+	}
+
+	rows := make([][]string, 0, len(shown))
+	for _, e := range shown {
+		rows = append(rows, []string{
+			dash(e.At), dash(e.Kind), strconv.Itoa(e.Port),
+			strconv.Itoa(e.PID), dash(e.DisplayName), dash(e.Group),
+		})
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %s since %s\n\n", len(events), plural(len(events), "event", "events"), since)
+	b.WriteString(table([]string{"AT", "KIND", "PORT", "PID", "NAME", "GROUP"}, rows))
+	if truncated {
+		b.WriteString("\n" + truncationNote(len(shown), len(events)))
+	}
+	return b.String()
+}
+
+func renderSessions(sessions []state.SessionRecord, activeOnly bool) string {
+	if len(sessions) == 0 {
+		if activeOnly {
+			return "no agent session has anything running; pass active_only: false for finished ones"
+		}
+		return "no agent session has been recorded on this machine"
+	}
+	shown, truncated := sessions, false
+	if len(shown) > MaxRows {
+		shown, truncated = shown[:MaxRows], true
+	}
+
+	rows := make([][]string, 0, len(shown))
+	for _, s := range shown {
+		rows = append(rows, []string{
+			s.ID, dash(s.Tool), dash(s.Worktree), dash(s.Branch),
+			strconv.Itoa(s.Runs), strconv.Itoa(s.Ports), strconv.Itoa(s.Groups),
+			yesNo(s.Active), dash(s.LastSeen),
+		})
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %s\n\n", len(sessions), plural(len(sessions), "session", "sessions"))
+	b.WriteString(table(
+		[]string{"ID", "TOOL", "WORKTREE", "BRANCH", "RUNS", "PORTS", "GROUPS", "ACTIVE", "LAST SEEN"}, rows))
+	if truncated {
+		b.WriteString("\n" + truncationNote(len(shown), len(sessions)))
+	}
+	return b.String()
+}
+
+func joinInts(v []int) string {
+	parts := make([]string, 0, len(v))
+	for _, n := range v {
+		parts = append(parts, strconv.Itoa(n))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/mcpserver/tools_query.go
+++ b/internal/mcpserver/tools_query.go
@@ -812,10 +812,10 @@ func renderWait(out WaitForPortOutput, path *string) string {
 	fmt.Fprintf(&b, "%d of %d %s %s after %s\n", len(out.Ready), total,
 		plural(total, "port is", "ports are"), how, elapsed)
 	if len(out.Ready) > 0 {
-		fmt.Fprintf(&b, "ready: %s\n", joinInts(out.Ready))
+		fmt.Fprintf(&b, "ready: %s\n", joinIntsInOrder(out.Ready))
 	}
 	if len(out.TimedOut) > 0 {
-		fmt.Fprintf(&b, "timed out: %s\n", joinInts(out.TimedOut))
+		fmt.Fprintf(&b, "timed out: %s\n", joinIntsInOrder(out.TimedOut))
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
@@ -827,7 +827,7 @@ func renderFreePorts(ports []int) string {
 	if len(ports) == 1 {
 		return fmt.Sprintf("port %d is free", ports[0])
 	}
-	return fmt.Sprintf("ports %s are free", joinInts(ports))
+	return fmt.Sprintf("ports %s are free", joinIntsInOrder(ports))
 }
 
 func renderClaim(out ClaimPortOutput) string {
@@ -835,7 +835,7 @@ func renderClaim(out ClaimPortOutput) string {
 		return "no ports are claimed for " + out.Key
 	}
 	return fmt.Sprintf("%s claims %s until %s",
-		out.Key, joinInts(out.Ports), dash(out.ExpiresAt))
+		out.Key, joinIntsInOrder(out.Ports), dash(out.ExpiresAt))
 }
 
 func renderRelease(out ClaimPortOutput) string {
@@ -966,7 +966,7 @@ func renderSessions(sessions []state.SessionRecord, activeOnly bool) string {
 	return b.String()
 }
 
-func joinInts(v []int) string {
+func joinIntsInOrder(v []int) string {
 	parts := make([]string, 0, len(v))
 	for _, n := range v {
 		parts = append(parts, strconv.Itoa(n))

--- a/internal/mcpserver/tools_query_test.go
+++ b/internal/mcpserver/tools_query_test.go
@@ -1,0 +1,682 @@
+package mcpserver_test
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/mcpserver"
+	"github.com/raskrebs/sonar/internal/mcpserver/fakedaemon"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// queryFixture is the default machine plus the capabilities the query tools
+// gate on. The default fixture deliberately lacks them, so the
+// capability_missing paths have a fixture of their own.
+func queryFixture(extra ...string) fakedaemon.Fixture {
+	fx := fakedaemon.DefaultFixture()
+	fx.Capabilities = append(append([]string{}, fx.Capabilities...), extra...)
+	return fx
+}
+
+// fixtureWithout is the default machine with a capability taken away, for the
+// tools that have to answer for a daemon that cannot help them.
+func fixtureWithout(capability string) fakedaemon.Fixture {
+	fx := fakedaemon.DefaultFixture()
+	kept := make([]string, 0, len(fx.Capabilities))
+	for _, c := range fx.Capabilities {
+		if c != capability {
+			kept = append(kept, c)
+		}
+	}
+	fx.Capabilities = kept
+	return fx
+}
+
+func TestQueryToolsAreAdvertised(t *testing.T) {
+	h := newHarness(t)
+
+	res, err := h.client.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	byName := map[string]*mcp.Tool{}
+	for _, tool := range res.Tools {
+		byName[tool.Name] = tool
+	}
+
+	readOnly := []string{
+		"wait_for_port", "next_free_port", "tail_logs", "health_check",
+		"dependency_graph", "port_history", "list_sessions",
+	}
+	for _, name := range append(readOnly, "claim_port") {
+		tool, ok := byName[name]
+		if !ok {
+			t.Fatalf("tools/list is missing %s", name)
+		}
+		if tool.Description == "" {
+			t.Errorf("%s has no description", name)
+		}
+		if tool.OutputSchema == nil {
+			t.Errorf("%s has no output schema", name)
+		}
+		if tool.Annotations == nil {
+			t.Fatalf("%s has no annotations", name)
+		}
+		if tool.Annotations.OpenWorldHint == nil || *tool.Annotations.OpenWorldHint {
+			t.Errorf("%s should be closed-world: it only talks to the local daemon", name)
+		}
+	}
+	for _, name := range readOnly {
+		if !byName[name].Annotations.ReadOnlyHint {
+			t.Errorf("%s should be annotated read-only", name)
+		}
+	}
+	// claim_port writes a reservation, so it is not read-only; claiming twice
+	// returns the same ports, so it is idempotent (spec 2 §1.1).
+	if byName["claim_port"].Annotations.ReadOnlyHint {
+		t.Error("claim_port is annotated read-only, but it writes a claim")
+	}
+	if !byName["claim_port"].Annotations.IdempotentHint {
+		t.Error("claim_port should be annotated idempotent")
+	}
+}
+
+// ------------------------------------------------------------ wait_for_port ---
+
+func TestWaitForPortReady(t *testing.T) {
+	h := newHarness(t)
+
+	res := h.call("wait_for_port", map[string]any{"ports": []any{3000}})
+	out := structured[mcpserver.WaitForPortOutput](t, res)
+	if len(out.Ready) != 1 || out.Ready[0] != 3000 {
+		t.Fatalf("ready = %v, want [3000]", out.Ready)
+	}
+	if len(out.TimedOut) != 0 {
+		t.Errorf("timed_out = %v, want empty", out.TimedOut)
+	}
+	if out.ElapsedMs < 0 {
+		t.Errorf("elapsed_ms = %d", out.ElapsedMs)
+	}
+	if text := textOf(res); !strings.Contains(text, "port 3000 is accepting connections") {
+		t.Errorf("text = %q", text)
+	}
+}
+
+func TestWaitForPortTimesOut(t *testing.T) {
+	h := newHarness(t)
+
+	res := h.call("wait_for_port", map[string]any{
+		"ports":           []any{3000, 65000},
+		"timeout_seconds": 1,
+	})
+	out := structured[mcpserver.WaitForPortOutput](t, res)
+	if len(out.Ready) != 1 || out.Ready[0] != 3000 {
+		t.Errorf("ready = %v, want [3000]", out.Ready)
+	}
+	if len(out.TimedOut) != 1 || out.TimedOut[0] != 65000 {
+		t.Errorf("timed_out = %v, want [65000]", out.TimedOut)
+	}
+	text := textOf(res)
+	if !strings.Contains(text, "timed out: 65000") {
+		t.Errorf("text = %q, want it to name the port that never came up", text)
+	}
+}
+
+// TestWaitForPortSeesAPortAppear is the readiness case that matters: the wait
+// is already open when the port shows up, and the daemon's delta and the
+// stream chunk both describe the same event.
+func TestWaitForPortSeesAPortAppear(t *testing.T) {
+	h := newHarness(t)
+
+	type result struct {
+		out  mcpserver.WaitForPortOutput
+		text string
+	}
+	done := make(chan result, 1)
+	go func() {
+		res, err := h.client.CallTool(t.Context(), &mcp.CallToolParams{
+			Name:      "wait_for_port",
+			Arguments: map[string]any{"ports": []any{4321}, "timeout_seconds": 10},
+		})
+		if err != nil || res.IsError {
+			done <- result{}
+			return
+		}
+		var out mcpserver.WaitForPortOutput
+		raw, _ := json.Marshal(res.StructuredContent)
+		_ = json.Unmarshal(raw, &out)
+		done <- result{out: out, text: textOf(res)}
+	}()
+
+	// The port opens while the wait is in flight.
+	appeared := state.Port{
+		Port: 4321, BindAddress: "127.0.0.1", IPVersion: "IPv4",
+		URL: "http://localhost:4321", PID: 5555, Process: "node",
+		DisplayName: "worker", Type: state.TypeUser, User: "dev",
+		ExposedURLs: []string{}, StartedAt: strPtr(fakedaemon.FixtureTime),
+	}
+	time.Sleep(20 * time.Millisecond)
+	h.fake.SetPorts(append(fakedaemon.DefaultPorts(), appeared))
+	h.fake.Push(state.Delta{Ports: state.Change[state.Port]{Added: []state.Port{appeared}}})
+
+	select {
+	case got := <-done:
+		if len(got.out.Ready) != 1 || got.out.Ready[0] != 4321 {
+			t.Fatalf("ready = %v, want [4321]", got.out.Ready)
+		}
+		if !strings.Contains(got.text, "port 4321 is accepting connections") {
+			t.Errorf("text = %q", got.text)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("wait_for_port never returned")
+	}
+}
+
+// TestWaitForPortHTTP is the difference the http argument buys: 5432 is bound
+// but not an HTTP server, so a TCP wait succeeds where an HTTP wait does not.
+func TestWaitForPortHTTP(t *testing.T) {
+	h := newHarness(t)
+
+	tcp := structured[mcpserver.WaitForPortOutput](t,
+		h.call("wait_for_port", map[string]any{"ports": []any{5432}, "timeout_seconds": 1}))
+	if len(tcp.Ready) != 1 {
+		t.Errorf("a TCP wait on a bound port = %v, want it ready", tcp)
+	}
+
+	res := h.call("wait_for_port", map[string]any{
+		"ports": []any{5432}, "timeout_seconds": 1, "http": true,
+	})
+	over := structured[mcpserver.WaitForPortOutput](t, res)
+	if len(over.TimedOut) != 1 || over.TimedOut[0] != 5432 {
+		t.Errorf("an HTTP wait on a non-http port = %v, want it timed out", over)
+	}
+	if text := textOf(res); !strings.Contains(text, "answering HTTP on /") {
+		t.Errorf("text = %q, want it to say what readiness meant", text)
+	}
+
+	// A path is the third form of the argument.
+	path := structured[mcpserver.WaitForPortOutput](t, h.call("wait_for_port", map[string]any{
+		"ports": []any{3000}, "timeout_seconds": 2, "http": "/health",
+	}))
+	if len(path.Ready) != 1 || path.Ready[0] != 3000 {
+		t.Errorf("an HTTP wait on a healthy port = %v, want it ready", path)
+	}
+}
+
+func TestWaitForPortRejectsBadArguments(t *testing.T) {
+	h := newHarness(t)
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"no ports", map[string]any{"ports": []any{}}},
+		{"not a port", map[string]any{"ports": []any{70000}}},
+		{"too long", map[string]any{"ports": []any{3000}, "timeout_seconds": 600}},
+		{"http is a number", map[string]any{"ports": []any{3000}, "http": 8080}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, ok := mcpserver.DecodeError(h.call("wait_for_port", tt.args))
+			if !ok {
+				t.Fatal("expected an error result")
+			}
+			if payload.Error.Code != mcpserver.CodeInvalidArguments {
+				t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+			}
+		})
+	}
+	if n := h.fake.Calls("ports.wait"); n != 0 {
+		t.Errorf("the daemon was asked to wait %d times for argument errors", n)
+	}
+}
+
+// ---------------------------------------------------------- next_free_port ---
+
+func TestNextFreePort(t *testing.T) {
+	h := newHarness(t)
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want []int
+	}{
+		{"default", map[string]any{}, []int{3001}},
+		{"count", map[string]any{"count": 3}, []int{3001, 3002, 3003}},
+		{"start", map[string]any{"start": 8080}, []int{8081}},
+		{"range", map[string]any{"range": "5000-5500"}, []int{5000}},
+		{"range over a listener", map[string]any{"range": "5173-5300"}, []int{5174}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := structured[rpc.PortsNextResult](t, h.call("next_free_port", tt.args))
+			if !equalInts(out.Ports, tt.want) {
+				t.Fatalf("ports = %v, want %v", out.Ports, tt.want)
+			}
+		})
+	}
+
+	if text := textOf(h.call("next_free_port", map[string]any{})); text != "port 3001 is free" {
+		t.Errorf("text = %q", text)
+	}
+
+	payload, ok := mcpserver.DecodeError(h.call("next_free_port", map[string]any{"range": "3000..4000"}))
+	if !ok {
+		t.Fatal("a malformed range should be an error result")
+	}
+	if payload.Error.Code != mcpserver.CodeInvalidArguments {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+	}
+}
+
+// TestNextFreePortSkipsClaims is the claims half of contract §28 seen from the
+// tools: a port this machine has claimed is not offered to the next caller.
+func TestNextFreePortSkipsClaims(t *testing.T) {
+	h := newHarnessWith(t, queryFixture("claims"))
+
+	claimed := structured[mcpserver.ClaimPortOutput](t, h.call("claim_port", map[string]any{
+		"project": "shop", "worktree": "main",
+	}))
+	if len(claimed.Ports) != 1 {
+		t.Fatalf("claim_port returned %v, want one port", claimed.Ports)
+	}
+	port := claimed.Ports[0]
+
+	out := structured[rpc.PortsNextResult](t, h.call("next_free_port", map[string]any{"start": port}))
+	if len(out.Ports) != 1 || out.Ports[0] == port {
+		t.Fatalf("next_free_port from %d = %v, want it to step over the claim", port, out.Ports)
+	}
+}
+
+// -------------------------------------------------------------- claim_port ---
+
+func TestClaimPortIsIdempotent(t *testing.T) {
+	h := newHarnessWith(t, queryFixture("claims"))
+
+	args := map[string]any{"project": "shop", "worktree": "feature-x", "count": 2}
+	first := structured[mcpserver.ClaimPortOutput](t, h.call("claim_port", args))
+	if first.Key != "shop/feature-x" {
+		t.Errorf("key = %q, want shop/feature-x", first.Key)
+	}
+	if len(first.Ports) != 2 {
+		t.Fatalf("ports = %v, want two", first.Ports)
+	}
+	if first.ExpiresAt == "" {
+		t.Error("a claim without an expiry is not a claim")
+	}
+
+	second := structured[mcpserver.ClaimPortOutput](t, h.call("claim_port", args))
+	if !equalInts(second.Ports, first.Ports) {
+		t.Fatalf("claiming again returned %v, want the same %v", second.Ports, first.Ports)
+	}
+
+	text := textOf(h.call("claim_port", args))
+	if !strings.HasPrefix(text, "shop/feature-x claims ") {
+		t.Errorf("text = %q", text)
+	}
+
+	released := structured[mcpserver.ClaimPortOutput](t,
+		h.call("claim_port", map[string]any{"project": "shop", "worktree": "feature-x", "release": true}))
+	if released.Released != 2 {
+		t.Errorf("released = %d, want 2", released.Released)
+	}
+	if len(released.Ports) != 0 {
+		t.Errorf("a release returned ports: %v", released.Ports)
+	}
+
+	// Releasing again is a no-op, not a failure.
+	again := structured[mcpserver.ClaimPortOutput](t,
+		h.call("claim_port", map[string]any{"project": "shop", "worktree": "feature-x", "release": true}))
+	if again.Released != 0 {
+		t.Errorf("released = %d on the second release, want 0", again.Released)
+	}
+}
+
+// TestClaimPortDefaultsToTheWorkingDirectory covers the identity the tool
+// derives when the caller names nothing: the checkout the MCP server runs in.
+func TestClaimPortDefaultsToTheWorkingDirectory(t *testing.T) {
+	h := newHarnessWith(t, queryFixture("claims"))
+
+	out := structured[mcpserver.ClaimPortOutput](t, h.call("claim_port", map[string]any{}))
+	if !strings.Contains(out.Key, "/") {
+		t.Fatalf("key = %q, want <project>/<worktree>", out.Key)
+	}
+	if len(out.Ports) != 1 {
+		t.Fatalf("ports = %v, want one", out.Ports)
+	}
+}
+
+func TestClaimPortWithoutTheCapability(t *testing.T) {
+	h := newHarness(t) // the default fixture advertises no claims
+
+	payload, ok := mcpserver.DecodeError(h.call("claim_port", map[string]any{"project": "shop"}))
+	if !ok {
+		t.Fatal("expected an error result")
+	}
+	if payload.Error.Code != mcpserver.CodeCapabilityMissing {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeCapabilityMissing)
+	}
+	if payload.Error.Hint == "" {
+		t.Error("capability_missing must say what to do about it")
+	}
+	if n := h.fake.Calls("claims.acquire"); n != 0 {
+		t.Errorf("the daemon was called %d times for a missing capability", n)
+	}
+}
+
+// ---------------------------------------------------------------- tail_logs ---
+
+func TestTailLogs(t *testing.T) {
+	h := newHarness(t)
+
+	res := h.call("tail_logs", map[string]any{"port": 3000})
+	out := structured[mcpserver.TailLogsOutput](t, res)
+	if len(out.Lines) != mcpserver.DefaultLogLines {
+		t.Fatalf("got %d lines, want the default %d", len(out.Lines), mcpserver.DefaultLogLines)
+	}
+	if !out.Truncated {
+		t.Error("a backlog longer than the request must be reported as truncated")
+	}
+	if out.Source == "" {
+		t.Error("the reply must say where it read from")
+	}
+	if last := out.Lines[len(out.Lines)-1]; !strings.HasSuffix(last, "line 250") {
+		t.Errorf("last line = %q, want the newest line", last)
+	}
+	if text := textOf(res); !strings.Contains(text, "100 lines from") || !strings.Contains(text, "line 250") {
+		t.Errorf("text = %q", text)
+	}
+
+	// Asking for more than the process wrote is not truncation.
+	whole := structured[mcpserver.TailLogsOutput](t,
+		h.call("tail_logs", map[string]any{"port": 3000, "lines": 1000}))
+	if len(whole.Lines) != 250 || whole.Truncated {
+		t.Errorf("got %d lines, truncated=%v, want the whole 250-line backlog", len(whole.Lines), whole.Truncated)
+	}
+}
+
+// TestTailLogsCapsTheRequest keeps the tool's own maximum: a request for more
+// than MaxLogLines asks the daemon for the maximum and says so.
+func TestTailLogsCapsTheRequest(t *testing.T) {
+	h := newHarness(t)
+
+	res := h.call("tail_logs", map[string]any{"port": 3000, "lines": 100000})
+	if res.IsError {
+		t.Fatalf("capping should not be an error: %s", textOf(res))
+	}
+	if text := textOf(res); !strings.Contains(text, "capped at 2000 lines") {
+		t.Errorf("text = %q, want it to say the request was capped", text)
+	}
+}
+
+func TestTailLogsSelectorRule(t *testing.T) {
+	h := newHarness(t)
+
+	for _, args := range []map[string]any{
+		{},
+		{"port": 3000, "pid": 4101},
+		{"port": 3000, "run_id": "run-7f3a"},
+	} {
+		payload, ok := mcpserver.DecodeError(h.call("tail_logs", args))
+		if !ok {
+			t.Fatalf("args %v: expected an error result", args)
+		}
+		if payload.Error.Code != mcpserver.CodeInvalidArguments {
+			t.Errorf("args %v: code = %q, want %q", args, payload.Error.Code, mcpserver.CodeInvalidArguments)
+		}
+	}
+}
+
+// TestTailLogsByRunID covers the resolution the daemon cannot do: ports.logs
+// takes a port or a pid, so a run id is looked up in the run registry first.
+func TestTailLogsByRunID(t *testing.T) {
+	h := newHarness(t) // the default fixture advertises the run registry
+	h.fake.Handle("runs.list", func(json.RawMessage) (any, error) {
+		return rpc.RunsListResult{Runs: []rpc.RunRecord{{
+			ID: "run-7f3a", PID: 4100, Group: "shop", Name: "api",
+			Cmd: "node server.js", Cwd: "/home/dev/shop",
+			StartedAt: fakedaemon.FixtureTime, Ports: []int{3000}, Status: "running",
+		}}}, nil
+	})
+
+	out := structured[mcpserver.TailLogsOutput](t,
+		h.call("tail_logs", map[string]any{"run_id": "run-7f3a", "lines": 5}))
+	if len(out.Lines) != 5 {
+		t.Fatalf("got %d lines, want 5", len(out.Lines))
+	}
+	if !strings.Contains(out.Source, "api") {
+		t.Errorf("source = %q, want the api's log", out.Source)
+	}
+
+	payload, ok := mcpserver.DecodeError(h.call("tail_logs", map[string]any{"run_id": "run-nope"}))
+	if !ok {
+		t.Fatal("an unknown run should be an error result")
+	}
+	if payload.Error.Code != "not_found" {
+		t.Errorf("code = %q, want not_found", payload.Error.Code)
+	}
+}
+
+func TestTailLogsWithoutTheRunRegistry(t *testing.T) {
+	h := newHarnessWith(t, fixtureWithout("runs"))
+
+	payload, ok := mcpserver.DecodeError(h.call("tail_logs", map[string]any{"run_id": "run-7f3a"}))
+	if !ok {
+		t.Fatal("expected an error result")
+	}
+	if payload.Error.Code != mcpserver.CodeCapabilityMissing {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeCapabilityMissing)
+	}
+}
+
+// ------------------------------------------------------------- health_check ---
+
+func TestHealthCheckMapsTheDaemonsVerdict(t *testing.T) {
+	h := newHarness(t)
+
+	tests := []struct {
+		name   string
+		port   int
+		status string
+		code   int
+		reason string
+	}{
+		{"healthy", 3000, "ok", 200, "healthy"},
+		{"bound but not http", 5432, "fail", 0, "non-http"},
+		{"nothing listening", 9999, "fail", 0, "refused"},
+		{"no probe yet", 22, "unknown", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := h.call("health_check", map[string]any{"port": tt.port})
+			out := structured[mcpserver.HealthCheckOutput](t, res)
+			if out.Status != tt.status {
+				t.Errorf("status = %q, want %q", out.Status, tt.status)
+			}
+			if out.Code != tt.code {
+				t.Errorf("code = %d, want %d", out.Code, tt.code)
+			}
+			if out.Reason != tt.reason {
+				t.Errorf("reason = %q, want %q", out.Reason, tt.reason)
+			}
+			if want := "http://localhost:" + strconv.Itoa(tt.port) + "/"; out.URL != want {
+				t.Errorf("url = %q, want %q", out.URL, want)
+			}
+			if text := textOf(res); !strings.Contains(text, tt.status) {
+				t.Errorf("text = %q, want it to carry the status", text)
+			}
+		})
+	}
+}
+
+func TestHealthCheckRejectsAnotherPath(t *testing.T) {
+	h := newHarness(t)
+
+	payload, ok := mcpserver.DecodeError(h.call("health_check", map[string]any{"port": 3000, "path": "/ready"}))
+	if !ok {
+		t.Fatal("expected an error result")
+	}
+	if payload.Error.Code != mcpserver.CodeInvalidArguments {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeInvalidArguments)
+	}
+	if !strings.Contains(payload.Error.Hint, "wait_for_port") {
+		t.Errorf("hint = %q, want it to point at the tool that can probe a path", payload.Error.Hint)
+	}
+	// "/" is the supported path and must not be rejected.
+	if res := h.call("health_check", map[string]any{"port": 3000, "path": "/"}); res.IsError {
+		t.Errorf(`path "/" was rejected: %s`, textOf(res))
+	}
+}
+
+// --------------------------------------------------------- dependency_graph ---
+
+func TestDependencyGraphAggregatesEdges(t *testing.T) {
+	h := newHarness(t)
+
+	res := h.call("dependency_graph", map[string]any{})
+	out := structured[mcpserver.DependencyGraphOutput](t, res)
+
+	want := []mcpserver.DependencyEdge{
+		{FromPort: 3000, ToPort: 5432, FromName: "api", ToName: "shop-db", Connections: 1},
+		{FromPort: 5173, ToPort: 3000, FromName: "vite", ToName: "api", Connections: 2},
+		{FromPort: 8080, ToPort: 3000, FromName: "shop-gateway", ToName: "api", Connections: 1},
+	}
+	if !jsonEqual(t, out.Edges, want) {
+		t.Fatalf("edges =\n%s\nwant\n%s", mustJSON(t, out.Edges), mustJSON(t, want))
+	}
+	text := textOf(res)
+	for _, want := range []string{"3 edges", "CONNECTIONS", "vite", "shop-db"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text is missing %q:\n%s", want, text)
+		}
+	}
+}
+
+// ------------------------------------------------------------- port_history ---
+
+func TestPortHistorySinceForms(t *testing.T) {
+	h := newHarness(t)
+
+	// The fixture's ring is one event an hour old, one two hours old and one
+	// from the day before last.
+	tests := []struct {
+		name string
+		args map[string]any
+		want int
+	}{
+		{"default 24h", map[string]any{}, 2},
+		{"duration", map[string]any{"since": "90m"}, 1},
+		{"wider duration", map[string]any{"since": "48h"}, 3},
+		{"timestamp", map[string]any{"since": time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)}, 2},
+		{"port filter", map[string]any{"since": "48h", "port": 5432}, 1},
+		{"limit", map[string]any{"since": "48h", "limit": 1}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := structured[rpc.PortsHistoryResult](t, h.call("port_history", tt.args))
+			if len(out.Events) != tt.want {
+				t.Fatalf("got %d events, want %d: %s", len(out.Events), tt.want, mustJSON(t, out.Events))
+			}
+		})
+	}
+
+	res := h.call("port_history", map[string]any{})
+	if text := textOf(res); !strings.Contains(text, "since 24h") || !strings.Contains(text, "KIND") {
+		t.Errorf("text = %q", text)
+	}
+}
+
+// TestPortHistoryPassesTheSinceGrammarThrough keeps one owner for the grammar:
+// the daemon rejects what it does not understand, and the tool reports its code.
+func TestPortHistoryPassesTheSinceGrammarThrough(t *testing.T) {
+	h := newHarness(t)
+
+	payload, ok := mcpserver.DecodeError(h.call("port_history", map[string]any{"since": "last tuesday"}))
+	if !ok {
+		t.Fatal("expected an error result")
+	}
+	if payload.Error.Code != "invalid_params" {
+		t.Errorf("code = %q, want the daemon's invalid_params", payload.Error.Code)
+	}
+}
+
+// ------------------------------------------------------------ list_sessions ---
+
+func TestListSessions(t *testing.T) {
+	fx := queryFixture("sessions")
+	fx.Sessions = append(fx.Sessions, state.SessionRecord{
+		Session: state.Session{
+			ID: "codex:1a2b", Tool: "codex", Label: "docs",
+			Worktree: "docs-fix", Branch: "docs", Detected: true,
+		},
+		FirstSeen: fakedaemon.FixtureTime, LastSeen: fakedaemon.FixtureTime,
+		Runs: 0, Ports: 0, Groups: 0, Active: false,
+	})
+	h := newHarnessWith(t, fx)
+
+	res := h.call("list_sessions", map[string]any{})
+	out := structured[rpc.SessionsListResult](t, res)
+	if len(out.Sessions) != 1 || out.Sessions[0].ID != "claude-code:9f2c" {
+		t.Fatalf("sessions = %s, want only the active one", mustJSON(t, out.Sessions))
+	}
+	if !jsonEqual(t, out.Sessions, fakedaemon.DefaultSessions()) {
+		t.Errorf("structured content differs from sessions.list:\n%s", mustJSON(t, out.Sessions))
+	}
+	text := textOf(res)
+	for _, want := range []string{"1 session", "claude-code:9f2c", "BRANCH", "ACTIVE"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text is missing %q:\n%s", want, text)
+		}
+	}
+
+	all := structured[rpc.SessionsListResult](t,
+		h.call("list_sessions", map[string]any{"active_only": false}))
+	if len(all.Sessions) != 2 {
+		t.Fatalf("active_only: false returned %d sessions, want 2", len(all.Sessions))
+	}
+}
+
+func TestListSessionsWithoutTheCapability(t *testing.T) {
+	h := newHarness(t)
+
+	payload, ok := mcpserver.DecodeError(h.call("list_sessions", map[string]any{}))
+	if !ok {
+		t.Fatal("expected an error result")
+	}
+	if payload.Error.Code != mcpserver.CodeCapabilityMissing {
+		t.Errorf("code = %q, want %q", payload.Error.Code, mcpserver.CodeCapabilityMissing)
+	}
+	if n := h.fake.Calls("sessions.list"); n != 0 {
+		t.Errorf("the daemon was called %d times for a missing capability", n)
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+// TestWaitForPortCancelsTheStream is spec 2 §1's cancellation rule: when the
+// MCP client drops the call, the daemon is told to stop waiting rather than
+// left probing a port nobody is listening for any more.
+func TestWaitForPortCancelsTheStream(t *testing.T) {
+	h := newHarness(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = h.client.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "wait_for_port",
+			Arguments: map[string]any{"ports": []any{65000}, "timeout_seconds": 300},
+		})
+	}()
+
+	waitFor(t, 10*time.Second, "the wait to reach the daemon", func() bool { return h.fake.Calls("ports.wait") == 1 })
+	cancel()
+	waitFor(t, 10*time.Second, "the stream to be cancelled", func() bool { return h.fake.Calls("stream.cancel") >= 1 })
+	<-done
+}

--- a/internal/mcpserver/tools_read.go
+++ b/internal/mcpserver/tools_read.go
@@ -16,7 +16,7 @@ import (
 // ListPortsInput is the argument set of list_ports.
 type ListPortsInput struct {
 	Group       string `json:"group,omitempty" jsonschema:"Only ports in this group. A group is a project (a .sonar.yaml, a compose project or a git root); a sonar start name or run id also selects that run's ports."`
-	Session     string `json:"session,omitempty" jsonschema:"Only ports started by this agent session id, as reported in each port's session object."`
+	Session     string `json:"session,omitempty" jsonschema:"Only ports started by this agent session id, as reported in each port's session object. A unique prefix of the id works too; list_sessions shows the ids."`
 	Type        string `json:"type,omitempty" jsonschema:"Only ports of one kind: user (a process someone started), docker (a published container port) or system (a service the machine runs)."`
 	IncludeApps bool   `json:"include_apps,omitempty" jsonschema:"Include desktop applications that happen to listen (Chrome, Docker Desktop, Spotlight). Off by default because they are noise for development work."`
 	Stats       bool   `json:"stats,omitempty" jsonschema:"Collect CPU, memory, thread and uptime stats for each port. Costs an extra scan; leave off unless you were asked about resource use."`
@@ -77,8 +77,9 @@ func (s *Server) addReadTools() {
 	}, s.inspectPort)
 }
 
-// listPorts is ports.list, plus the session filter the daemon does not have
-// yet: the session lives on the port object, so it is filtered here.
+// listPorts is ports.list. Every filter is the daemon's own, including
+// session: it matches an id or a unique prefix of one (contract §29), which is
+// the daemon's rule and not a second one invented here.
 func (s *Server) listPorts(ctx context.Context, _ *mcp.CallToolRequest, in ListPortsInput) (*mcp.CallToolResult, any, error) {
 	params := rpc.PortsListParams{All: in.IncludeApps}
 	if in.Group != "" {
@@ -92,6 +93,9 @@ func (s *Server) listPorts(ctx context.Context, _ *mcp.CallToolRequest, in ListP
 			return errorResult(unsupportedValue("type", in.Type, "user", "docker", "system")), nil, nil
 		}
 	}
+	if in.Session != "" {
+		params.Session = &in.Session
+	}
 	if in.Stats {
 		params.Include = rpc.Include{"stats"}
 	}
@@ -99,9 +103,6 @@ func (s *Server) listPorts(ctx context.Context, _ *mcp.CallToolRequest, in ListP
 	var res rpc.PortsListResult
 	if err := s.daemon.Call(ctx, "ports.list", params, &res); err != nil {
 		return s.failed(err)
-	}
-	if in.Session != "" {
-		res.Ports = filterBySession(res.Ports, in.Session)
 	}
 	if res.Ports == nil {
 		res.Ports = []state.Port{}
@@ -156,23 +157,6 @@ func (s *Server) failed(err error) (*mcp.CallToolResult, any, error) {
 		return errorResult(domain), nil, nil
 	}
 	return nil, nil, err
-}
-
-// filterBySession keeps the ports a session started. The daemon carries the
-// session on the port (contract §5) but has no session filter of its own until
-// the sessions slice lands, so the match happens here: on the id, and on the
-// label, because that is what an agent is likely to have been told.
-func filterBySession(ports []state.Port, session string) []state.Port {
-	out := make([]state.Port, 0, len(ports))
-	for _, p := range ports {
-		if p.Session == nil {
-			continue
-		}
-		if p.Session.ID == session || (p.Session.Label != "" && p.Session.Label == session) {
-			out = append(out, p)
-		}
-	}
-	return out
 }
 
 func describeMismatch(wantPort, pid, gotPort int) string {


### PR DESCRIPTION
Roadmap step 2A.5.

- Tools: `wait_for_port` (streamed `ports.wait`, cancellable), `next_free_port`, `claim_port` (acquire/release via `claims.*`, project/worktree from the MCP process cwd), `tail_logs` (port/pid/run_id), `health_check`, `dependency_graph` (edges aggregated with connection counts), `port_history`, `list_sessions`. Capability-gated where the daemon may lack `claims`, `sessions` or `runs`.
- `list_ports {session}` now uses the daemon's own session filter.
- `claims.Identity` shared between `sonar claim` and `claim_port`.
- Fake daemon serves the query methods and streams, all schema-validated.

Demo over stdio against a real daemon: claim a port, wait for it over HTTP, health check, tail logs, history, sessions, release.