### PR TITLE
feat: serve ports, groups and sessions as subscribable mcp resources with prompts

### DIFF
--- a/internal/mcpserver/daemonconn.go
+++ b/internal/mcpserver/daemonconn.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -171,29 +172,62 @@ func (d *Daemon) Reconnects() int {
 	return d.reconnects
 }
 
+// StateSub is a handle on a state.subscribe that outlives one connection.
+type StateSub struct {
+	d  *Daemon
+	ps *persistentSub
+}
+
+// Close ends the subscription: it takes it out of the reconnect set and tells
+// the daemon to stop (state.unsubscribe), so the MCP server stops counting as
+// a subscriber. That matters beyond tidiness — a connected subscriber is
+// activity against the daemon's idle timeout (contract §15) — which is why the
+// resource layer holds a subscription only while a client is watching
+// something (contract §30).
+func (s *StateSub) Close(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.d.forget(s.ps)
+	return s.ps.unsubscribe(ctx)
+}
+
 // Subscribe opens a state.subscribe that is re-issued after every reconnect.
 // deltas receives every state.delta; resumed, if set, is called with the fresh
-// snapshot each time the subscription is re-established, which is a
+// snapshot each time the subscription is established, which is a
 // resource-serving layer's cue to re-send ResourceUpdated for every URI it has
 // handed out (spec 1).
+//
+// The handle comes back even when the initial subscribe failed, because the
+// subscription is registered either way: a daemon that is away right now gets
+// it on the next reconnect, and the caller's resumed hook is how they hear
+// about it.
 func (d *Daemon) Subscribe(ctx context.Context, opts client.SubscribeOptions,
-	deltas func(state.Delta), resumed func(state.Snapshot)) error {
+	deltas func(state.Delta), resumed func(state.Snapshot)) (*StateSub, error) {
 
 	ps := &persistentSub{opts: opts, deltas: deltas, resumed: resumed}
 
 	d.mu.Lock()
 	if d.closed {
 		d.mu.Unlock()
-		return errors.New("mcpserver: the daemon connection is closed")
+		return nil, errors.New("mcpserver: the daemon connection is closed")
 	}
 	c := d.cur
 	d.subs = append(d.subs, ps)
 	d.mu.Unlock()
 
+	handle := &StateSub{d: d, ps: ps}
 	if c == nil {
-		return d.unavailable()
+		return handle, d.unavailable()
 	}
-	return ps.open(ctx, c)
+	return handle, ps.open(ctx, c)
+}
+
+// forget stops re-issuing ps after a reconnect.
+func (d *Daemon) forget(ps *persistentSub) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.subs = slices.DeleteFunc(d.subs, func(other *persistentSub) bool { return other == ps })
 }
 
 // Close disconnects and stops reconnecting.
@@ -348,4 +382,22 @@ func (ps *persistentSub) stop() {
 	if cancel != nil {
 		cancel()
 	}
+}
+
+// unsubscribe stops the pump and tells the daemon we are done. Unlike stop, it
+// is the deliberate end of a subscription rather than a connection going away,
+// so the daemon hears about it.
+func (ps *persistentSub) unsubscribe(ctx context.Context) error {
+	ps.mu.Lock()
+	sub, cancel := ps.sub, ps.cancel
+	ps.sub, ps.cancel = nil, nil
+	ps.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if sub == nil {
+		return nil
+	}
+	return sub.Unsubscribe(ctx)
 }

--- a/internal/mcpserver/export_test.go
+++ b/internal/mcpserver/export_test.go
@@ -1,0 +1,7 @@
+package mcpserver
+
+// SubscribedURIs is the set of resource URIs clients are watching right now.
+// It exists for the tests, which need to know that a subscription has been
+// registered: MCP's own subscribe is a long-lived request the client sends
+// without waiting for it to be answered.
+func (s *Server) SubscribedURIs() []string { return s.subs.uris() }

--- a/internal/mcpserver/fakedaemon/handlers.go
+++ b/internal/mcpserver/fakedaemon/handlers.go
@@ -23,6 +23,7 @@ func (f *Fake) registerCore() {
 		return rpc.GroupsListResult{Groups: f.Fixture().Groups}, nil
 	})
 	f.registerQuery()
+	f.registerResourceMethods()
 }
 
 func (f *Fake) handleHello(raw json.RawMessage) (any, error) {

--- a/internal/mcpserver/fakedaemon/handlers_resources.go
+++ b/internal/mcpserver/fakedaemon/handlers_resources.go
@@ -1,0 +1,45 @@
+package fakedaemon
+
+import (
+	"encoding/json"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// The reads the MCP resources are served from beyond `ports.list` and
+// `groups.list`: one group in full, and the sessions collection.
+
+func (f *Fake) registerResourceMethods() {
+	f.Handle("groups.inspect", f.handleGroupsInspect)
+}
+
+// handleGroupsInspect is the daemon's `groups.inspect`: the group plus the
+// ports that belong to it. An unknown name is not_found, which is what makes
+// `resources/read sonar://groups/nope` a not_found for the client.
+func (f *Fake) handleGroupsInspect(raw json.RawMessage) (any, error) {
+	var p rpc.GroupsInspectParams
+	if err := unmarshal(raw, &p); err != nil {
+		return nil, err
+	}
+	if p.Name == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams,
+			"groups.inspect needs a name", "run `sonar groups` to see the names")
+	}
+
+	fx := f.Fixture()
+	for _, g := range fx.Groups {
+		if g.Name != p.Name {
+			continue
+		}
+		ports := []state.Port{}
+		for _, row := range fx.Ports {
+			if inGroup(row, g.Name) {
+				ports = append(ports, filterPort(row, include{}))
+			}
+		}
+		return rpc.GroupsInspectResult{Group: g, Ports: ports}, nil
+	}
+	return nil, rpc.NewError(rpc.CodeNotFound,
+		"no group named "+p.Name, "run `sonar groups` to see the names")
+}

