### PR TITLE
fix: attribute a systemd unit only to the processes that belong to it

### DIFF
--- a/internal/ports/displayname.go
+++ b/internal/ports/displayname.go
@@ -267,28 +267,6 @@ func isOpaqueName(name string) bool {
 	return false
 }
 
-// parseSystemdUnit extracts a systemd unit name from /proc/<pid>/cgroup contents.
-// Handles both cgroup v1 and v2 layouts. Returns "" if no real unit is found.
-func parseSystemdUnit(cgroup string) string {
-	for _, line := range strings.Split(cgroup, "\n") {
-		// cgroup v2 line: "0::/system.slice/nginx.service"
-		// cgroup v1 line: "1:name=systemd:/system.slice/nginx.service"
-		idx := strings.LastIndex(line, "/")
-		if idx < 0 {
-			continue
-		}
-		seg := line[idx+1:]
-		if strings.HasSuffix(seg, ".service") || strings.HasSuffix(seg, ".scope") {
-			// Skip user session scopes which aren't real services.
-			if strings.HasPrefix(seg, "session-") || strings.HasPrefix(seg, "user@") {
-				continue
-			}
-			return seg
-		}
-	}
-	return ""
-}
-
 // isNoiseDir reports whether a directory name is a generic build / temp
 // directory that doesn't identify a project (and so should be skipped when
 // augmenting names with cwd context).

--- a/internal/ports/displayname_linux.go
+++ b/internal/ports/displayname_linux.go
@@ -19,26 +19,18 @@ func batchGetCwds(pids []int) map[int]string {
 	return result
 }
 
