### PR TITLE
feat: serve groups.init from the daemon

### DIFF
--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -1065,6 +1065,9 @@
         },
         "write": {
           "type": "boolean"
+        },
+        "force": {
+          "type": "boolean"
         }
       },
       "type": "object",

--- a/internal/daemon/groups_init.go
+++ b/internal/daemon/groups_init.go
@@ -1,0 +1,184 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// `groups.init` is `sonar init` over the wire (contract §4): it proposes a
+// `.sonar.yaml` for a checkout from what is listening in it right now, and
+// optionally writes it.
+//
+// Both paths share one proposer, groups.Propose, and nothing else. The CLI
+// keeps scanning the OS itself and writing the file itself, because `sonar
+// init` has to work on a machine with no daemon running; routing it through
+// this handler would trade that away for no gain. What must not drift is the
+// *proposal* — which ports become services, what they are named, what command
+// is guessed — and that lives in one function both callers hand their ports to.
+//
+// The daemon has no working directory of the caller's, so unlike the CLI it
+// cannot default the root: `root_dir` is required (contract §4).
+func init() {
+	RegisterHandler("groups.init", handleGroupsInit)
+	// The capability is already announced by groups_config.go; registering it
+	// again is a no-op, and saying it here keeps the method self-contained.
+	RegisterCapability("groups")
+}
+
+func handleGroupsInit(_ context.Context, req *Request) (any, error) {
+	var p rpc.GroupsInitParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	root, err := initRoot(p.RootDir)
+	if err != nil {
+		return nil, err
+	}
+	target := filepath.Join(root, groups.ConfigName)
+	// The daemon writes exactly one filename on a client's say-so, and the
+	// check is made here too rather than trusted to the join above.
+	if err := checkConfigPath(target); err != nil {
+		return nil, err
+	}
+
+	snap, err := initSnapshot(req.Runtime)
+	if err != nil {
+		return nil, err
+	}
+	cfg := groups.Propose(root, state.ToListeningAll(snap.Ports), nil)
+	data, err := groups.Marshal(cfg)
+	if err != nil {
+		return nil, rpc.NewError(rpc.CodeInternal, "rendering "+groups.ConfigName+": "+err.Error(),
+			"check `sonar daemon log`")
+	}
+
+	result := rpc.GroupsInitResult{
+		MutationResult: rpc.MutationResult{OK: true, Affected: serviceNames(cfg)},
+		Path:           target,
+		YAML:           string(data),
+		Proposal:       proposalGroup(cfg),
+	}
+	if !p.Write {
+		// The default is a preview: the caller gets the exact bytes a write
+		// would put on disk and decides.
+		return result, nil
+	}
+
+	// §16: `sonar init` refuses to overwrite without --force, and so does this.
+	// The registry (contract §2) has no `already_exists`, and inventing a code
+	// for one method is worse than the accurate hint, so this is
+	// `invalid_params` naming the parameter that unblocks it.
+	if _, err := os.Lstat(target); err == nil && !p.Force {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, target+" already exists",
+			`pass {"force": true} to overwrite it, or read it with groups.config.get`)
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		return nil, rpc.NewError(rpc.CodeInternal, "writing "+target+": "+err.Error(),
+			"check that the daemon may write to "+root)
+	}
+
+	// Index the file the daemon just wrote and republish, so the group flips to
+	// source `file` in the delta subscribers get before the caller's own next
+	// read (the same order `groups.config.set` keeps).
+	if err := req.Runtime.Scanner.LoadConfig(target); err != nil {
+		req.Runtime.Logger.Warn("reloading a config after writing it", "path", target, "error", err)
+	}
+	req.Runtime.Logger.Info("wrote "+groups.ConfigName,
+		"path", target, "group", cfg.Name, "services", len(cfg.Services))
+	republish(req.Runtime)
+	return result, nil
+}
+
+// initRoot validates the caller's root and resolves it the way `sonar init`
+// resolves its own working directory: the git root above it when there is one,
+// so the file lands next to `.git` and matches the group the resolver already
+// publishes (§16).
+func initRoot(raw string) (string, error) {
+	dir := strings.TrimSpace(raw)
+	if dir == "" {
+		return "", rpc.NewError(rpc.CodeInvalidParams, "root_dir is required",
+			`the daemon has no working directory of yours; send {"root_dir": "/path/to/repo"}`)
+	}
+	if !filepath.IsAbs(dir) {
+		return "", rpc.NewError(rpc.CodeInvalidParams, "root_dir must be an absolute path: "+dir,
+			"resolve it against the caller's working directory first")
+	}
+	abs := groups.Canonical(dir)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", rpc.NewError(rpc.CodeNotFound, "no such directory: "+dir,
+			"root_dir is the project directory the "+groups.ConfigName+" goes in")
+	}
+	if !info.IsDir() {
+		return "", rpc.NewError(rpc.CodeInvalidParams, dir+" is not a directory",
+			"root_dir is the project directory, not the "+groups.ConfigName+" itself")
+	}
+	if root, _, ok := groups.Find(abs); ok {
+		return root, nil
+	}
+	return abs, nil
+}
+
+// initSnapshot is the state the proposal is built from: the same cache
+// `groups.list` reads, refreshed when nobody is keeping it warm (contract §20).
+func initSnapshot(rt *Runtime) (state.Snapshot, error) {
+	if rt.Subscribers() > 0 {
+		if snap := rt.Scanner.Cached(); snap.Seq > 0 {
+			return snap, nil
+		}
+	}
+	snap, err := rt.Scanner.Snapshot(scanner.Include{})
+	if err != nil {
+		return state.Snapshot{}, rpc.NewError(rpc.CodeInternal, "scan failed: "+err.Error(),
+			"check `sonar daemon log` for the scanner error")
+	}
+	return snap, nil
+}
+
+// serviceNames is the affected list: this method mutates a file, so what it
+// reports is service names, exactly as `groups.config.set` does (contract §22).
+func serviceNames(cfg *groups.Config) []string {
+	out := make([]string, 0, len(cfg.Services))
+	for _, s := range cfg.Services {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+// proposalGroup renders the proposed config as the group row it would produce.
+// Every proposed service came from a port listening in the snapshot this call
+// read, so the rows are marked running: that is what "proposed from what is
+// running now" means, and it saves a client a second join to say so.
+func proposalGroup(cfg *groups.Config) state.Group {
+	dir, path := cfg.Dir, cfg.Path
+	g := state.Group{
+		Name:       cfg.Name,
+		Source:     state.SourceFile,
+		RootDir:    &dir,
+		ConfigPath: &path,
+		Status:     "stopped",
+		Members:    []int{},
+		Services:   groups.ServiceRows(cfg),
+	}
+	for i := range g.Services {
+		if g.Services[i].Port == nil {
+			continue
+		}
+		port := *g.Services[i].Port
+		g.Services[i].Running, g.Services[i].PortActual = true, &port
+		g.Members = append(g.Members, port)
+	}
+	sort.Ints(g.Members)
+	if len(g.Services) > 0 {
+		g.Status = "running"
+	}
+	return g
+}

--- a/internal/daemon/groups_init_test.go
+++ b/internal/daemon/groups_init_test.go
@@ -1,0 +1,267 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// initHarness gives a test a daemon that can see two services listening inside
+// a git checkout that has no `.sonar.yaml` yet — the state `groups.init` exists
+// to get out of.
+func initHarness(t *testing.T, ctx context.Context) (*testHarness, string, string) {
+	t.Helper()
+	root := resolvedDir(t, t.TempDir())
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newHarness(t, ctx)
+	h.setRows(
+		ports.ListeningPort{
+			Port: 8000, BindAddress: "127.0.0.1", PID: 4242,
+			Process: "python", Display: "api", Command: "uv run api", Cwd: root,
+		},
+		ports.ListeningPort{
+			Port: 5173, BindAddress: "127.0.0.1", PID: 4243,
+			Process: "node", Display: "web", Command: "npm run dev",
+			Cwd: filepath.Join(root, "web"),
+		},
+		// Somebody else's process, in somebody else's directory: it must not
+		// end up in this project's file.
+		ports.ListeningPort{
+			Port: 9999, BindAddress: "127.0.0.1", PID: 4244,
+			Process: "other", Display: "other", Command: "other", Cwd: resolvedDir(t, t.TempDir()),
+		},
+	)
+	if _, err := h.loop.Snapshot(scanner.Include{}); err != nil {
+		t.Fatalf("priming the scanner: %v", err)
+	}
+	return h, root, filepath.Join(root, groups.ConfigName)
+}
+
+// callInit is the method under test, with the params a caller sends.
+func callInit(t *testing.T, c *testClient, p rpc.GroupsInitParams) (rpc.GroupsInitResult, *rpc.Error) {
+	t.Helper()
+	var res rpc.GroupsInitResult
+	e := c.call("groups.init", p, &res)
+	return res, e
+}
+
+// TestGroupsInitDryRunReturnsAParsableProposal is the default call: no write,
+// and what comes back is the exact file that would have been written.
+func TestGroupsInitDryRunReturnsAParsableProposal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	res, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root})
+	if e != nil {
+		t.Fatalf("groups.init: %v", e)
+	}
+	if !res.OK || res.Path != target {
+		t.Fatalf("result = %+v, want ok with path %q", res, target)
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Fatalf("a dry run must not write %s (err = %v)", target, err)
+	}
+	if !strings.Contains(res.YAML, "sonar init") {
+		t.Errorf("yaml is missing the generated header:\n%s", res.YAML)
+	}
+
+	// The proposal has to survive the loader, or `write: true` would put an
+	// unusable file on disk.
+	cfg := loadYAML(t, res.YAML)
+	if cfg.Name != res.Proposal.Name {
+		t.Errorf("parsed name %q, proposal says %q", cfg.Name, res.Proposal.Name)
+	}
+	if got := servicePorts(t, res.YAML); len(got) != 2 || got[0] != 5173 || got[1] != 8000 {
+		t.Fatalf("proposed ports = %v, want the two inside the checkout", got)
+	}
+	if len(res.Affected) != 2 {
+		t.Errorf("affected = %v, want the two proposed service names", res.Affected)
+	}
+	if res.Proposal.ConfigPath == nil || *res.Proposal.ConfigPath != target {
+		t.Errorf("proposal config_path = %v, want %q", res.Proposal.ConfigPath, target)
+	}
+	if len(res.Proposal.Members) != 2 || res.Proposal.Status != "running" {
+		t.Errorf("proposal group = %+v, want the two running members", res.Proposal)
+	}
+}
+
+// TestGroupsInitWriteFlipsTheGroupToFile is the whole point of the method: the
+// file lands on disk and the next read already calls the group a file group.
+func TestGroupsInitWriteFlipsTheGroupToFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	res, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root, Write: true})
+	if e != nil {
+		t.Fatalf("groups.init: %v", e)
+	}
+	onDisk, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading what the daemon wrote: %v", err)
+	}
+	if string(onDisk) != res.YAML {
+		t.Errorf("the file and the returned yaml differ:\n%s\n---\n%s", onDisk, res.YAML)
+	}
+
+	var list rpc.GroupsListResult
+	if e := c.call("groups.list", nil, &list); e != nil {
+		t.Fatalf("groups.list: %v", e)
+	}
+	g, ok := groupNamed(list.Groups, res.Proposal.Name)
+	if !ok {
+		t.Fatalf("group %q is gone after init: %+v", res.Proposal.Name, list.Groups)
+	}
+	if g.Source != "file" {
+		t.Errorf("group source = %q, want file", g.Source)
+	}
+	if g.ConfigPath == nil || *g.ConfigPath != target {
+		t.Errorf("group config_path = %v, want %q", g.ConfigPath, target)
+	}
+	if len(g.Services) != 2 {
+		t.Fatalf("group services = %+v, want the two just written", g.Services)
+	}
+	for _, svc := range g.Services {
+		if !svc.Running {
+			t.Errorf("service %q should be running: %+v", svc.Name, svc)
+		}
+	}
+}
+
+// TestGroupsInitRefusesToOverwrite keeps §16's rule on the wire: an existing
+// file is never clobbered by accident, and the error names the way past it.
+func TestGroupsInitRefusesToOverwrite(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	const hand = "name: hand-written\n"
+	if err := os.WriteFile(target, []byte(hand), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A dry run still answers: reading is never blocked by an existing file.
+	if _, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root}); e != nil {
+		t.Fatalf("dry run over an existing file: %v", e)
+	}
+
+	_, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root, Write: true})
+	if e == nil {
+		t.Fatal("writing over an existing file should have been refused")
+	}
+	if e.Data.Code != "invalid_params" || !strings.Contains(e.Data.Hint, "force") {
+		t.Errorf("error = %+v, want invalid_params hinting at force", e.Data)
+	}
+	if b, _ := os.ReadFile(target); string(b) != hand {
+		t.Errorf("the file was touched anyway:\n%s", b)
+	}
+}
+
+// TestGroupsInitForceOverwrites is the other half of the same rule.
+func TestGroupsInitForceOverwrites(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	if err := os.WriteFile(target, []byte("name: hand-written\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root, Write: true, Force: true})
+	if e != nil {
+		t.Fatalf("groups.init --force: %v", e)
+	}
+	b, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != res.YAML || strings.Contains(string(b), "hand-written") {
+		t.Errorf("force did not replace the file:\n%s", b)
+	}
+}
+
+// TestGroupsInitRejectsABadRoot: the daemon has no working directory of the
+// caller's, so a root it cannot use is a parameter error, not a guess.
+func TestGroupsInitRejectsABadRoot(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, _ := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	file := filepath.Join(root, "notadir")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		root string
+		code string
+	}{
+		{"missing", "", "invalid_params"},
+		{"relative", filepath.Join("relative", "path"), "invalid_params"},
+		{"nonexistent", filepath.Join(root, "nope", "nope"), "not_found"},
+		{"not a directory", file, "invalid_params"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, e := callInit(t, c, rpc.GroupsInitParams{RootDir: tc.root, Write: true})
+			if e == nil {
+				t.Fatalf("root_dir %q should have been refused", tc.root)
+			}
+			if e.Data.Code != tc.code {
+				t.Errorf("error code = %q, want %q (%s)", e.Data.Code, tc.code, e.Data.Detail)
+			}
+		})
+	}
+}
+
+// loadYAML writes a proposal to a scratch file and reads it back through the
+// real loader, which is the check that matters: the daemon must never propose
+// something `groups.Load` would reject.
+func loadYAML(t *testing.T, text string) *groups.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), groups.ConfigName)
+	if err := os.WriteFile(path, []byte(text), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := groups.Load(path)
+	if err != nil {
+		t.Fatalf("the proposal does not load: %v\n%s", err, text)
+	}
+	return cfg
+}
+
+// servicePorts is the proposed ports, sorted, read back out of the YAML.
+func servicePorts(t *testing.T, text string) []int {
+	t.Helper()
+	cfg := loadYAML(t, text)
+	out := make([]int, 0, len(cfg.Services))
+	for _, s := range cfg.Services {
+		out = append(out, s.Port)
+	}
+	return out
+}
+
+func groupNamed(gg []state.Group, name string) (state.Group, bool) {
+	for _, g := range gg {
+		if g.Name == name {
+			return g, true
+		}
+	}
+	return state.Group{}, false
+}

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -357,9 +357,14 @@ type ConfigProblem struct {
 	Error string `json:"error"`
 }
 