--- a/internal/mcpserver/fakedaemon/schema_test.go
+++ b/internal/mcpserver/fakedaemon/schema_test.go
@@ -45,6 +45,7 @@ func TestRepliesValidateAgainstTheProtocolSchema(t *testing.T) {
 		{"claims.acquire", rpc.ClaimsAcquireParams{Project: "shop"}, "ClaimsAcquireResult"},
 		{"claims.list", rpc.Empty{}, "ClaimsListResult"},
 		{"claims.release", rpc.ClaimsReleaseParams{Key: "shop/main"}, "ClaimsReleaseResult"},
+		{"groups.inspect", rpc.GroupsInspectParams{Name: "shop"}, "GroupsInspectResult"},
 	}
 
 	for _, tc := range cases {

--- a/internal/mcpserver/integration_resources_test.go
+++ b/internal/mcpserver/integration_resources_test.go
@@ -1,0 +1,190 @@
+//go:build integration
+
+// Step 2A.3's demo in executable form: over stdio against a real daemon,
+// subscribe to sonar://ports, start a listener, and watch the resources/updated
+// notification arrive; stop the listener and watch the next one; unsubscribe
+// and watch the daemon's subscriber count go back to zero.
+package mcpserver_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/mcpserver"
+)
+
+func TestRealDaemonResourcesListAndRead(t *testing.T) {
+	e := newRealEnv(t)
+	port := e.listen(t)
+	session := e.connect(t)
+
+	res, err := session.ListResources(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("resources/list: %v", err)
+	}
+	uris := []string{}
+	for _, r := range res.Resources {
+		uris = append(uris, r.URI)
+		t.Logf("%-18s %s", r.URI, r.MIMEType)
+	}
+	for _, want := range []string{mcpserver.URIPorts, mcpserver.URIGroups, mcpserver.URISessions} {
+		if !contains(uris, want) {
+			t.Fatalf("resources/list = %v, want it to carry %s", uris, want)
+		}
+	}
+
+	read, err := session.ReadResource(context.Background(),
+		&mcp.ReadResourceParams{URI: mcpserver.URIPorts})
+	if err != nil {
+		t.Fatalf("reading %s: %v", mcpserver.URIPorts, err)
+	}
+	var body rpc.PortsListResult
+	if err := json.Unmarshal([]byte(read.Contents[0].Text), &body); err != nil {
+		t.Fatalf("decoding %s: %v", mcpserver.URIPorts, err)
+	}
+	if !hasPort(body.Ports, port) {
+		t.Fatalf("sonar://ports does not carry this test's own listener on %d", port)
+	}
+	t.Logf("sonar://ports carries %d ports, including this test's %d", len(body.Ports), port)
+}
+
+// TestRealDaemonResourceSubscription is the demo: a change on the machine
+// becomes a resources/updated in the client, and unsubscribing gives the
+// daemon its idle timeout back.
+func TestRealDaemonResourceSubscription(t *testing.T) {
+	e := newRealEnv(t)
+
+	updates := make(chan string, 32)
+	cmd := exec.Command(e.bin, "mcp", "--log-level", "debug")
+	cmd.Env = e.env()
+	cmd.Stderr = &stderrSink{e: e}
+	client := mcp.NewClient(&mcp.Implementation{Name: "sonar-itest", Version: "1"},
+		&mcp.ClientOptions{
+			ResourceUpdatedHandler: func(_ context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+				updates <- req.Params.URI
+			},
+		})
+	session, err := client.Connect(context.Background(), &mcp.CommandTransport{Command: cmd}, nil)
+	if err != nil {
+		t.Fatalf("connecting to `sonar mcp`: %v\nstderr:\n%s", err, e.stderr())
+	}
+	defer session.Close()
+
+	ctx := context.Background()
+	if err := session.Subscribe(ctx, &mcp.SubscribeParams{URI: mcpserver.URIPorts}); err != nil {
+		t.Fatalf("subscribing to %s: %v", mcpserver.URIPorts, err)
+	}
+	waitForStatus(t, e, "the daemon to count the MCP server as a subscriber", func(s daemonStatus) bool {
+		return s.Subscribers >= 1
+	})
+
+	// A port appears.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uri := awaitUpdate(t, updates, 20*time.Second); uri != mcpserver.URIPorts {
+		t.Fatalf("update = %q, want %s", uri, mcpserver.URIPorts)
+	}
+	t.Logf("a new listener on %d produced resources/updated for %s",
+		ln.Addr().(*net.TCPAddr).Port, mcpserver.URIPorts)
+
+	// And goes away again.
+	drain(updates)
+	_ = ln.Close()
+	if uri := awaitUpdate(t, updates, 20*time.Second); uri != mcpserver.URIPorts {
+		t.Fatalf("update after the listener closed = %q, want %s", uri, mcpserver.URIPorts)
+	}
+	t.Log("closing the listener produced a second resources/updated")
+
+	if err := session.Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: mcpserver.URIPorts}); err != nil {
+		t.Fatalf("unsubscribing: %v", err)
+	}
+	waitForStatus(t, e, "the daemon's subscriber count to go back to zero", func(s daemonStatus) bool {
+		return s.Subscribers == 0
+	})
+	t.Log("after unsubscribing `sonar daemon status` reports 0 subscribers")
+}
+
+// TestRealDaemonPromptsOverStdio is the prompt half of the demo.
+func TestRealDaemonPromptsOverStdio(t *testing.T) {
+	e := newRealEnv(t)
+	session := e.connect(t)
+
+	list, err := session.ListPrompts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("prompts/list: %v", err)
+	}
+	if len(list.Prompts) != 2 {
+		t.Fatalf("prompts/list = %+v, want two prompts", list.Prompts)
+	}
+
+	res, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
+		Name:      mcpserver.PromptFreePort,
+		Arguments: map[string]string{"port": "8123"},
+	})
+	if err != nil {
+		t.Fatalf("prompts/get free_port: %v", err)
+	}
+	text, ok := res.Messages[0].Content.(*mcp.TextContent)
+	if !ok || !strings.Contains(text.Text, "Inspect port 8123") {
+		t.Fatalf("free_port expanded to %+v", res.Messages)
+	}
+	t.Logf("prompts/get free_port {port: 8123} →\n%s", text.Text)
+}
+
+type daemonStatus struct {
+	Running     bool `json:"running"`
+	Subscribers int  `json:"subscribers"`
+}
+
+func waitForStatus(t *testing.T, e *realEnv, what string, ok func(daemonStatus) bool) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	var last daemonStatus
+	for time.Now().Before(deadline) {
+		out := e.run(t, "daemon", "status", "--json")
+		if err := json.Unmarshal([]byte(out), &last); err == nil && ok(last) {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s (last status: %+v)", what, last)
+}
+
+func awaitUpdate(t *testing.T, updates chan string, limit time.Duration) string {
+	t.Helper()
+	select {
+	case uri := <-updates:
+		return uri
+	case <-time.After(limit):
+		t.Fatal("no resources/updated arrived")
+		return ""
+	}
+}
+
+func drain(updates chan string) {
+	for {
+		select {
+		case <-updates:
+		default:
+			return
+		}
+	}
+}
+
+func contains(all []string, want string) bool {
+	for _, v := range all {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcpserver/prompts.go
+++ b/internal/mcpserver/prompts.go
@@ -1,0 +1,123 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The prompts (spec 2, section 1.3). Both are thin on purpose: they are the
+// two moments where a person reaches for sonar and would otherwise have to
+// write the instruction themselves, and the text is the workflow the tools
+// were designed around — find out who owns a port before freeing it, and bring
+// a project up in dependency order rather than one server at a time.
+
+// PromptFreePort and PromptBringUpProject are the prompt names.
+const (
+	PromptFreePort        = "free_port"
+	PromptBringUpProject  = "bring_up_project"
+	freePortDescription   = "Work out what is holding a port and how to free it without breaking someone else's work."
+	bringUpProjectDescrip = "Start every service a project declares, in dependency order, and report the URLs."
+)
+
+func init() { registerPrompts((*Server).addPrompts) }
+
+func (s *Server) addPrompts() {
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        PromptFreePort,
+		Title:       "Free a port",
+		Description: freePortDescription,
+		Arguments: []*mcp.PromptArgument{{
+			Name:        "port",
+			Title:       "Port",
+			Description: "The TCP port to free, for example 3000.",
+			Required:    true,
+		}},
+	}, freePortPrompt)
+
+	s.mcp.AddPrompt(&mcp.Prompt{
+		Name:        PromptBringUpProject,
+		Title:       "Bring up a project",
+		Description: bringUpProjectDescrip,
+		Arguments: []*mcp.PromptArgument{{
+			Name:        "path",
+			Title:       "Project path",
+			Description: "The project directory holding the .sonar.yaml. Defaults to the working directory the MCP server was started in.",
+		}},
+	}, bringUpProjectPrompt)
+}
+
+// freePortPrompt is spec 2's text verbatim. The last sentence is the whole
+// point of the prompt: the model is being asked to find the owner, not to kill
+// the process.
+func freePortPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	port, err := portArgument(req.Params.Arguments["port"])
+	if err != nil {
+		return nil, err
+	}
+	return userPrompt(freePortDescription, fmt.Sprintf(
+		"Inspect port %d, explain what owns it and who started it, then propose the least "+
+			"destructive way to free it. Do not kill without confirming what it is.", port)), nil
+}
+
+// bringUpProjectPrompt defaults the path to the server's working directory,
+// which for a stdio server is the directory the client (and so the developer)
+// is working in.
+func bringUpProjectPrompt(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	path := strings.TrimSpace(req.Params.Arguments["path"])
+	if path == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, promptError(fmt.Sprintf(
+				"%s needs a path: this server has no working directory of its own (%v)",
+				PromptBringUpProject, err))
+		}
+		path = cwd
+	}
+	return userPrompt(bringUpProjectDescrip, fmt.Sprintf(
+		"Read `.sonar.yaml` in %s via `list_groups`, start each service with `start_service` "+
+			"in dependency order, wait for their ports, and report the URLs.", path)), nil
+}
+
+// portArgument parses the one argument free_port takes. Prompt arguments are
+// strings on the wire, so "3000" and " 3000 " are the same port and "http" is
+// an error the client can show rather than a prompt that reads as nonsense.
+func portArgument(raw string) (int, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return 0, promptError(PromptFreePort + " needs a port, for example {\"port\": \"3000\"}")
+	}
+	port, err := strconv.Atoi(value)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, promptError(fmt.Sprintf("%q is not a TCP port; pass a number between 1 and 65535", raw))
+	}
+	return port, nil
+}
+
+// userPrompt wraps text as the single user message a prompt expands to. Both
+// prompts are instructions to the model, not context for it, so they are user
+// messages rather than assistant ones.
+func userPrompt(description, text string) *mcp.GetPromptResult {
+	return &mcp.GetPromptResult{
+		Description: description,
+		Messages: []*mcp.PromptMessage{{
+			Role:    "user",
+			Content: &mcp.TextContent{Text: text},
+		}},
+	}
+}
+
+// promptError is an argument failure. A prompt has no IsError channel the way
+// a tool result does, so it fails the call with the invalid-params code and
+// the tools' "<code>: <message>" wording.
+func promptError(message string) error {
+	return &jsonrpc.Error{
+		Code:    jsonrpc.CodeInvalidParams,
+		Message: CodeInvalidArguments + ": " + message,
+	}
+}