-// batchGetServiceUnits returns pid -> systemd unit by reading
-// /proc/<pid>/cgroup and parsing the systemd cgroup line.
-//
-// A typical line looks like:
-//
-//	0::/system.slice/nginx.service
-//	0::/user.slice/user-1000.slice/user@1000.service/app.slice/myapp.service
-//
-// We extract the last "*.service" / "*.scope" segment as the unit name.
+// batchGetServiceUnits returns pid -> systemd unit for the pids that really
+// belong to a unit. Membership in a unit's cgroup is not enough: a process
+// inherits the cgroup of whoever started it, so a shell (or a CI runner's test
+// binary) would otherwise be named after the ambient session or agent unit.
+// See unitResolver for the attribution rules.
 func batchGetServiceUnits(pids []int) map[int]string {
 	result := make(map[int]string)
+	r := newUnitResolver()
 	for _, pid := range pids {
-		data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/cgroup")
-		if err != nil {
-			continue
-		}
-		if unit := parseSystemdUnit(string(data)); unit != "" {
+		if unit := r.unitFor(pid); unit != "" {
 			result[pid] = unit
 		}
 	}
 	return result
 }
-

--- a/internal/ports/displayname_test.go
+++ b/internal/ports/displayname_test.go
@@ -38,10 +38,10 @@ func TestResolveProcessName(t *testing.T) {
 
 		// Python -c (multiprocessing.spawn worker)
 		{
-			name: "python -c with parent uvicorn",
-			cmd:  "/usr/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(...)",
+			name:      "python -c with parent uvicorn",
+			cmd:       "/usr/bin/python -c from multiprocessing.spawn import spawn_main; spawn_main(...)",
 			parentCmd: "/Users/me/.venv/bin/python /Users/me/.venv/bin/uvicorn server:app --reload --port 8001",
-			want: "uvicorn",
+			want:      "uvicorn",
 		},
 		{
 			name:      "python -c with no parent falls back to interpreter",
@@ -188,53 +188,6 @@ func TestResolveProcessName(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("\ncmd:       %q\nparentCmd: %q\ncwd:       %q\ngot:  %q\nwant: %q",
 					tc.cmd, tc.parentCmd, tc.cwd, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestParseSystemdUnit(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{
-			name: "cgroup v2 system service",
-			in:   "0::/system.slice/nginx.service\n",
-			want: "nginx.service",
-		},
-		{
-			name: "cgroup v2 user app",
-			in:   "0::/user.slice/user-1000.slice/user@1000.service/app.slice/myapp.service\n",
-			want: "myapp.service",
-		},
-		{
-			name: "cgroup v1",
-			in:   "12:freezer:/\n11:devices:/system.slice/postgresql.service\n0::/\n",
-			want: "postgresql.service",
-		},
-		{
-			name: "scope unit",
-			in:   "0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-something.scope\n",
-			want: "app-something.scope",
-		},
-		{
-			name: "no unit",
-			in:   "0::/user.slice/user-1000.slice/session-2.scope\n",
-			want: "",
-		},
-		{
-			name: "empty",
-			in:   "",
-			want: "",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := parseSystemdUnit(tc.in)
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/internal/ports/serviceunit.go
+++ b/internal/ports/serviceunit.go
@@ -1,0 +1,262 @@
+package ports
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Attribution of a systemd unit to a listening process.
+//
+// A process inherits the cgroup of whatever started it, so "the process sits
+// in unit X's cgroup" is far weaker than "the process belongs to unit X".
+// On a GitHub Actions runner every step runs inside the runner agent's own
+// unit, so a plain test listener would otherwise be named after
+// hosted-compute-agent.service. The rules below attribute a unit only when
+// the process really is that unit:
+//
+//   - its cgroup path must end in a "*.service" leaf (a bare "*.slice", a
+//     "session-*.scope" or a "user@*.service" leaf is a session/login
+//     container, not a service);
+//   - it must be the unit's main pid, or reach that main pid through its
+//     ancestors without leaving the unit's cgroup on the way;
+//   - the unit must not be the ambient unit of the caller — if sonar itself
+//     runs inside that unit, the unit is the environment we are observing
+//     from, not an attribution.
+//
+// The main pid is read from /sys/fs/cgroup/<path>/cgroup.procs (no exec).
+// `systemctl show -p MainPID` is used only when that file cannot be read.
+
+const (
+	defaultProcRoot   = "/proc"
+	defaultCgroupRoot = "/sys/fs/cgroup"
+	maxAncestorDepth  = 64
+)
+
+// cgroupPathOf extracts the systemd cgroup path from /proc/<pid>/cgroup
+// contents. It prefers the unified (v2) line, then the name=systemd v1
+// controller, then any other controller with a non-root path.
+func cgroupPathOf(content string) string {
+	var v2, systemd, other string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		path := parts[2]
+		if path == "" || path == "/" {
+			continue
+		}
+		switch {
+		case parts[0] == "0" && parts[1] == "":
+			if v2 == "" {
+				v2 = path
+			}
+		case strings.Contains(parts[1], "name=systemd"):
+			if systemd == "" {
+				systemd = path
+			}
+		default:
+			if other == "" {
+				other = path
+			}
+		}
+	}
+	switch {
+	case v2 != "":
+		return v2
+	case systemd != "":
+		return systemd
+	default:
+		return other
+	}
+}
+
+// serviceUnitOf returns the systemd service unit a cgroup path belongs to, or
+// "" when the path is not a service's own cgroup. Only a "*.service" leaf
+// counts: "*.slice", "session-*.scope" and other "*.scope" leaves are
+// containers for user sessions and app launches, and a "user@<uid>.service"
+// leaf is the per-user systemd manager, not a service the process provides.
+func serviceUnitOf(path string) string {
+	leaf := path
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		leaf = path[idx+1:]
+	}
+	if leaf == "" || !strings.HasSuffix(leaf, ".service") {
+		return ""
+	}
+	if strings.HasPrefix(leaf, "user@") {
+		return ""
+	}
+	return leaf
+}
+
+// mainPIDOf returns the first pid listed in a cgroup.procs file, which for a
+// service cgroup is the unit's main pid. Returns 0 when the file holds no pid.
+func mainPIDOf(cgroupProcs string) int {
+	for _, line := range strings.Split(cgroupProcs, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if pid, err := strconv.Atoi(line); err == nil && pid > 0 {
+			return pid
+		}
+	}
+	return 0
+}
+
+// unitResolver answers "which systemd unit owns this pid?" against a /proc and
+// a /sys/fs/cgroup tree. The roots are fields so tests can point it at
+// fixtures. One resolver is built per scan; its caches keep the number of file
+// reads proportional to the number of distinct pids and units seen.
+type unitResolver struct {
+	procRoot   string
+	cgroupRoot string
+	selfPID    int
+	// allowExec permits the `systemctl show -p MainPID` fallback. It stays
+	// off on the hot path whenever cgroup.procs can be read directly.
+	allowExec bool
+
+	selfUnit  string
+	selfKnown bool
+	paths     map[int]string
+	mains     map[string]int
+}
+
+func newUnitResolver() *unitResolver {
+	// The systemctl fallback is armed only when /sys/fs/cgroup is missing or
+	// unreadable, so a normal scan never spawns a process.
+	_, err := os.Stat(defaultCgroupRoot)
+	return &unitResolver{
+		procRoot:   defaultProcRoot,
+		cgroupRoot: defaultCgroupRoot,
+		selfPID:    os.Getpid(),
+		allowExec:  err != nil,
+		paths:      map[int]string{},
+		mains:      map[string]int{},
+	}
+}
+
+// cgroupPath returns the systemd cgroup path of a pid ("" when unknown).
+func (r *unitResolver) cgroupPath(pid int) string {
+	if path, ok := r.paths[pid]; ok {
+		return path
+	}
+	data, err := os.ReadFile(filepath.Join(r.procRoot, strconv.Itoa(pid), "cgroup"))
+	path := ""
+	if err == nil {
+		path = cgroupPathOf(string(data))
+	}
+	r.paths[pid] = path
+	return path
+}
+
+// ppid returns the parent pid of a pid, read from /proc/<pid>/status.
+func (r *unitResolver) ppid(pid int) int {
+	data, err := os.ReadFile(filepath.Join(r.procRoot, strconv.Itoa(pid), "status"))
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		rest, ok := strings.CutPrefix(line, "PPid:")
+		if !ok {
+			continue
+		}
+		if ppid, err := strconv.Atoi(strings.TrimSpace(rest)); err == nil {
+			return ppid
+		}
+		return 0
+	}
+	return 0
+}
+
+// mainPID returns the main pid of the unit occupying a cgroup path, or 0 when
+// it cannot be determined.
+func (r *unitResolver) mainPID(path, unit string) int {
+	if pid, ok := r.mains[path]; ok {
+		return pid
+	}
+	pid := 0
+	data, err := os.ReadFile(filepath.Join(r.cgroupRoot, filepath.Clean("/"+path), "cgroup.procs"))
+	if err == nil {
+		pid = mainPIDOf(string(data))
+	} else if r.allowExec {
+		pid = systemctlMainPID(unit)
+	}
+	r.mains[path] = pid
+	return pid
+}
+
+// ambientUnit returns the unit sonar itself runs inside, if any. Processes are
+// not attributed to it: it is the environment the scan happens in (a login
+// session, a CI runner agent), and every child started there inherits it.
+func (r *unitResolver) ambientUnit() string {
+	if !r.selfKnown {
+		r.selfUnit = serviceUnitOf(r.cgroupPath(r.selfPID))
+		r.selfKnown = true
+	}
+	return r.selfUnit
+}
+
+// unitFor returns the systemd unit to attribute to a pid, or "".
+func (r *unitResolver) unitFor(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	path := r.cgroupPath(pid)
+	unit := serviceUnitOf(path)
+	if unit == "" {
+		return ""
+	}
+	if unit == r.ambientUnit() {
+		return ""
+	}
+	main := r.mainPID(path, unit)
+	if main == 0 {
+		// The unit's main pid is unknowable here (no readable
+		// /sys/fs/cgroup and no systemctl). The cgroup leaf is still a
+		// real service that is not our own ambient unit, so keep the
+		// pre-existing behaviour rather than dropping the name.
+		return unit
+	}
+	if pid == main {
+		return unit
+	}
+	// Walk up the ancestors. Staying inside the unit's cgroup the whole way
+	// and reaching the main pid means the process was forked by the service.
+	// Any ancestor in a different cgroup is a session / scope boundary: the
+	// process only inherited the cgroup, it does not belong to the unit.
+	for a, depth := r.ppid(pid), 0; a > 1 && depth < maxAncestorDepth; a, depth = r.ppid(a), depth+1 {
+		if a == main {
+			return unit
+		}
+		if r.cgroupPath(a) != path {
+			return ""
+		}
+	}
+	return ""
+}
+
+// systemctlMainPID asks systemd for a unit's main pid. Used only when
+// /sys/fs/cgroup is not readable, so it never runs on the normal hot path.
+func systemctlMainPID(unit string) int {
+	if unit == "" {
+		return 0
+	}
+	out, err := exec.Command("systemctl", "show", "-p", "MainPID", "--value", unit).Output()
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}

--- a/internal/ports/serviceunit_test.go
+++ b/internal/ports/serviceunit_test.go
@@ -1,0 +1,323 @@
+package ports
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestCgroupPathOf(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "cgroup v2",
+			in:   "0::/system.slice/nginx.service\n",
+			want: "/system.slice/nginx.service",
+		},
+		{
+			name: "cgroup v1 name=systemd wins over other controllers",
+			in: "12:freezer:/\n" +
+				"11:devices:/system.slice\n" +
+				"1:name=systemd:/system.slice/postgresql.service\n" +
+				"0::/\n",
+			want: "/system.slice/postgresql.service",
+		},
+		{
+			name: "cgroup v1 without name=systemd falls back to any controller",
+			in:   "12:freezer:/\n11:devices:/system.slice/postgresql.service\n0::/\n",
+			want: "/system.slice/postgresql.service",
+		},
+		{
+			name: "root only",
+			in:   "0::/\n",
+			want: "",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "malformed lines ignored",
+			in:   "garbage\n0::/system.slice/ssh.service\n",
+			want: "/system.slice/ssh.service",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cgroupPathOf(tc.in); got != tc.want {
+				t.Errorf("cgroupPathOf() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServiceUnitOf(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"system service", "/system.slice/nginx.service", "nginx.service"},
+		{"user service", "/user.slice/user-1000.slice/user@1000.service/app.slice/myapp.service", "myapp.service"},
+		{"login session scope", "/user.slice/user-1000.slice/session-3.scope", ""},
+		{"app scope", "/user.slice/user-1000.slice/user@1000.service/app.slice/app-terminal.scope", ""},
+		{"slice only", "/user.slice/user-1000.slice", ""},
+		{"user manager itself", "/user.slice/user-1000.slice/user@1000.service", ""},
+		{"machine scope", "/machine.slice/docker-abc.scope", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := serviceUnitOf(tc.path); got != tc.want {
+				t.Errorf("serviceUnitOf(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMainPIDOf(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"single pid", "1234\n", 1234},
+		{"first of many", "1234\n1235\n1240\n", 1234},
+		{"blank lines skipped", "\n\n99\n", 99},
+		{"empty", "", 0},
+		{"garbage", "not-a-pid\n", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mainPIDOf(tc.in); got != tc.want {
+				t.Errorf("mainPIDOf(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeProc is one process in the fake /proc tree: the cgroup line captured
+// from a real system and the parent that started it.
+type fakeProc struct {
+	pid    int
+	ppid   int
+	cgroup string
+}
+
+// writeFakeSystem materialises a /proc tree and a /sys/fs/cgroup tree in temp
+// dirs. cgroupProcs maps a cgroup path to the pids listed in its cgroup.procs
+// (first one is the unit's main pid); a path left out of the map has no
+// cgroup.procs file, standing in for an unreadable /sys/fs/cgroup.
+func writeFakeSystem(t *testing.T, procs []fakeProc, cgroupProcs map[string][]int) (procRoot, cgroupRoot string) {
+	t.Helper()
+	root := t.TempDir()
+	procRoot = filepath.Join(root, "proc")
+	cgroupRoot = filepath.Join(root, "cgroup")
+	for _, p := range procs {
+		dir := filepath.Join(procRoot, strconv.Itoa(p.pid))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		write(t, filepath.Join(dir, "cgroup"), "0::"+p.cgroup+"\n")
+		write(t, filepath.Join(dir, "status"),
+			"Name:\tproc"+strconv.Itoa(p.pid)+"\nPPid:\t"+strconv.Itoa(p.ppid)+"\nUid:\t0\n")
+	}
+	for path, pids := range cgroupProcs {
+		dir := filepath.Join(cgroupRoot, filepath.FromSlash(path))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		content := ""
+		for _, pid := range pids {
+			content += strconv.Itoa(pid) + "\n"
+		}
+		write(t, filepath.Join(dir, "cgroup.procs"), content)
+	}
+	return procRoot, cgroupRoot
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const (
+	sshCgroup      = "/system.slice/ssh.service"
+	pgCgroup       = "/system.slice/postgresql.service"
+	agentCgroup    = "/system.slice/hosted-compute-agent.service"
+	sessionCgroup  = "/user.slice/user-1000.slice/session-3.scope"
+	appScopeCgroup = "/user.slice/user-1000.slice/user@1000.service/app.slice/app-terminal.scope"
+	userSvcCgroup  = "/user.slice/user-1000.slice/user@1000.service/app.slice/myapp.service"
+	orphanCgroup   = "/system.slice/orphan.service"
+	cronCgroup     = "/system.slice/cron.service"
+)
+
+// fakeSystem models one machine: a couple of genuine services, a GitHub
+// runner agent that spawned a test listener, a login session with a dev
+// server, and a per-user systemd service.
+func fakeSystem() ([]fakeProc, map[string][]int) {
+	procs := []fakeProc{
+		{pid: 1, ppid: 0, cgroup: "/init.scope"},
+
+		// Genuine system services started by systemd.
+		{pid: 100, ppid: 1, cgroup: sshCgroup},   // sshd main pid
+		{pid: 101, ppid: 100, cgroup: sshCgroup}, // per-connection sshd
+		{pid: 200, ppid: 1, cgroup: pgCgroup},    // postgres main pid
+		{pid: 201, ppid: 200, cgroup: pgCgroup},  // postgres worker
+
+		// GitHub runner: the agent unit, its worker, and the test binary
+		// the workflow started. All three sit in the agent's cgroup.
+		{pid: 300, ppid: 1, cgroup: agentCgroup},
+		{pid: 301, ppid: 300, cgroup: agentCgroup},
+		{pid: 302, ppid: 301, cgroup: agentCgroup}, // the test listener
+		{pid: 999, ppid: 301, cgroup: agentCgroup}, // sonar itself
+
+		// Interactive login session and a dev server started from it.
+		{pid: 400, ppid: 1, cgroup: sessionCgroup},
+		{pid: 401, ppid: 400, cgroup: sessionCgroup},
+		{pid: 500, ppid: 1, cgroup: appScopeCgroup},
+
+		// A per-user systemd service and a child it forked.
+		{pid: 501, ppid: 1, cgroup: userSvcCgroup},
+		{pid: 502, ppid: 501, cgroup: userSvcCgroup},
+
+		// In cron.service's cgroup but started from the login session:
+		// inherited the cgroup, does not descend from the unit's main pid.
+		{pid: 600, ppid: 1, cgroup: cronCgroup},
+		{pid: 601, ppid: 400, cgroup: cronCgroup},
+
+		// A service whose cgroup.procs is not readable.
+		{pid: 700, ppid: 1, cgroup: orphanCgroup},
+	}
+	cgroupProcs := map[string][]int{
+		sshCgroup:      {100, 101},
+		pgCgroup:       {200, 201},
+		agentCgroup:    {300, 301, 302, 999},
+		sessionCgroup:  {400, 401},
+		appScopeCgroup: {500},
+		userSvcCgroup:  {501, 502},
+		cronCgroup:     {600, 601},
+	}
+	return procs, cgroupProcs
+}
+
+func TestUnitResolverAttribution(t *testing.T) {
+	procs, cgroupProcs := fakeSystem()
+	procRoot, cgroupRoot := writeFakeSystem(t, procs, cgroupProcs)
+
+	tests := []struct {
+		name    string
+		selfPID int // the pid sonar runs as
+		pid     int
+		want    string
+	}{
+		// Genuine services keep their unit, whether the listener is the
+		// main pid or a process the service forked.
+		{"sshd main pid", 999, 100, "ssh.service"},
+		{"sshd session child", 999, 101, "ssh.service"},
+		{"postgres main pid", 999, 200, "postgresql.service"},
+		{"postgres worker", 999, 201, "postgresql.service"},
+
+		// The reported bug: on a runner every step inherits the agent's
+		// cgroup, and sonar runs inside it too, so the unit is ambient.
+		{"runner agent main pid is ambient", 999, 300, ""},
+		{"runner worker is ambient", 999, 301, ""},
+		{"test listener on a runner", 999, 302, ""},
+
+		// Login sessions and app scopes are not services at all.
+		{"login shell", 999, 400, ""},
+		{"dev server started from a shell", 999, 401, ""},
+		{"process in an app scope", 999, 500, ""},
+
+		// systemd --user services are real services.
+		{"user service main pid", 999, 501, "myapp.service"},
+		{"user service child", 999, 502, "myapp.service"},
+
+		// Same cgroup, but the ancestor chain leaves the unit before
+		// reaching its main pid.
+		{"cron main pid", 999, 600, "cron.service"},
+		{"session process inheriting a service cgroup", 999, 601, ""},
+
+		// No readable cgroup.procs: keep the unit rather than losing the
+		// name of a genuine service.
+		{"service with unknown main pid", 999, 700, "orphan.service"},
+
+		// Scanning from a login session instead of inside the agent unit:
+		// genuine services are unaffected, sessions still get nothing.
+		{"sshd seen from a login shell", 400, 100, "ssh.service"},
+		{"dev server seen from a login shell", 400, 401, ""},
+		{"app scope seen from a login shell", 400, 500, ""},
+
+		{"unknown pid", 999, 12345, ""},
+		{"invalid pid", 999, 0, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &unitResolver{
+				procRoot:   procRoot,
+				cgroupRoot: cgroupRoot,
+				selfPID:    tc.selfPID,
+				paths:      map[int]string{},
+				mains:      map[string]int{},
+			}
+			if got := r.unitFor(tc.pid); got != tc.want {
+				t.Errorf("unitFor(%d) = %q, want %q", tc.pid, got, tc.want)
+			}
+		})
+	}
+}
+
+// The main-pid lookup must come from /sys/fs/cgroup, never from spawning
+// systemctl, whenever the cgroup tree is readable.
+func TestUnitResolverReadsMainPIDFromCgroupTree(t *testing.T) {
+	procs, cgroupProcs := fakeSystem()
+	// Re-exec'd service: the main pid is not the lowest pid in the cgroup.
+	cgroupProcs[pgCgroup] = []int{201, 200}
+	procRoot, cgroupRoot := writeFakeSystem(t, procs, cgroupProcs)
+
+	r := &unitResolver{
+		procRoot:   procRoot,
+		cgroupRoot: cgroupRoot,
+		selfPID:    999,
+		paths:      map[int]string{},
+		mains:      map[string]int{},
+	}
+	if got := r.mainPID(pgCgroup, "postgresql.service"); got != 201 {
+		t.Fatalf("mainPID = %d, want 201 (first pid in cgroup.procs)", got)
+	}
+	// 201 is now the main pid, so it is attributed; 200 is its parent, not
+	// its descendant, so it is not.
+	if got := r.unitFor(201); got != "postgresql.service" {
+		t.Errorf("unitFor(201) = %q, want postgresql.service", got)
+	}
+	if got := r.unitFor(200); got != "" {
+		t.Errorf("unitFor(200) = %q, want empty", got)
+	}
+}
+
+// A cycle or a very deep ancestor chain must not hang the walk.
+func TestUnitResolverAncestorCycle(t *testing.T) {
+	procs := []fakeProc{
+		{pid: 10, ppid: 11, cgroup: sshCgroup},
+		{pid: 11, ppid: 10, cgroup: sshCgroup},
+	}
+	procRoot, cgroupRoot := writeFakeSystem(t, procs, map[string][]int{sshCgroup: {9, 10, 11}})
+	r := &unitResolver{
+		procRoot:   procRoot,
+		cgroupRoot: cgroupRoot,
+		selfPID:    999, // not in the tree: nothing is ambient here
+
+		paths: map[int]string{},
+		mains: map[string]int{},
+	}
+	if got := r.unitFor(11); got != "" {
+		t.Errorf("unitFor(11) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Roadmap step 1A.11. On Linux the enricher named any process inside the ambient cgroup after that unit (a test listener on a GitHub runner showed as `hosted-compute-agent.service`).

- A pid gets `service_unit` only when its cgroup leaf is a `.service` (not `user@`, not a scope or slice), the unit is not the one sonar itself runs in, and the pid is the unit's main pid or a descendant that never left the unit's cgroup. The main pid comes from `cgroup.procs`; `systemctl` is a fallback only when `/sys/fs/cgroup` is unreadable.
- Reproduced before/after in a privileged golang container with a real cgroup v2 tree: the plain listener shows its own name, a genuine service keeps its unit.
- No wire change.