+// GroupsInitParams asks for a proposed `.sonar.yaml` for the checkout at
+// RootDir. Write is the contract's opt-in to actually writing it, so the
+// default is a preview; Force is the wire form of `sonar init --force` and is
+// the only way past an existing file (contract §4, §16).
 type GroupsInitParams struct {
 	RootDir string `json:"root_dir"`
 	Write   bool   `json:"write,omitempty"`
+	Force   bool   `json:"force,omitempty"`
 }
 
 type GroupsInitResult struct {

--- a/internal/groups/propose.go
+++ b/internal/groups/propose.go
@@ -75,8 +75,17 @@ func proposeService(p ports.ListeningPort, root string, index *Index, used map[s
 	return svc
 }
 
-// portDir is the directory a port belongs to: the process cwd, or the Compose
-// project's working directory for a container.
+// portDir is the directory a port belongs to: the process cwd, the Compose
+// project's working directory for a container, or — when neither is at hand —
+// the project root the resolver already attributed the port to.
+//
+// The last arm is what lets the daemon propose from a published snapshot.
+// state.Port carries no Compose working directory (the resolver consumes it
+// before a row is published), but it does carry project_root, which for a
+// Compose container *is* the git root above that working directory. Without it
+// a `groups.init` served by the daemon would silently drop every container the
+// CLI proposes. It only fires when the two better answers are absent, so the
+// direct path is unchanged.
 func portDir(p ports.ListeningPort, index *Index) string {
 	if p.Cwd != "" {
 		return p.Cwd
@@ -86,7 +95,7 @@ func portDir(p ports.ListeningPort, index *Index) string {
 			return dir
 		}
 	}
-	return ""
+	return p.ProjectRoot
 }
 
 // proposeCmd guesses the command that would bring this service back up.

--- a/internal/groups/propose_test.go
+++ b/internal/groups/propose_test.go
@@ -101,3 +101,33 @@ func TestProposeEmptyRepo(t *testing.T) {
 		t.Fatalf("an empty proposal does not validate: %v", err)
 	}
 }
+
+// TestProposeUsesProjectRootWhenTheComposeDirIsGone is the daemon's case. A
+// published state.Port carries no Compose working directory — the resolver
+// consumes it before publishing — so a proposal built from a snapshot has only
+// project_root to go on. Without the fallback every container silently drops
+// out of a `groups.init` served by the daemon.
+func TestProposeUsesProjectRootWhenTheComposeDirIsGone(t *testing.T) {
+	f := newFixture(t)
+
+	pp := []ports.ListeningPort{
+		{Port: 5432, PID: 9, Process: "com.docke", Type: ports.PortTypeDocker,
+			DockerContainer: "sonar-db-1", DockerImage: "postgres:17",
+			DockerComposeService: "db", DockerComposeProject: "sonar",
+			ProjectRoot: f.repo},
+		// Attributed to a checkout that is not the one being proposed for.
+		{Port: 6379, PID: 10, Process: "com.docke", Type: ports.PortTypeDocker,
+			DockerContainer: "other-cache-1", DockerComposeService: "cache",
+			DockerComposeProject: "other", ProjectRoot: f.composeOut},
+	}
+
+	// No index at all: the compose arm of portDir cannot answer.
+	cfg := Propose(f.repo, pp, nil)
+
+	if len(cfg.Services) != 1 {
+		t.Fatalf("services = %+v, want only the container inside the repo", cfg.Services)
+	}
+	if got := cfg.Services[0]; got.Port != 5432 || got.Name != "db" || got.Cwd != "" {
+		t.Errorf("service = %+v, want db on 5432 at the repo root", got)
+	}
+}


### PR DESCRIPTION
Roadmap step 1A.12. `groups.init` was declared in the contract and schema but had no handler; the desktop shelled out to `sonar init`.

- `groups.init {root_dir, write?, force?}` → `{ok, affected, path, yaml, proposal}`: `root_dir` is required, canonicalised and resolved to the git root; `write:false` is the dry run; an existing file is refused unless `force` (`invalid_params` with a hint naming it). After writing, the config is loaded into the index and a `groups` delta published so the group flips to `source: file`.
- `groups.Propose` falls back to `project_root` when neither cwd nor the compose dir is known, so proposals from a published snapshot keep their containers.
- `sonar init` is untouched; both paths share `groups.Propose`.
- Schema regenerated (`force` added).