--- a/internal/mcpserver/prompts_test.go
+++ b/internal/mcpserver/prompts_test.go
@@ -1,0 +1,126 @@
+package mcpserver_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/mcpserver"
+)
+
+// TestPromptsListShowsBothPrompts pins the argument schemas a client renders:
+// free_port needs a port, bring_up_project takes an optional path.
+func TestPromptsListShowsBothPrompts(t *testing.T) {
+	h := newHarness(t)
+
+	res, err := h.client.ListPrompts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("prompts/list: %v", err)
+	}
+	byName := map[string]*mcp.Prompt{}
+	for _, p := range res.Prompts {
+		byName[p.Name] = p
+	}
+	if len(byName) != 2 {
+		t.Fatalf("prompts/list = %v, want free_port and bring_up_project", byName)
+	}
+
+	free := byName[mcpserver.PromptFreePort]
+	if free == nil || len(free.Arguments) != 1 {
+		t.Fatalf("free_port = %+v, want one argument", free)
+	}
+	if free.Arguments[0].Name != "port" || !free.Arguments[0].Required {
+		t.Errorf("free_port argument = %+v, want a required port", free.Arguments[0])
+	}
+
+	bring := byName[mcpserver.PromptBringUpProject]
+	if bring == nil || len(bring.Arguments) != 1 {
+		t.Fatalf("bring_up_project = %+v, want one argument", bring)
+	}
+	if bring.Arguments[0].Name != "path" || bring.Arguments[0].Required {
+		t.Errorf("bring_up_project argument = %+v, want an optional path", bring.Arguments[0])
+	}
+	for _, p := range res.Prompts {
+		if p.Description == "" || p.Title == "" {
+			t.Errorf("%s needs a title and a description: %+v", p.Name, p)
+		}
+	}
+}
+
+// TestFreePortPromptIsTheSpecText: the prompt is spec 2 section 1.3 verbatim,
+// as one user message. The last sentence is the point of it.
+func TestFreePortPromptIsTheSpecText(t *testing.T) {
+	h := newHarness(t)
+
+	text := promptText(t, h, mcpserver.PromptFreePort, map[string]string{"port": "8123"})
+	want := "Inspect port 8123, explain what owns it and who started it, then propose the " +
+		"least destructive way to free it. Do not kill without confirming what it is."
+	if text != want {
+		t.Fatalf("free_port =\n%q\nwant\n%q", text, want)
+	}
+}
+
+// TestBringUpProjectDefaultsToTheWorkingDirectory: with no path the prompt
+// means "this project", which for a stdio server is the directory the client
+// started it in.
+func TestBringUpProjectDefaultsToTheWorkingDirectory(t *testing.T) {
+	h := newHarness(t)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := promptText(t, h, mcpserver.PromptBringUpProject, nil)
+	want := "Read `.sonar.yaml` in " + cwd + " via `list_groups`, start each service with " +
+		"`start_service` in dependency order, wait for their ports, and report the URLs."
+	if text != want {
+		t.Fatalf("bring_up_project =\n%q\nwant\n%q", text, want)
+	}
+
+	text = promptText(t, h, mcpserver.PromptBringUpProject, map[string]string{"path": "/home/dev/shop"})
+	if !strings.Contains(text, "in /home/dev/shop via") {
+		t.Errorf("bring_up_project did not use the path it was given: %q", text)
+	}
+}
+
+// TestFreePortRejectsSomethingThatIsNotAPort: a prompt has no error result the
+// way a tool does, so a bad argument fails the call — with the same wording an
+// invalid tool argument gets.
+func TestFreePortRejectsSomethingThatIsNotAPort(t *testing.T) {
+	h := newHarness(t)
+
+	for _, args := range []map[string]string{nil, {"port": "http"}, {"port": "99999"}} {
+		_, err := h.client.GetPrompt(context.Background(),
+			&mcp.GetPromptParams{Name: mcpserver.PromptFreePort, Arguments: args})
+		if err == nil {
+			t.Fatalf("free_port %v should have failed", args)
+		}
+		if !strings.Contains(err.Error(), mcpserver.CodeInvalidArguments) {
+			t.Errorf("free_port %v failed with %q, want %s", args, err, mcpserver.CodeInvalidArguments)
+		}
+	}
+}
+
+// promptText expands a prompt and returns its single user message.
+func promptText(t *testing.T, h *harness, name string, args map[string]string) string {
+	t.Helper()
+	res, err := h.client.GetPrompt(context.Background(),
+		&mcp.GetPromptParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf("prompts/get %s: %v", name, err)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("%s returned %d messages, want 1", name, len(res.Messages))
+	}
+	msg := res.Messages[0]
+	if msg.Role != "user" {
+		t.Errorf("%s role = %q, want user", name, msg.Role)
+	}
+	content, ok := msg.Content.(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("%s content is %T, want text", name, msg.Content)
+	}
+	return content.Text
+}

--- a/internal/mcpserver/reconnect_test.go
+++ b/internal/mcpserver/reconnect_test.go
@@ -95,7 +95,7 @@ func TestSubscriptionIsReissuedOnReconnect(t *testing.T) {
 	var mu sync.Mutex
 	var resumes int
 	deltas := make(chan state.Delta, 4)
-	err := h.server.Daemon().Subscribe(context.Background(), client.SubscribeOptions{},
+	_, err := h.server.Daemon().Subscribe(context.Background(), client.SubscribeOptions{},
 		func(d state.Delta) { deltas <- d },
 		func(state.Snapshot) {
 			mu.Lock()
@@ -120,16 +120,13 @@ func TestSubscriptionIsReissuedOnReconnect(t *testing.T) {
 	if err := h.fake.Restart(); err != nil {
 		t.Fatalf("restarting the fake daemon: %v", err)
 	}
+	// The resume hook fires once the re-issued subscription has its snapshot,
+	// which is a moment after the daemon counts the subscriber.
 	waitFor(t, 10*time.Second, "the subscription to be re-issued", func() bool {
-		return h.fake.Subscribers() == 1
+		mu.Lock()
+		defer mu.Unlock()
+		return h.fake.Subscribers() == 1 && resumes >= 2
 	})
-
-	mu.Lock()
-	got := resumes
-	mu.Unlock()
-	if got < 2 {
-		t.Errorf("the resume hook fired %d times, want it once per connection", got)
-	}
 
 	h.fake.Push(state.Delta{})
 	select {

--- a/internal/mcpserver/resources.go
+++ b/internal/mcpserver/resources.go
@@ -1,0 +1,258 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// The resources (spec 2, section 1.2). A resource is the same daemon read a
+// tool does, minus the argument set: a client that wants "what is listening"
+// as context rather than as an answer to a question subscribes to
+// `sonar://ports` once and re-reads it when the server says it changed.
+//
+// The bodies are the daemon's own JSON, indented the way `sonar list --json`
+// prints it, so a person reading a transcript and a model reading the resource
+// see the same document.
+const (
+	// URIPorts is `ports.list` with no apps and no stats: the ports a
+	// developer means when they say "what is running".
+	URIPorts = "sonar://ports"
+	// URIGroups is `groups.list`.
+	URIGroups = "sonar://groups"
+	// URIGroupTemplate addresses one group: `groups.inspect`.
+	URIGroupTemplate = "sonar://groups/{name}"
+	// URISessions is `sessions.list`.
+	URISessions = "sonar://sessions"
+
+	// groupURIPrefix is the literal half of URIGroupTemplate.
+	groupURIPrefix = "sonar://groups/"
+
+	// ResourceMIME is the content type of every sonar resource.
+	ResourceMIME = "application/json"
+)
+
+// resourceRegistrars and promptRegistrars are the registration lists the
+// server walks at startup. A file that owns a resource or a prompt registers
+// it from its own init(), so adding one never means editing server.go — the
+// same convention the tool files use for toolRegistrars.
+var (
+	resourceRegistrars []func(*Server)
+	promptRegistrars   []func(*Server)
+)
+
+// registerResources adds a resource registrar. Call it from an init().
+func registerResources(f func(*Server)) { resourceRegistrars = append(resourceRegistrars, f) }
+
+// registerPrompts adds a prompt registrar. Call it from an init().
+func registerPrompts(f func(*Server)) { promptRegistrars = append(promptRegistrars, f) }
+
+func init() { registerResources((*Server).addResources) }
+
+const portsResourceDescription = `Everything listening on this machine's TCP ports right now, as JSON: the same rows list_ports returns, with the project, group, run and agent session behind each port. Desktop applications and per-process stats are left out.
+
+Subscribe to this resource to keep it fresh: the server sends a resources/updated notification when the daemon's port table changes, at most once a second.`
+
+const groupsResourceDescription = `Every group the daemon knows, as JSON: projects with a .sonar.yaml, compose projects, git roots and ` + "`sonar start`" + ` runs, each with its member ports and declared services.
+
+Read this before starting a project's services: it says what the project declares and what part of it is already up.`
+
+const groupResourceDescription = `One group in full, as JSON: its services, their declared and actual ports, and every port that belongs to it. The URI is sonar://groups/<name>, where <name> is a group name from sonar://groups or list_groups.`
+
+const sessionsResourceDescription = `The agent sessions the daemon has seen, as JSON: which tool and worktree each one is, when it was last active, and how many runs, ports and groups it owns.
+
+Use it to tell your own ports from another session's before you free anything.`
+
+// sessionsUnavailableNote replaces the second half of the sessions description
+// when the daemon does not track sessions. The resource stays registered, and
+// stays an empty list, so a client can cache the resource list across daemon
+// versions the way it caches the tool list (spec 2, "Runtime").
+const sessionsUnavailableNote = `
+
+This daemon does not track sessions (its daemon.hello does not advertise the "sessions" capability), so the list is empty until it is upgraded.`
+
+// addResources registers the four resources and the group template.
+func (s *Server) addResources() {
+	s.mcp.AddResource(&mcp.Resource{
+		URI:         URIPorts,
+		Name:        "ports",
+		Title:       "Listening ports",
+		Description: portsResourceDescription,
+		MIMEType:    ResourceMIME,
+	}, s.readPortsResource)
+
+	s.mcp.AddResource(&mcp.Resource{
+		URI:         URIGroups,
+		Name:        "groups",
+		Title:       "Groups",
+		Description: groupsResourceDescription,
+		MIMEType:    ResourceMIME,
+	}, s.readGroupsResource)
+
+	s.mcp.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: URIGroupTemplate,
+		Name:        "group",
+		Title:       "One group",
+		Description: groupResourceDescription,
+		MIMEType:    ResourceMIME,
+	}, s.readGroupResource)
+
+	description := sessionsResourceDescription
+	if !s.daemon.Has("sessions") {
+		description += sessionsUnavailableNote
+	}
+	s.mcp.AddResource(&mcp.Resource{
+		URI:         URISessions,
+		Name:        "sessions",
+		Title:       "Agent sessions",
+		Description: description,
+		MIMEType:    ResourceMIME,
+	}, s.readSessionsResource)
+}
+
+func (s *Server) readPortsResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	var res rpc.PortsListResult
+	if err := s.daemon.Call(ctx, "ports.list", rpc.PortsListParams{}, &res); err != nil {
+		return nil, s.resourceFailed(req.Params.URI, err)
+	}
+	if res.Ports == nil {
+		res.Ports = []state.Port{}
+	}
+	return jsonResource(req.Params.URI, res)
+}
+
+func (s *Server) readGroupsResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	var res rpc.GroupsListResult
+	if err := s.daemon.Call(ctx, "groups.list", rpc.Empty{}, &res); err != nil {
+		return nil, s.resourceFailed(req.Params.URI, err)
+	}
+	if res.Groups == nil {
+		res.Groups = []state.Group{}
+	}
+	return jsonResource(req.Params.URI, res)
+}
+
+// readGroupResource is the template's handler. The daemon's own `not_found`
+// for an unknown group is what the client sees, so a model that guessed a
+// group name gets the same answer here as from a tool call.
+func (s *Server) readGroupResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	name, ok := GroupNameFromURI(req.Params.URI)
+	if !ok || name == "" {
+		return nil, resourceError(req.Params.URI, Domain("not_found",
+			fmt.Sprintf("%s does not name a group", req.Params.URI),
+			"group URIs are sonar://groups/<name>; read sonar://groups for the names"))
+	}
+
+	var res rpc.GroupsInspectResult
+	if err := s.daemon.Call(ctx, "groups.inspect", rpc.GroupsInspectParams{Name: name}, &res); err != nil {
+		return nil, s.resourceFailed(req.Params.URI, err)
+	}
+	if res.Ports == nil {
+		res.Ports = []state.Port{}
+	}
+	return jsonResource(req.Params.URI, res)
+}
+
+// readSessionsResource serves `sessions.list` when the daemon has sessions,
+// and an empty list when it does not. An older daemon is not an error: the
+// resource list is advertised once and cached, so a resource that disappeared
+// would look like a broken server rather than an older one.
+func (s *Server) readSessionsResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	res := rpc.SessionsListResult{Sessions: []state.SessionRecord{}}
+	if !s.daemon.Has("sessions") {
+		return jsonResource(req.Params.URI, res)
+	}
+	if err := s.daemon.Call(ctx, "sessions.list", rpc.SessionsListParams{}, &res); err != nil {
+		return nil, s.resourceFailed(req.Params.URI, err)
+	}
+	if res.Sessions == nil {
+		res.Sessions = []state.SessionRecord{}
+	}
+	return jsonResource(req.Params.URI, res)
+}
+
+// GroupURI is the resource URI of one group. The name is escaped, because a
+// group name is a project name and may carry anything a directory name can.
+func GroupURI(name string) string { return groupURIPrefix + url.PathEscape(name) }
+
+// GroupNameFromURI is GroupURI's inverse. It reports false for a URI that is
+// not a group URI at all.
+func GroupNameFromURI(uri string) (string, bool) {
+	rest, ok := strings.CutPrefix(uri, groupURIPrefix)
+	if !ok {
+		return "", false
+	}
+	name, err := url.PathUnescape(rest)
+	if err != nil {
+		// A malformed escape is not a name; the raw text is the best guess
+		// and the daemon will say not_found for it.
+		name = rest
+	}
+	return name, true
+}
+
+// knownResourceURI reports whether uri is one this server serves. It is the
+// check resources/subscribe makes: the SDK does not validate the URI of a
+// subscription, and a subscription to a URI that will never change is a
+// silent hang rather than an error.
+func knownResourceURI(uri string) bool {
+	switch uri {
+	case URIPorts, URIGroups, URISessions:
+		return true
+	}
+	name, ok := GroupNameFromURI(uri)
+	return ok && name != ""
+}
+
+// jsonResource is the one body format: the daemon's result, indented two
+// spaces the way the CLI's --json output is.
+func jsonResource(uri string, v any) (*mcp.ReadResourceResult, error) {
+	body, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("mcpserver: encoding %s: %w", uri, err)
+	}
+	return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
+		URI:      uri,
+		MIMEType: ResourceMIME,
+		Text:     string(body),
+	}}}, nil
+}
+
+// resourceFailed turns a daemon call's failure into a resource read failure.
+// A resource read has no IsError channel the way a tool result does, so every
+// domain failure is a JSON-RPC error here — but it keeps the tools' wording,
+// "<code>: <message> (<hint>)", and carries the same {code, message, hint} in
+// the error's data, so a client branches on the same vocabulary either way.
+func (s *Server) resourceFailed(uri string, err error) error {
+	domain, ok := asDomain(err)
+	if !ok {
+		return err
+	}
+	return resourceError(uri, domain)
+}
+
+func resourceError(uri string, e *DomainError) error {
+	code := int64(jsonrpc.CodeInternalError)
+	if e.Code == "not_found" {
+		code = mcp.CodeResourceNotFound
+	}
+	data, err := json.Marshal(map[string]any{
+		"uri": uri,
+		"error": map[string]string{
+			"code":    e.Code,
+			"message": e.Message,
+			"hint":    e.Hint,
+		},
+	})
+	if err != nil {
+		data = nil
+	}
+	return &jsonrpc.Error{Code: code, Message: e.Error(), Data: data}
+}

--- a/internal/mcpserver/resources_test.go
+++ b/internal/mcpserver/resources_test.go
@@ -1,0 +1,243 @@
+package mcpserver_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/mcpserver"
+	"github.com/raskrebs/sonar/internal/mcpserver/fakedaemon"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// TestResourcesListAdvertisesTheCollections: a client that wants sonar as
+// context rather than as a tool finds the four collections and the group
+// template, and finds that it may subscribe to them.
+func TestResourcesListAdvertisesTheCollections(t *testing.T) {
+	h := newHarness(t)
+
+	res, err := h.client.ListResources(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("resources/list: %v", err)
+	}
+	byURI := map[string]*mcp.Resource{}
+	for _, r := range res.Resources {
+		byURI[r.URI] = r
+	}
+	for _, uri := range []string{mcpserver.URIPorts, mcpserver.URIGroups, mcpserver.URISessions} {
+		r, ok := byURI[uri]
+		if !ok {
+			t.Fatalf("resources/list does not carry %s: %v", uri, byURI)
+		}
+		if r.MIMEType != mcpserver.ResourceMIME {
+			t.Errorf("%s mimeType = %q, want %q", uri, r.MIMEType, mcpserver.ResourceMIME)
+		}
+		if r.Name == "" || r.Description == "" {
+			t.Errorf("%s needs a name and a description a model can act on: %+v", uri, r)
+		}
+	}
+
+	templates, err := h.client.ListResourceTemplates(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("resources/templates/list: %v", err)
+	}
+	if len(templates.ResourceTemplates) != 1 ||
+		templates.ResourceTemplates[0].URITemplate != mcpserver.URIGroupTemplate {
+		t.Fatalf("resources/templates/list = %+v, want %s",
+			templates.ResourceTemplates, mcpserver.URIGroupTemplate)
+	}
+
+	caps := h.client.InitializeResult().Capabilities.Resources
+	if caps == nil || !caps.Subscribe || !caps.ListChanged {
+		t.Fatalf("resources capabilities = %+v, want subscribe and listChanged", caps)
+	}
+}
+
+// TestPortsResourceIsPortsListWithoutAppsOrStats pins the body: the daemon's
+// own `{ports: [Port]}`, desktop applications filtered out and stats and
+// health left uncollected, exactly as spec 2 section 1.2 describes it.
+func TestPortsResourceIsPortsListWithoutAppsOrStats(t *testing.T) {
+	h := newHarness(t)
+
+	var got rpc.PortsListResult
+	readResource(t, h, mcpserver.URIPorts, &got)
+
+	want := []state.Port{}
+	for _, p := range fakedaemon.DefaultPorts() {
+		if p.IsApp {
+			continue
+		}
+		p.Stats, p.Health = nil, nil
+		want = append(want, p)
+	}
+	if !reflect.DeepEqual(got.Ports, want) {
+		t.Fatalf("sonar://ports is not ports.list:\n got %s\nwant %s",
+			mustJSON(t, got.Ports), mustJSON(t, want))
+	}
+}
+
+// TestGroupsResourceIsGroupsList checks the second collection.
+func TestGroupsResourceIsGroupsList(t *testing.T) {
+	h := newHarness(t)
+
+	var got rpc.GroupsListResult
+	readResource(t, h, mcpserver.URIGroups, &got)
+
+	if !reflect.DeepEqual(got.Groups, fakedaemon.DefaultGroups()) {
+		t.Fatalf("sonar://groups is not groups.list:\n got %s\nwant %s",
+			mustJSON(t, got.Groups), mustJSON(t, fakedaemon.DefaultGroups()))
+	}
+}
+
+// TestGroupTemplateResolvesToOneGroup is the template half: the name in the
+// URI is the name in the daemon call, and the body is groups.inspect —
+// the group plus its member ports.
+func TestGroupTemplateResolvesToOneGroup(t *testing.T) {
+	h := newHarness(t)
+
+	var got rpc.GroupsInspectResult
+	readResource(t, h, mcpserver.GroupURI("shop"), &got)
+
+	if got.Name != "shop" {
+		t.Fatalf("group name = %q, want shop", got.Name)
+	}
+	if len(got.Services) != 2 {
+		t.Errorf("the group should carry its .sonar.yaml services, got %+v", got.Services)
+	}
+	ports := []int{}
+	for _, p := range got.Ports {
+		ports = append(ports, p.Port)
+	}
+	if !reflect.DeepEqual(ports, []int{3000, 5173}) {
+		t.Errorf("member ports = %v, want [3000 5173]", ports)
+	}
+}
+
+// TestUnknownGroupReadsAsNotFound: a model that guessed a group name gets the
+// daemon's own not_found, in the wording the tools use.
+func TestUnknownGroupReadsAsNotFound(t *testing.T) {
+	h := newHarness(t)
+
+	_, err := h.client.ReadResource(context.Background(),
+		&mcp.ReadResourceParams{URI: mcpserver.GroupURI("nope")})
+	if err == nil {
+		t.Fatal("reading an unknown group should fail")
+	}
+	var wire *jsonrpc.Error
+	if !errors.As(err, &wire) {
+		t.Fatalf("error is %T, want a JSON-RPC error", err)
+	}
+	if !strings.HasPrefix(wire.Message, "not_found: ") {
+		t.Errorf("message = %q, want it to start with not_found:", wire.Message)
+	}
+	if wire.Code != mcp.CodeResourceNotFound {
+		t.Errorf("code = %d, want %d (resource not found)", wire.Code, mcp.CodeResourceNotFound)
+	}
+	var data struct {
+		URI   string `json:"uri"`
+		Error struct {
+			Code string `json:"code"`
+			Hint string `json:"hint"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(wire.Data, &data); err != nil {
+		t.Fatalf("decoding the error data: %v (%s)", err, wire.Data)
+	}
+	if data.Error.Code != "not_found" || data.URI != mcpserver.GroupURI("nope") {
+		t.Errorf("error data = %+v, want the sonar code and the URI", data)
+	}
+	if data.Error.Hint == "" {
+		t.Error("a domain failure carries a hint")
+	}
+}
+
+// TestSessionsResourceServesTheCollection: with a daemon that tracks sessions,
+// the resource is sessions.list.
+func TestSessionsResourceServesTheCollection(t *testing.T) {
+	h := newHarnessWith(t, withSessions(fakedaemon.DefaultFixture()))
+
+	var got rpc.SessionsListResult
+	readResource(t, h, mcpserver.URISessions, &got)
+
+	if !reflect.DeepEqual(got.Sessions, fakedaemon.DefaultSessions()) {
+		t.Fatalf("sonar://sessions is not sessions.list:\n got %s\nwant %s",
+			mustJSON(t, got.Sessions), mustJSON(t, fakedaemon.DefaultSessions()))
+	}
+}
+
+// TestSessionsResourceIsEmptyOnAnOlderDaemon: a daemon that does not advertise
+// `sessions` does not make the resource disappear — the resource list is
+// advertised once and cached — it makes it an empty list, and the description
+// says why.
+func TestSessionsResourceIsEmptyOnAnOlderDaemon(t *testing.T) {
+	h := newHarness(t) // the default fixture has no sessions capability
+
+	var got rpc.SessionsListResult
+	readResource(t, h, mcpserver.URISessions, &got)
+	if len(got.Sessions) != 0 {
+		t.Fatalf("sessions = %+v, want an empty list", got.Sessions)
+	}
+	if calls := h.fake.Calls("sessions.list"); calls != 0 {
+		t.Errorf("sessions.list was called %d times on a daemon without the capability", calls)
+	}
+
+	res, err := h.client.ListResources(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("resources/list: %v", err)
+	}
+	for _, r := range res.Resources {
+		if r.URI != mcpserver.URISessions {
+			continue
+		}
+		if !strings.Contains(r.Description, "does not track sessions") {
+			t.Errorf("the description should say why the list is empty, got %q", r.Description)
+		}
+		return
+	}
+	t.Fatal("sonar://sessions is not in resources/list")
+}
+
+// withSessions is the fixture of a daemon new enough to have the sessions
+// collection (contract §29).
+func withSessions(fx fakedaemon.Fixture) fakedaemon.Fixture {
+	fx.Capabilities = append(append([]string{}, fx.Capabilities...), "sessions")
+	return fx
+}
+
+// readResource reads one resource and decodes its JSON body into out.
+func readResource(t *testing.T, h *harness, uri string, out any) {
+	t.Helper()
+	res, err := h.client.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: uri})
+	if err != nil {
+		t.Fatalf("reading %s: %v", uri, err)
+	}
+	if len(res.Contents) != 1 {
+		t.Fatalf("reading %s returned %d contents, want 1", uri, len(res.Contents))
+	}
+	c := res.Contents[0]
+	if c.URI != uri {
+		t.Errorf("content URI = %q, want %q", c.URI, uri)
+	}
+	if c.MIMEType != mcpserver.ResourceMIME {
+		t.Errorf("content mimeType = %q, want %q", c.MIMEType, mcpserver.ResourceMIME)
+	}
+	if !strings.Contains(c.Text, "\n  ") {
+		t.Errorf("the body should be indented like `sonar list --json`, got %q", clipText(c.Text))
+	}
+	if err := json.Unmarshal([]byte(c.Text), out); err != nil {
+		t.Fatalf("decoding %s: %v\n%s", uri, err, clipText(c.Text))
+	}
+}
+
+func clipText(s string) string {
+	if len(s) > 400 {
+		return s[:400] + "…"
+	}
+	return s
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -59,6 +59,9 @@ type Server struct {
 	mcp    *mcp.Server
 	daemon *Daemon
 	log    *slog.Logger
+	// subs is the resource-subscription hub: it owns the one daemon
+	// state.subscribe the resources are served from.
+	subs *subscriptions
 	// ownsDaemon records whether Close should disconnect: a caller who passed
 	// their own connection keeps it.
 	ownsDaemon bool
@@ -85,36 +88,32 @@ func New(ctx context.Context, opts Options) (*Server, error) {
 		owns = true
 	}
 
-	s := &Server{
-		mcp: mcp.NewServer(
-			&mcp.Implementation{
-				Name:    ServerName,
-				Title:   "sonar",
-				Version: opts.Version,
-			},
-			&mcp.ServerOptions{Instructions: Instructions, Logger: log},
-		),
-		daemon:     d,
-		log:        log,
-		ownsDaemon: owns,
-	}
+	s := &Server{daemon: d, log: log, ownsDaemon: owns}
+	s.subs = newSubscriptions(s)
+	s.mcp = mcp.NewServer(
+		&mcp.Implementation{
+			Name:    ServerName,
+			Title:   "sonar",
+			Version: opts.Version,
+		},
+		&mcp.ServerOptions{
+			Instructions: Instructions,
+			Logger:       log,
+			// Setting these two is what advertises resources.subscribe.
+			SubscribeHandler:   s.subs.subscribe,
+			UnsubscribeHandler: s.subs.unsubscribe,
+		},
+	)
 	for _, register := range toolRegistrars {
 		register(s)
 	}
+	for _, register := range resourceRegistrars {
+		register(s)
+	}
+	for _, register := range promptRegistrars {
+		register(s)
+	}
 	return s, nil
-}
-
-// toolRegistrars holds one function per tools_*.go file, each adding that
-// file's tools to a new server. The list exists so a file can own its tools
-// end to end — schema, description, handler and registration — instead of
-// naming them here as well: the tool set is the sum of the files, and two
-// slices adding tools in parallel never touch the same line.
-var toolRegistrars []func(*Server)
-
-// registerTools adds a file's registrar. Call it from an init in the file that
-// declares the tools.
-func registerTools(register func(*Server)) {
-	toolRegistrars = append(toolRegistrars, register)
 }
 
 // MCP exposes the underlying server so later slices can add resources and
@@ -165,3 +164,16 @@ func outputSchema(v any) json.RawMessage {
 // boolPtr is for the annotation fields the SDK models as *bool, where nil,
 // false and true are three different statements.
 func boolPtr(b bool) *bool { return &b }
+
+// toolRegistrars holds one function per tools_*.go file, each adding that
+// file's tools to a new server. The list exists so a file can own its tools
+// end to end — schema, description, handler and registration — instead of
+// naming them here as well: the tool set is the sum of the files, and two
+// slices adding tools in parallel never touch the same line.
+var toolRegistrars []func(*Server)
+
+// registerTools adds a file's registrar. Call it from an init in the file that
+// declares the tools.
+func registerTools(register func(*Server)) {
+	toolRegistrars = append(toolRegistrars, register)
+}

--- a/internal/mcpserver/subscriptions.go
+++ b/internal/mcpserver/subscriptions.go
@@ -1,0 +1,325 @@
+package mcpserver
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// NotifyInterval is the coalescing window of spec 2, section 1.2: at most one
+// resources/updated per URI per second. A scan that finds a dozen ports
+// arriving at once is one notification, not a dozen, and a client that
+// re-reads on every notification is not made to re-read in a loop.
+const NotifyInterval = time.Second
+
+// subscriptions is the bridge between the two subscription models: MCP's, in
+// which a client subscribes per resource URI, and the daemon's, in which one
+// connection subscribes to the whole state.
+//
+// The bridge is deliberately lazy. The MCP server holds no state.subscribe
+// until a client asks for one, and drops it again when the last subscription
+// goes, because a subscriber counts as activity against the daemon's idle
+// timeout (contract §15, §30): an agent that started `sonar mcp` and never
+// used a resource must not keep a daemon alive for the rest of the day.
+type subscriptions struct {
+	srv      *Server
+	interval time.Duration
+
+	mu sync.Mutex
+	// sessions maps a resource URI to the client sessions watching it. A URI
+	// with no sessions is deleted, so the map is also "what is being watched".
+	sessions map[string]map[*mcp.ServerSession]bool
+	// watching records the sessions we have a disconnect watcher for. The SDK
+	// forgets a disconnected session's subscriptions but does not call the
+	// unsubscribe handler, so the count has to be corrected here or the
+	// daemon subscription outlives the client that asked for it.
+	watching map[*mcp.ServerSession]bool
+	// sub is the daemon subscription, held while at least one URI is watched.
+	sub     *StateSub
+	opening bool
+	// suppressResume swallows the resumed hook that fires inside the very
+	// first Subscribe: that snapshot is not a reconnect, and the client that
+	// just subscribed is about to read the resource anyway.
+	suppressResume bool
+	// lastSent and pending are the coalescer: when a URI last went out, and
+	// the timer that will send the update it is currently holding back.
+	lastSent map[string]time.Time
+	pending  map[string]*time.Timer
+}
+
+func newSubscriptions(s *Server) *subscriptions {
+	return &subscriptions{
+		srv:      s,
+		interval: NotifyInterval,
+		sessions: map[string]map[*mcp.ServerSession]bool{},
+		watching: map[*mcp.ServerSession]bool{},
+		lastSent: map[string]time.Time{},
+		pending:  map[string]*time.Timer{},
+	}
+}
+
+// subscribe is the server's SubscribeHandler. The first subscription opens the
+// daemon's state.subscribe with events off and no include: resources are the
+// port, group and session collections, and asking for stats or health would
+// make the daemon collect them for a client that never reads them.
+func (s *subscriptions) subscribe(ctx context.Context, req *mcp.SubscribeRequest) error {
+	uri := req.Params.URI
+	if !knownResourceURI(uri) {
+		return mcp.ResourceNotFoundError(uri)
+	}
+
+	s.mu.Lock()
+	if s.sessions[uri] == nil {
+		s.sessions[uri] = map[*mcp.ServerSession]bool{}
+	}
+	s.sessions[uri][req.Session] = true
+	watch := !s.watching[req.Session]
+	s.watching[req.Session] = true
+	open := s.sub == nil && !s.opening
+	if open {
+		s.opening, s.suppressResume = true, true
+	}
+	s.mu.Unlock()
+
+	if watch {
+		go s.watchSession(req.Session)
+	}
+	if open {
+		s.open(ctx)
+	}
+	return nil
+}
+
+// open issues the daemon subscription. A daemon that is away right now is not
+// a reason to refuse the client's subscription: the handle is registered
+// either way, the reconnect loop re-issues it, and the resumed hook then tells
+// every subscriber to re-read (spec 2, "Runtime").
+func (s *subscriptions) open(ctx context.Context) {
+	sub, err := s.srv.daemon.Subscribe(ctx, client.SubscribeOptions{}, s.delta, s.resumed)
+
+	s.mu.Lock()
+	s.opening, s.suppressResume = false, false
+	s.sub = sub
+	s.mu.Unlock()
+
+	if err != nil {
+		s.srv.log.Warn("the daemon subscription behind the resources could not be opened",
+			"error", err)
+		return
+	}
+	s.srv.log.Debug("opened the daemon state subscription for resource subscribers")
+}
+
+// unsubscribe is the server's UnsubscribeHandler.
+func (s *subscriptions) unsubscribe(_ context.Context, req *mcp.UnsubscribeRequest) error {
+	s.drop(req.Session, req.Params.URI)
+	return nil
+}
+
+// drop removes one session's interest in uris and closes the daemon
+// subscription when nothing is left watching.
+//
+// It deliberately makes its own context rather than borrowing the caller's:
+// an unsubscribe arrives as the cancellation of the client's subscription
+// stream, so the context that carries it is already dead, and telling the
+// daemon to stop is exactly the call that must still go out.
+func (s *subscriptions) drop(session *mcp.ServerSession, uris ...string) {
+	s.mu.Lock()
+	for _, uri := range uris {
+		watchers := s.sessions[uri]
+		if watchers == nil {
+			continue
+		}
+		delete(watchers, session)
+		if len(watchers) > 0 {
+			continue
+		}
+		delete(s.sessions, uri)
+		if timer := s.pending[uri]; timer != nil {
+			timer.Stop()
+			delete(s.pending, uri)
+		}
+		delete(s.lastSent, uri)
+	}
+	idle := len(s.sessions) == 0
+	sub := s.sub
+	if idle {
+		s.sub = nil
+	}
+	s.mu.Unlock()
+
+	if !idle || sub == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+	if err := sub.Close(ctx); err != nil {
+		s.srv.log.Warn("closing the daemon state subscription failed", "error", err)
+		return
+	}
+	s.srv.log.Debug("closed the daemon state subscription: nothing is subscribed")
+}
+
+// watchSession drops a client's subscriptions when its session ends. Without
+// it a client that exits without unsubscribing would leave the daemon
+// subscription open for the life of the process.
+func (s *subscriptions) watchSession(session *mcp.ServerSession) {
+	_ = session.Wait()
+
+	s.mu.Lock()
+	delete(s.watching, session)
+	var uris []string
+	for uri, watchers := range s.sessions {
+		if watchers[session] {
+			uris = append(uris, uri)
+		}
+	}
+	s.mu.Unlock()
+	if len(uris) == 0 {
+		return
+	}
+	s.drop(session, uris...)
+}
+
+// uris is the set of resource URIs clients are watching right now, sorted.
+func (s *subscriptions) uris() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.sessions))
+	for uri := range s.sessions {
+		out = append(out, uri)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// delta is the state.delta hook: one notification per subscribed URI the
+// delta touched.
+func (s *subscriptions) delta(d state.Delta) {
+	for _, uri := range s.affected(d) {
+		s.notify(uri)
+	}
+}
+
+// resumed is the reconnect hook. Deltas from the gap are gone, so everything
+// a client holds is suspect: every subscribed URI is announced once, ahead of
+// the coalescer rather than through it, so a reconnect always produces exactly
+// one notification per URI (spec 2, "Runtime").
+func (s *subscriptions) resumed(state.Snapshot) {
+	s.mu.Lock()
+	if s.suppressResume {
+		s.suppressResume = false
+		s.mu.Unlock()
+		return
+	}
+	uris := make([]string, 0, len(s.sessions))
+	now := time.Now()
+	for uri := range s.sessions {
+		uris = append(uris, uri)
+		s.lastSent[uri] = now
+	}
+	for uri, timer := range s.pending {
+		timer.Stop()
+		delete(s.pending, uri)
+	}
+	s.mu.Unlock()
+
+	slices.Sort(uris) // a stable order, so a transcript reads the same twice
+	for _, uri := range uris {
+		s.send(uri)
+	}
+}
+
+// affected maps one delta onto the resource URIs it changed, keeping only URIs
+// somebody is actually watching.
+//
+// `sonar://groups` follows spec 2 literally: it is announced when a group
+// appears or disappears, not when one is updated in place, because a group
+// whose member ports changed is news for that group's own URI and for
+// `sonar://ports`, both of which are announced.
+func (s *subscriptions) affected(d state.Delta) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var out []string
+	add := func(uri string) {
+		if len(s.sessions[uri]) == 0 || slices.Contains(out, uri) {
+			return
+		}
+		out = append(out, uri)
+	}
+
+	if changed(d.Ports) {
+		add(URIPorts)
+	}
+	for _, g := range d.Groups.Added {
+		add(GroupURI(g.Name))
+	}
+	for _, g := range d.Groups.Updated {
+		add(GroupURI(g.Name))
+	}
+	for _, name := range d.Groups.Removed {
+		add(GroupURI(name))
+	}
+	if len(d.Groups.Added) > 0 || len(d.Groups.Removed) > 0 {
+		add(URIGroups)
+	}
+	if changed(d.Sessions) {
+		add(URISessions)
+	}
+	return out
+}
+
+func changed[T any](c state.Change[T]) bool {
+	return len(c.Added) > 0 || len(c.Updated) > 0 || len(c.Removed) > 0
+}
+
+// notify sends one update for uri, or holds it back to the end of the current
+// second when one already went out. The first change in a quiet period is
+// delivered immediately — an agent waiting for a server to come up should not
+// wait a second to hear about it — and everything after it is folded into one
+// trailing notification.
+func (s *subscriptions) notify(uri string) {
+	s.mu.Lock()
+	last, seen := s.lastSent[uri]
+	now := time.Now()
+	switch {
+	case !seen || now.Sub(last) >= s.interval:
+		s.lastSent[uri] = now
+		s.mu.Unlock()
+		s.send(uri)
+		return
+	case s.pending[uri] != nil:
+		// A trailing notification is already scheduled: this change joins it.
+		s.mu.Unlock()
+		return
+	}
+	s.pending[uri] = time.AfterFunc(s.interval-now.Sub(last), func() { s.flush(uri) })
+	s.mu.Unlock()
+}
+
+func (s *subscriptions) flush(uri string) {
+	s.mu.Lock()
+	delete(s.pending, uri)
+	watched := len(s.sessions[uri]) > 0
+	if watched {
+		s.lastSent[uri] = time.Now()
+	}
+	s.mu.Unlock()
+	if watched {
+		s.send(uri)
+	}
+}
+
+func (s *subscriptions) send(uri string) {
+	err := s.srv.mcp.ResourceUpdated(context.Background(),
+		&mcp.ResourceUpdatedNotificationParams{URI: uri})
+	if err != nil {
+		s.srv.log.Warn("sending a resource update failed", "uri", uri, "error", err)
+	}
+}

--- a/internal/mcpserver/subscriptions_test.go
+++ b/internal/mcpserver/subscriptions_test.go
@@ -1,0 +1,306 @@
+package mcpserver_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/raskrebs/sonar/internal/mcpserver"
+	"github.com/raskrebs/sonar/internal/mcpserver/fakedaemon"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// watcher is the harness of the subscription tests: the same real server over
+// a real transport, with a client that records every resources/updated it is
+// sent.
+type watcher struct {
+	*harness
+	updates chan string
+}
+
+func newWatcher(t *testing.T) *watcher { return newWatcherWith(t, fakedaemon.DefaultFixture()) }
+
+func newWatcherWith(t *testing.T, fx fakedaemon.Fixture) *watcher {
+	t.Helper()
+
+	fake := fakedaemon.New(fx)
+	if err := fake.Start(); err != nil {
+		t.Fatalf("starting the fake daemon: %v", err)
+	}
+	t.Cleanup(fake.Close)
+
+	logs := &bytes.Buffer{}
+	ctx := context.Background()
+	server, err := mcpserver.New(ctx, mcpserver.Options{
+		Version: "test",
+		Logger:  mcpserver.NewLogger(logs, slog.LevelDebug, true),
+		DaemonOptions: mcpserver.DaemonOptions{
+			Socket:      fake.Addr(),
+			NoAutostart: true,
+			Timeout:     5 * time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("starting the MCP server: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	serverT, clientT := mcp.NewInMemoryTransports()
+	if _, err := server.MCP().Connect(ctx, serverT, nil); err != nil {
+		t.Fatalf("connecting the server transport: %v", err)
+	}
+
+	updates := make(chan string, 64)
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1"},
+		&mcp.ClientOptions{
+			ResourceUpdatedHandler: func(_ context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+				updates <- req.Params.URI
+			},
+		})
+	session, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("connecting the client: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	return &watcher{
+		harness: &harness{t: t, fake: fake, server: server, client: session, logs: logs},
+		updates: updates,
+	}
+}
+
+// subscribe subscribes and waits until the server has registered it. Under the
+// 2026-07-28 protocol a subscription is a long-lived request the client sends
+// without awaiting a reply, so the call returning does not mean the server has
+// seen it yet.
+func (w *watcher) subscribe(uri string) {
+	w.t.Helper()
+	if err := w.client.Subscribe(context.Background(), &mcp.SubscribeParams{URI: uri}); err != nil {
+		w.t.Fatalf("subscribing to %s: %v", uri, err)
+	}
+	waitFor(w.t, 5*time.Second, "the server to register the subscription to "+uri, func() bool {
+		return slices.Contains(w.server.SubscribedURIs(), uri)
+	})
+	waitFor(w.t, 5*time.Second, "the daemon to see a subscriber", func() bool {
+		return w.fake.Subscribers() == 1
+	})
+}
+
+func (w *watcher) unsubscribe(uri string) {
+	w.t.Helper()
+	if err := w.client.Unsubscribe(context.Background(), &mcp.UnsubscribeParams{URI: uri}); err != nil {
+		w.t.Fatalf("unsubscribing from %s: %v", uri, err)
+	}
+	waitFor(w.t, 5*time.Second, "the server to drop the subscription to "+uri, func() bool {
+		return !slices.Contains(w.server.SubscribedURIs(), uri)
+	})
+}
+
+// collect drains the notifications that arrive within window.
+func (w *watcher) collect(window time.Duration) []string {
+	var got []string
+	deadline := time.After(window)
+	for {
+		select {
+		case uri := <-w.updates:
+			got = append(got, uri)
+		case <-deadline:
+			sort.Strings(got)
+			return got
+		}
+	}
+}
+
+// await waits for the next notification.
+func (w *watcher) await(limit time.Duration) (string, bool) {
+	select {
+	case uri := <-w.updates:
+		return uri, true
+	case <-time.After(limit):
+		return "", false
+	}
+}
+
+// TestSubscribeOpensTheDaemonSubscriptionAndUnsubscribeClosesIt is the gating
+// rule of contract §30: `sonar mcp` holds a state.subscribe only while a
+// client is watching something, because a subscriber is activity against the
+// daemon's idle timeout.
+func TestSubscribeOpensTheDaemonSubscriptionAndUnsubscribeClosesIt(t *testing.T) {
+	w := newWatcher(t)
+
+	if w.fake.Subscribers() != 0 {
+		t.Fatal("the server subscribed to the daemon before any client asked for a resource")
+	}
+
+	w.subscribe(mcpserver.URIPorts)
+	w.subscribe(mcpserver.URIGroups)
+	if calls := w.fake.Calls("state.subscribe"); calls != 1 {
+		t.Errorf("state.subscribe was called %d times for two resources, want 1", calls)
+	}
+
+	w.unsubscribe(mcpserver.URIPorts)
+	// One resource is still watched: the daemon subscription stays.
+	time.Sleep(200 * time.Millisecond)
+	if w.fake.Subscribers() != 1 {
+		t.Fatal("the daemon subscription was dropped while a resource was still watched")
+	}
+
+	w.unsubscribe(mcpserver.URIGroups)
+	waitFor(t, 5*time.Second, "the daemon subscription to be closed", func() bool {
+		return w.fake.Subscribers() == 0
+	})
+	if calls := w.fake.Calls("state.unsubscribe"); calls != 1 {
+		t.Errorf("state.unsubscribe was called %d times, want 1", calls)
+	}
+}
+
+// TestSubscribingToAnUnknownURIIsRefused: the SDK does not check the URI of a
+// subscription, and a subscription to a URI that will never be announced is a
+// silent hang, so the server checks.
+//
+// The refusal is not visible to the client under the 2026-07-28 protocol,
+// where a subscription is a long-lived request whose failure the SDK does not
+// report back; what is visible is that nothing was subscribed to — no daemon
+// subscription was opened, and no notification is ever sent for the URI.
+func TestSubscribingToAnUnknownURIIsRefused(t *testing.T) {
+	w := newWatcher(t)
+
+	_ = w.client.Subscribe(context.Background(), &mcp.SubscribeParams{URI: "sonar://nonsense"})
+	time.Sleep(200 * time.Millisecond)
+
+	if calls := w.fake.Calls("state.subscribe"); calls != 0 {
+		t.Errorf("a refused subscription opened %d daemon subscriptions, want 0", calls)
+	}
+	w.fake.Push(state.Delta{Ports: state.Change[state.Port]{Added: fakedaemon.ManyPorts(1)}})
+	if got := w.collect(400 * time.Millisecond); len(got) != 0 {
+		t.Errorf("a refused subscription still received %v", got)
+	}
+}
+
+// TestDeltaNotifiesExactlyTheAffectedURIs is the step's demo in miniature: a
+// delta from the daemon produces resources/updated in the client, for the URIs
+// the delta touched and no others.
+func TestDeltaNotifiesExactlyTheAffectedURIs(t *testing.T) {
+	w := newWatcherWith(t, withSessions(fakedaemon.DefaultFixture()))
+	for _, uri := range []string{
+		mcpserver.URIPorts,
+		mcpserver.URIGroups,
+		mcpserver.URISessions,
+		mcpserver.GroupURI("shop"),
+		mcpserver.GroupURI("shop-infra"),
+	} {
+		w.subscribe(uri)
+	}
+
+	// A port appearing inside an existing group: the ports collection and that
+	// one group changed. The group list did not: no group came or went.
+	w.fake.Push(state.Delta{
+		Ports:  state.Change[state.Port]{Added: fakedaemon.ManyPorts(1)},
+		Groups: state.Change[state.Group]{Updated: []state.Group{fakedaemon.DefaultGroups()[0]}},
+	})
+
+	want := []string{mcpserver.GroupURI("shop"), mcpserver.URIPorts}
+	sort.Strings(want)
+	if got := w.collect(600 * time.Millisecond); !slices.Equal(got, want) {
+		t.Fatalf("updates = %v, want %v", got, want)
+	}
+
+	// A group appearing, and a session with it: now the collections change too.
+	w.fake.Push(state.Delta{
+		Groups:   state.Change[state.Group]{Added: []state.Group{{Name: "new-thing"}}},
+		Sessions: state.Change[state.SessionRecord]{Updated: fakedaemon.DefaultSessions()},
+	})
+
+	// sonar://groups/new-thing is nobody's subscription, so it is not sent.
+	want = []string{mcpserver.URIGroups, mcpserver.URISessions}
+	sort.Strings(want)
+	if got := w.collect(600 * time.Millisecond); !slices.Equal(got, want) {
+		t.Fatalf("updates = %v, want %v", got, want)
+	}
+}
+
+// TestNotificationsAreCoalesced pins the 1/s rule of spec 2 section 1.2: a
+// burst of deltas is one notification, and the changes that arrived during the
+// window are announced once at the end of it rather than dropped.
+func TestNotificationsAreCoalesced(t *testing.T) {
+	w := newWatcher(t)
+	w.subscribe(mcpserver.URIPorts)
+
+	start := time.Now()
+	for range 3 {
+		w.fake.Push(state.Delta{Ports: state.Change[state.Port]{Added: fakedaemon.ManyPorts(1)}})
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if got := w.collect(300 * time.Millisecond); len(got) != 1 {
+		t.Fatalf("three deltas in 300 ms produced %d notifications (%v), want 1", len(got), got)
+	}
+
+	// The two that were held back are one trailing notification, no earlier
+	// than a second after the first went out.
+	uri, ok := w.await(2 * time.Second)
+	if !ok {
+		t.Fatal("the coalesced changes were never announced")
+	}
+	if uri != mcpserver.URIPorts {
+		t.Fatalf("trailing update = %q, want %q", uri, mcpserver.URIPorts)
+	}
+	if elapsed := time.Since(start); elapsed < mcpserver.NotifyInterval {
+		t.Errorf("the trailing update came after %s, want at least %s", elapsed, mcpserver.NotifyInterval)
+	}
+	if extra := w.collect(300 * time.Millisecond); len(extra) != 0 {
+		t.Errorf("a quiet daemon still sent %v", extra)
+	}
+}
+
+// TestReconnectReplaysEverySubscribedURI: the deltas from the gap are gone, so
+// after a reconnect every subscribed URI is announced exactly once and the
+// client re-reads (spec 2, "Runtime").
+func TestReconnectReplaysEverySubscribedURI(t *testing.T) {
+	w := newWatcher(t)
+	w.subscribe(mcpserver.URIPorts)
+	w.subscribe(mcpserver.GroupURI("shop"))
+
+	// Subscribing is not itself news: nothing changed yet.
+	if got := w.collect(400 * time.Millisecond); len(got) != 0 {
+		t.Fatalf("subscribing produced %v, want nothing until something changes", got)
+	}
+
+	w.fake.Stop()
+	if err := w.fake.Restart(); err != nil {
+		t.Fatalf("restarting the fake daemon: %v", err)
+	}
+	waitFor(t, 10*time.Second, "the server to reconnect", w.server.Daemon().Connected)
+
+	want := []string{mcpserver.GroupURI("shop"), mcpserver.URIPorts}
+	sort.Strings(want)
+	got := w.collect(2 * time.Second)
+	if !slices.Equal(got, want) {
+		t.Fatalf("after a reconnect updates = %v, want exactly %v", got, want)
+	}
+
+	// And the subscription is live again on the new connection.
+	w.fake.Push(state.Delta{Ports: state.Change[state.Port]{Added: fakedaemon.ManyPorts(1)}})
+	if uri, ok := w.await(3 * time.Second); !ok || uri != mcpserver.URIPorts {
+		t.Fatalf("after a reconnect a delta produced %q (%v), want %s", uri, ok, mcpserver.URIPorts)
+	}
+}
+
+// TestClosingTheClientReleasesTheDaemon: a client that exits without
+// unsubscribing must not leave the daemon holding a subscriber for it.
+func TestClosingTheClientReleasesTheDaemon(t *testing.T) {
+	w := newWatcher(t)
+	w.subscribe(mcpserver.URIPorts)
+
+	if err := w.client.Close(); err != nil {
+		t.Fatalf("closing the client session: %v", err)
+	}
+	waitFor(t, 5*time.Second, "the daemon subscription to be released", func() bool {
+		return w.fake.Subscribers() == 0
+	})
+}


### PR DESCRIPTION
Roadmap step 2A.3.

- Resources `sonar://ports`, `sonar://groups`, `sonar://groups/{name}` (template) and `sonar://sessions`, JSON bodies equal to the daemon results; `resources/read` failures map to JSON-RPC errors with the contract code and hint in `data`.
- `resources/subscribe` + `listChanged`: the daemon `state.subscribe` is held only while a resource subscription exists; each delta produces `ResourceUpdated` for exactly the affected subscribed URIs, coalesced to one per URI per second; a reconnect replays one notification per subscribed URI.
- Prompts `free_port {port}` and `bring_up_project {path}` with the spec text.
- `Daemon.Subscribe` returns a closable handle.

Demo over stdio against a real daemon: subscribe to `sonar://ports`, start and stop an http.server, two notifications arrive, unsubscribe brings the daemon's subscriber count back to 0.