### PR TITLE
feat: publish host stats for localhost in a hosts collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,27 @@ sonar list --no-daemon --json
 # check
 ```
 
+### `sonar host`
+
+```sh
+sonar host          # cpu, load, memory and disk of the machine sonar watches
+sonar host --json
+```
+
+```sh
+sonar host
+# check
+```
+
+The daemon measures its own machine on the scan cadence and publishes it as the
+`localhost` row of the snapshot's `hosts` collection: os and kernel, uptime, cpu
+percent, load average, memory and the disk holding `/`. CPU percent is the work
+done between two scans, so it is null until the daemon has scanned twice; a
+figure a platform cannot produce — the load average on Windows, which has none —
+is null rather than zero. Registered remote hosts join the same table in
+milestone 3. The command needs a running daemon: it is the daemon that holds the
+previous sample a percentage is measured against.
+
 ### The daemon
 
 One background process scans ports, resolves groups, polls health, keeps the

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -33,6 +33,34 @@
         "removed"
       ]
     },
+    "ChangeHost": {
+      "properties": {
+        "added": {
+          "items": {
+            "$ref": "#/definitions/Host"
+          },
+          "type": "array"
+        },
+        "updated": {
+          "items": {
+            "$ref": "#/definitions/Host"
+          },
+          "type": "array"
+        },
+        "removed": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "added",
+        "updated",
+        "removed"
+      ]
+    },
     "ChangePort": {
       "properties": {
         "added": {
@@ -482,6 +510,9 @@
         },
         "sessions": {
           "$ref": "#/definitions/ChangeSessionRecord"
+        },
+        "hosts": {
+          "$ref": "#/definitions/ChangeHost"
         }
       },
       "type": "object",
@@ -493,7 +524,8 @@
         "groups",
         "tunnels",
         "proxies",
-        "sessions"
+        "sessions",
+        "hosts"
       ]
     },
     "Docker": {
@@ -1388,6 +1420,163 @@
         "pid",
         "display_name",
         "group"
+      ]
+    },
+    "Host": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "connecting",
+            "connected",
+            "unreachable",
+            "outdated",
+            "incompatible"
+          ]
+        },
+        "status_reason": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "daemon_version": {
+          "type": "string"
+        },
+        "protocol_version": {
+          "type": "string"
+        },
+        "latency_ms": {
+          "type": "integer"
+        },
+        "os": {
+          "type": "string"
+        },
+        "arch": {
+          "type": "string"
+        },
+        "kernel": {
+          "type": "string"
+        },
+        "uptime_s": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cpu_percent": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "load": {
+          "oneOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "memory_used_bytes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "memory_total_bytes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disk_used_bytes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disk_total_bytes": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disk_path": {
+          "type": "string"
+        },
+        "ports": {
+          "type": "integer"
+        },
+        "groups": {
+          "type": "integer"
+        },
+        "last_seen": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "address",
+        "status",
+        "status_reason",
+        "daemon_version",
+        "protocol_version",
+        "latency_ms",
+        "os",
+        "arch",
+        "kernel",
+        "uptime_s",
+        "cpu_percent",
+        "load",
+        "memory_used_bytes",
+        "memory_total_bytes",
+        "disk_used_bytes",
+        "disk_total_bytes",
+        "disk_path",
+        "ports",
+        "groups",
+        "last_seen"
       ]
     },
     "Include": {
@@ -2999,6 +3188,12 @@
             "$ref": "#/definitions/SessionRecord"
           },
           "type": "array"
+        },
+        "hosts": {
+          "items": {
+            "$ref": "#/definitions/Host"
+          },
+          "type": "array"
         }
       },
       "type": "object",
@@ -3011,7 +3206,8 @@
         "groups",
         "tunnels",
         "proxies",
-        "sessions"
+        "sessions",
+        "hosts"
       ]
     },
     "StateSnapshotParams": {

--- a/internal/cmd/host.go
+++ b/internal/cmd/host.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var hostJSONFlag bool
+
+var hostCmd = &cobra.Command{
+	Use:   "host",
+	Short: "Show the machine sonar is watching and its load",
+	Long: `Show the hosts sonar knows about: their cpu, load average, memory and disk.
+
+Today that is this machine, published as ` + "`localhost`" + `. Registered remote
+hosts join the same table in milestone 3.
+
+Examples:
+  sonar host          # the table
+  sonar host --json   # the rows state.snapshot publishes`,
+	Args: cobra.NoArgs,
+	RunE: runHost,
+}
+
+func init() {
+	hostCmd.Flags().BoolVar(&hostJSONFlag, "json", false, "Output as JSON")
+	rootCmd.AddCommand(hostCmd)
+}
+
+func runHost(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	hosts, err := readHosts(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if hostJSONFlag {
+		return writeJSON(map[string]any{"hosts": hosts})
+	}
+	renderHosts(os.Stdout, hosts)
+	return nil
+}
+
+// readHosts asks the daemon for the `hosts` collection.
+//
+// There is no direct-scan fallback, unlike the read commands of contract §20.
+// CPU percent is a delta between two samples across the scan interval, and the
+// daemon is what holds the previous one: a one-shot CLI could only report a
+// different number under the same name.
+func readHosts(ctx context.Context) ([]state.Host, error) {
+	c, err := dialDaemon(ctx)
+	if err != nil {
+		if errors.Is(err, client.ErrNotRunning) {
+			return nil, errors.New("host stats need a running daemon; start one with `sonar serve --detach`")
+		}
+		return nil, err
+	}
+	defer c.Close()
+
+	var snap state.Snapshot
+	if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{}, &snap); err != nil {
+		return nil, cliError(err)
+	}
+	if snap.Hosts == nil {
+		return []state.Host{}, nil
+	}
+	return snap.Hosts, nil
+}
+
+// renderHosts prints the host table.
+func renderHosts(w io.Writer, hosts []state.Host) {
+	if len(hosts) == 0 {
+		fmt.Fprintln(w, "No hosts.")
+		return
+	}
+	fmt.Fprintf(w, "%-14s %-12s %-15s %-10s %-7s %-19s %-16s %s\n",
+		display.Bold("NAME"), display.Bold("STATUS"), display.Bold("OS/ARCH"),
+		display.Bold("UPTIME"), display.Bold("CPU"), display.Bold("LOAD"),
+		display.Bold("MEMORY"), display.Bold("DISK"))
+	for _, h := range hosts {
+		fmt.Fprintf(w, "%-14s %-12s %-15s %-10s %-7s %-19s %-16s %s\n",
+			display.Cyan(h.Name), hostStatus(h.Status), osArch(h),
+			hostUptime(h.UptimeS), hostPercent(h.CPUPercent), hostLoad(h.Load),
+			hostUsage(h.MemoryUsed, h.MemoryTotal), hostUsage(h.DiskUsed, h.DiskTotal))
+	}
+}
+
+func hostStatus(status string) string {
+	switch status {
+	case state.HostConnected:
+		return display.Green(status)
+	case state.HostConnecting:
+		return display.Yellow(status)
+	case "":
+		return "-"
+	default:
+		return display.Red(status)
+	}
+}
+
+func osArch(h state.Host) string {
+	if h.OS == "" && h.Arch == "" {
+		return "-"
+	}
+	return h.OS + "/" + h.Arch
+}
+
+// hostUptime is the coarse form a load table wants: the two largest units,
+// never seconds once a machine has been up for an hour.
+func hostUptime(secs *int64) string {
+	if secs == nil || *secs < 0 {
+		return "-"
+	}
+	d := time.Duration(*secs) * time.Second
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	minutes := int(d.Minutes()) % 60
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case hours > 0:
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	case minutes > 0:
+		return fmt.Sprintf("%dm", minutes)
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
+func hostPercent(pct *float64) string {
+	if pct == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", *pct)
+}
+
+// hostLoad prints the three averages. Windows has no load average at all, and
+// prints a dash rather than three zeroes that would read as an idle machine.
+func hostLoad(load []float64) string {
+	if len(load) == 0 {
+		return "-"
+	}
+	parts := make([]string, len(load))
+	for i, v := range load {
+		parts[i] = fmt.Sprintf("%.2f", v)
+	}
+	return strings.Join(parts, " ")
+}
+
+// hostUsage prints "used/total" in one unit, chosen from the total so the two
+// numbers can be compared at a glance.
+func hostUsage(used, total *int64) string {
+	if used == nil || total == nil || *total <= 0 {
+		return "-"
+	}
+	unit, name := sizeUnit(*total)
+	return fmt.Sprintf("%.1f/%.1f %s", float64(*used)/unit, float64(*total)/unit, name)
+}
+
+func sizeUnit(total int64) (float64, string) {
+	const k = 1024.0
+	switch {
+	case float64(total) >= k*k*k*k:
+		return k * k * k * k, "TiB"
+	case float64(total) >= k*k*k:
+		return k * k * k, "GiB"
+	case float64(total) >= k*k:
+		return k * k, "MiB"
+	default:
+		return k, "KiB"
+	}
+}

--- a/internal/cmd/host_test.go
+++ b/internal/cmd/host_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+func hostFixture() state.Host {
+	uptime := int64(824253)
+	cpu := 12.4
+	memUsed, memTotal := int64(9)<<30, int64(32)<<30
+	diskUsed, diskTotal := int64(412)<<30, int64(931)<<30
+	return state.Host{
+		Name: state.LocalhostName, Address: state.LocalhostName,
+		Status: state.HostConnected, DaemonVersion: "0.5.1", ProtocolVersion: "1.0.0",
+		OS: "linux", Arch: "amd64", Kernel: "6.8.0-40-generic",
+		UptimeS: &uptime, CPUPercent: &cpu,
+		Load:       []float64{1.24, 0.98, 0.71},
+		MemoryUsed: &memUsed, MemoryTotal: &memTotal,
+		DiskUsed: &diskUsed, DiskTotal: &diskTotal, DiskPath: "/",
+		Ports: 6, Groups: 2, LastSeen: "2026-09-06T10:00:00Z",
+	}
+}
+
+// The golden table. Column widths are the contract with whoever reads this in
+// a terminal, so they are pinned rather than eyeballed.
+func TestHostTableIsGolden(t *testing.T) {
+	windows := hostFixture()
+	windows.Name = "hetzner"
+	windows.OS, windows.Arch = "windows", "amd64"
+	windows.Load = nil // no load average on Windows
+	windows.CPUPercent = nil
+
+	var buf bytes.Buffer
+	renderHosts(&buf, []state.Host{hostFixture(), windows})
+
+	want := strings.Join([]string{
+		"NAME           STATUS       OS/ARCH         UPTIME     CPU     LOAD                MEMORY           DISK",
+		"localhost      connected    linux/amd64     9d 12h     12.4%   1.24 0.98 0.71      9.0/32.0 GiB     412.0/931.0 GiB",
+		"hetzner        connected    windows/amd64   9d 12h     -       -                   9.0/32.0 GiB     412.0/931.0 GiB",
+		"",
+	}, "\n")
+	if got := buf.String(); got != want {
+		t.Errorf("host table\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestHostTableWithNoHosts(t *testing.T) {
+	var buf bytes.Buffer
+	renderHosts(&buf, nil)
+	if got := buf.String(); got != "No hosts.\n" {
+		t.Errorf("empty table = %q", got)
+	}
+}
+
+// A machine whose load could not be read prints dashes, never zeroes: "we do
+// not know" and "the machine is idle" are different answers.
+func TestHostTableRendersUnknownsAsDashes(t *testing.T) {
+	var buf bytes.Buffer
+	renderHosts(&buf, []state.Host{{Name: "localhost", Status: state.HostConnected}})
+	row := strings.Split(buf.String(), "\n")[1]
+	if strings.Count(row, "-") < 4 {
+		t.Errorf("row with nothing measured = %q, want dashes for every unknown", row)
+	}
+}
+
+func TestHostUptimeFormats(t *testing.T) {
+	tests := map[int64]string{
+		0:      "0s",
+		45:     "45s",
+		90:     "1m",
+		3700:   "1h 1m",
+		824253: "9d 12h",
+	}
+	for secs, want := range tests {
+		v := secs
+		if got := hostUptime(&v); got != want {
+			t.Errorf("hostUptime(%d) = %q, want %q", secs, got, want)
+		}
+	}
+	if got := hostUptime(nil); got != "-" {
+		t.Errorf("hostUptime(nil) = %q, want a dash", got)
+	}
+}
+
+func TestHostUsagePicksAUnitFromTheTotal(t *testing.T) {
+	mb := int64(700) << 20
+	gb := int64(4) << 30
+	if got := hostUsage(&mb, &gb); got != "0.7/4.0 GiB" {
+		t.Errorf("hostUsage = %q, want 0.7/4.0 GiB", got)
+	}
+	if got := hostUsage(nil, &gb); got != "-" {
+		t.Errorf("hostUsage with no used figure = %q, want a dash", got)
+	}
+}
+
+// Host stats live in the daemon, so the command says so rather than printing
+// an empty table.
+func TestHostCommandWithoutADaemonSaysSo(t *testing.T) {
+	prev := dialDaemon
+	dialDaemon = func(context.Context) (*client.Client, error) { return nil, client.ErrNotRunning }
+	t.Cleanup(func() { dialDaemon = prev })
+
+	_, err := readHosts(context.Background())
+	if err == nil {
+		t.Fatal("readHosts without a daemon did not fail")
+	}
+	if !strings.Contains(err.Error(), "sonar serve") {
+		t.Errorf("error = %q, want it to name the command that starts a daemon", err)
+	}
+	if errors.Is(err, client.ErrNotRunning) {
+		t.Error("the raw dial error reached the user")
+	}
+}

--- a/internal/daemon/hosts_test.go
+++ b/internal/daemon/hosts_test.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+func testHost(cpu float64) state.Host {
+	return state.Host{
+		Name: state.LocalhostName, Address: state.LocalhostName,
+		Status: state.HostConnected, CPUPercent: &cpu, Ports: 3, Groups: 1,
+	}
+}
+
+// `hosts` survives the per-subscriber filter. A machine's load is state the
+// daemon collects for itself on every tick, like configured health (contract
+// §22), not an enrichment a client opts into with `include`.
+func TestFilterSnapshotKeepsHosts(t *testing.T) {
+	snap := state.Snapshot{
+		Ports: []state.Port{{Port: 3000, Stats: &state.Stats{CPUPercent: 4}}},
+		Hosts: []state.Host{testHost(12.5)},
+	}
+	got := filterSnapshot(snap, scanner.Include{})
+	if len(got.Hosts) != 1 || got.Hosts[0].CPUPercent == nil {
+		t.Fatalf("hosts = %+v, want the row with its load", got.Hosts)
+	}
+	if got.Ports[0].Stats != nil {
+		t.Error("port stats survived a subscriber that did not ask for them")
+	}
+}
+
+// Every collection is an array on the wire, never null (contract §5).
+func TestFilterSnapshotNeverLeavesHostsNull(t *testing.T) {
+	got := filterSnapshot(state.Snapshot{}, scanner.Include{})
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if string(decoded["hosts"]) != "[]" {
+		t.Errorf("hosts = %s, want []", decoded["hosts"])
+	}
+}
+
+// A tick where only the machine's load moved still reaches a subscriber that
+// asked for neither stats nor health.
+func TestHostOnlyDeltaIsSentWithoutInclude(t *testing.T) {
+	prev := state.Snapshot{Hosts: []state.Host{testHost(12.5)}}
+	next := state.Snapshot{Seq: 2, Hosts: []state.Host{testHost(41)}}
+
+	msg := marshalDelta(prev, next, scanner.Include{})
+	if msg == nil {
+		t.Fatal("a host-only delta was dropped for a subscriber with no include")
+	}
+
+	var note struct {
+		Method string      `json:"method"`
+		Params state.Delta `json:"params"`
+	}
+	if err := json.Unmarshal(msg, &note); err != nil {
+		t.Fatal(err)
+	}
+	if note.Method != rpc.MethodStateDelta {
+		t.Errorf("method = %q, want %q", note.Method, rpc.MethodStateDelta)
+	}
+	if len(note.Params.Hosts.Updated) != 1 {
+		t.Fatalf("hosts change = %+v, want one update", note.Params.Hosts)
+	}
+	if got := *note.Params.Hosts.Updated[0].CPUPercent; got != 41 {
+		t.Errorf("cpu_percent = %v, want 41", got)
+	}
+}
+
+// A tick where nothing at all moved is still not sent.
+func TestEmptyDeltaIsStillDropped(t *testing.T) {
+	snap := state.Snapshot{Hosts: []state.Host{testHost(12.5)}}
+	if msg := marshalDelta(snap, snap, scanner.Include{}); msg != nil {
+		t.Errorf("an empty delta was sent: %s", msg)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -111,8 +111,9 @@ func New(opts Options) *Server {
 	s.loop = opts.Scanner
 	if s.loop == nil {
 		s.loop = scanner.New(scanner.Options{
-			DaemonVersion: opts.Version,
-			Logger:        opts.Logger,
+			DaemonVersion:   opts.Version,
+			ProtocolVersion: rpc.ProtocolVersion,
+			Logger:          opts.Logger,
 		})
 	}
 	s.loop.SetDemand(s.demand)
@@ -535,7 +536,8 @@ func emptyDelta(d state.Delta) bool {
 		len(d.Groups.Added) == 0 && len(d.Groups.Updated) == 0 && len(d.Groups.Removed) == 0 &&
 		len(d.Tunnels.Added) == 0 && len(d.Tunnels.Updated) == 0 && len(d.Tunnels.Removed) == 0 &&
 		len(d.Proxies.Added) == 0 && len(d.Proxies.Updated) == 0 && len(d.Proxies.Removed) == 0 &&
-		len(d.Sessions.Added) == 0 && len(d.Sessions.Updated) == 0 && len(d.Sessions.Removed) == 0
+		len(d.Sessions.Added) == 0 && len(d.Sessions.Updated) == 0 && len(d.Sessions.Removed) == 0 &&
+		len(d.Hosts.Added) == 0 && len(d.Hosts.Updated) == 0 && len(d.Hosts.Removed) == 0
 }
 
 // filterSnapshot strips the enrichments this subscriber did not ask for, so
@@ -554,6 +556,13 @@ func filterSnapshot(snap state.Snapshot, include scanner.Include) state.Snapshot
 	}
 	if snap.Sessions == nil {
 		snap.Sessions = []state.SessionRecord{}
+	}
+	// `hosts` is never filtered. A machine's load is state the daemon
+	// collects for itself on every tick, not an enrichment a subscriber opts
+	// into, so it reaches every subscriber whatever their `include` — the
+	// rule contract §22 set for configured health.
+	if snap.Hosts == nil {
+		snap.Hosts = []state.Host{}
 	}
 	return snap
 }

--- a/internal/hoststats/host_darwin.go
+++ b/internal/hoststats/host_darwin.go
@@ -1,0 +1,132 @@
+package hoststats
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// readHost reads the machine from sysctl, one statfs and one `ps`.
+//
+// macOS has no cgo-free system-wide CPU counter: the numbers Activity Monitor
+// shows come from host_processor_info, a Mach call that needs libSystem, and
+// the BSD sysctls that carry them elsewhere (kern.cp_time) do not exist on
+// XNU. kern.proc.all's per-process tick fields are present in the struct but
+// left at zero by the kernel. What is left is `ps -A -o pid=,time=`: every
+// process's cumulative CPU time, ~20 ms for one fork, differenced per pid
+// across the scan interval and divided by wall time times hw.ncpu. Work done
+// by a process that exited between two ticks is lost, so the figure runs a
+// little low on a machine churning through short-lived processes.
+func readHost(ctx context.Context) (reading, error) {
+	r := reading{diskPath: "/"}
+	r.kernel, _ = unix.Sysctl("kern.osrelease")
+
+	if load, err := unix.SysctlRaw("vm.loadavg"); err == nil {
+		if parsed, ok := parseSysctlLoadavg(load); ok {
+			r.load = parsed
+		}
+	}
+	if used, total, ok := darwinMemory(); ok {
+		r.memUsed, r.memTotal = i64(used), i64(total)
+	}
+	if tv, err := unix.SysctlTimeval("kern.boottime"); err == nil && tv.Sec > 0 {
+		if up := time.Since(time.Unix(tv.Sec, 0)).Seconds(); up > 0 {
+			r.uptimeS = i64(int64(up))
+		}
+	}
+	r.diskUsed, r.diskTotal = diskUsage(r.diskPath)
+	r.cpu = darwinCPU(ctx)
+	return r, nil
+}
+
+// darwinMemory reports used and total physical memory.
+//
+// Total is hw.memsize. Used is what is left once everything the kernel could
+// hand to a new allocation is taken out: free and speculative pages, purgeable
+// pages, and the external (file-backed) pageable pages that are just cache.
+// That mirrors Linux's MemAvailable rather than Activity Monitor's "Memory
+// Used", so the two platforms' numbers mean the same thing.
+func darwinMemory() (used, total int64, ok bool) {
+	memsize, ok := sysctlUint("hw.memsize")
+	if !ok || memsize == 0 {
+		return 0, 0, false
+	}
+	pagesize, ok := sysctlUint("hw.pagesize")
+	if !ok || pagesize == 0 {
+		return 0, 0, false
+	}
+	var available uint64
+	for _, name := range []string{
+		"vm.page_free_count",
+		"vm.page_speculative_count",
+		"vm.page_purgeable_count",
+		"vm.page_pageable_external_count",
+	} {
+		v, ok := sysctlUint(name)
+		if !ok {
+			return 0, 0, false
+		}
+		available += v * pagesize
+	}
+	if available > memsize {
+		available = memsize
+	}
+	return int64(memsize - available), int64(memsize), true
+}
+
+// darwinCPU samples every process's cumulative CPU time.
+func darwinCPU(ctx context.Context) cpuSample {
+	out, err := exec.CommandContext(ctx, "ps", "-A", "-o", "pid=,time=").Output()
+	if err != nil {
+		return cpuSample{}
+	}
+	perProc, ok := parsePSTimes(string(out))
+	if !ok {
+		return cpuSample{}
+	}
+	var busy float64
+	for _, secs := range perProc {
+		busy += secs
+	}
+	cpus := runtime.NumCPU()
+	if n, ok := sysctlUint("hw.ncpu"); ok && n > 0 {
+		cpus = int(n)
+	}
+	return cpuSample{ok: true, busy: busy, cpus: cpus, perProc: perProc}
+}
+
+// sysctlUint reads an integer sysctl whose width varies by oid: neighbours in
+// the same vm namespace are four bytes and eight bytes on the same kernel, and
+// unix.SysctlUint32 fails outright on the wide ones.
+func sysctlUint(name string) (uint64, bool) {
+	raw, err := unix.SysctlRaw(name)
+	if err != nil {
+		return 0, false
+	}
+	switch len(raw) {
+	case 4:
+		return uint64(le32(raw)), true
+	case 8:
+		return le64(raw), true
+	}
+	return 0, false
+}
+
+// diskUsage measures the filesystem holding path, ignoring the blocks reserved
+// for root the way `df` does.
+func diskUsage(path string) (used, total *int64) {
+	var fs unix.Statfs_t
+	if err := unix.Statfs(path, &fs); err != nil {
+		return nil, nil
+	}
+	bsize := uint64(fs.Bsize)
+	t := fs.Blocks * bsize
+	avail := fs.Bavail * bsize
+	if t == 0 || avail > t {
+		return nil, nil
+	}
+	return u64(t - avail), u64(t)
+}

--- a/internal/hoststats/host_linux.go
+++ b/internal/hoststats/host_linux.go
@@ -1,0 +1,75 @@
+package hoststats
+
+import (
+	"context"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// readHost reads the machine from /proc and one statfs. Nothing shells out and
+// nothing needs cgo, so this is the same code path inside a scratch container
+// as on a desktop.
+func readHost(_ context.Context) (reading, error) {
+	r := reading{diskPath: "/", kernel: unameRelease()}
+
+	if data, err := os.ReadFile("/proc/stat"); err == nil {
+		if busy, total, ok := parseProcStat(string(data)); ok {
+			r.cpu = cpuSample{ok: true, busy: busy, total: total, cpus: runtime.NumCPU()}
+		}
+	}
+	if data, err := os.ReadFile("/proc/loadavg"); err == nil {
+		if load, ok := parseLoadavg(string(data)); ok {
+			r.load = load
+		}
+	}
+	if data, err := os.ReadFile("/proc/meminfo"); err == nil {
+		if used, total, ok := parseMeminfo(string(data)); ok {
+			r.memUsed, r.memTotal = i64(used), i64(total)
+		}
+	}
+	if data, err := os.ReadFile("/proc/uptime"); err == nil {
+		if secs, ok := parseUptime(string(data)); ok {
+			r.uptimeS = i64(secs)
+		}
+	}
+	r.diskUsed, r.diskTotal = diskUsage(r.diskPath)
+	return r, nil
+}
+
+// unameRelease is the kernel release, "6.8.0-40-generic".
+func unameRelease() string {
+	var u unix.Utsname
+	if err := unix.Uname(&u); err != nil {
+		return ""
+	}
+	return cstring(u.Release[:])
+}
+
+func cstring(b []byte) string {
+	for i, c := range b {
+		if c == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}
+
+// diskUsage measures the filesystem holding path. Used is total minus the free
+// space *this user* may claim: the reserved blocks root keeps back are not
+// space anyone can have, so counting them as free would overstate the disk on
+// every default ext4 by five percent.
+func diskUsage(path string) (used, total *int64) {
+	var fs unix.Statfs_t
+	if err := unix.Statfs(path, &fs); err != nil {
+		return nil, nil
+	}
+	bsize := uint64(fs.Bsize)
+	t := fs.Blocks * bsize
+	avail := fs.Bavail * bsize
+	if t == 0 || avail > t {
+		return nil, nil
+	}
+	return u64(t - avail), u64(t)
+}

--- a/internal/hoststats/host_other.go
+++ b/internal/hoststats/host_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin && !windows
+
+package hoststats
+
+import "context"
+
+// readHost is the fallback for a platform sonar does not ship binaries for.
+// Every field stays null, so a client sees "we do not know" rather than a zero
+// that reads like an idle machine.
+func readHost(_ context.Context) (reading, error) { return reading{}, nil }

--- a/internal/hoststats/host_windows.go
+++ b/internal/hoststats/host_windows.go
@@ -1,0 +1,129 @@
+package hoststats
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// kernel32 procedures golang.org/x/sys/windows does not wrap. They are
+// resolved lazily, once, from the system directory — never from the working
+// directory — so this adds no dependency and no DLL-planting surface.
+var (
+	modkernel32       = windows.NewLazySystemDLL("kernel32.dll")
+	procGetSystemTime = modkernel32.NewProc("GetSystemTimes")
+	procGlobalMemory  = modkernel32.NewProc("GlobalMemoryStatusEx")
+	procGetTickCount  = modkernel32.NewProc("GetTickCount64")
+)
+
+// memoryStatusEx is MEMORYSTATUSEX. Length must be set before the call.
+type memoryStatusEx struct {
+	Length               uint32
+	MemoryLoad           uint32
+	TotalPhys            uint64
+	AvailPhys            uint64
+	TotalPageFile        uint64
+	AvailPageFile        uint64
+	TotalVirtual         uint64
+	AvailVirtual         uint64
+	AvailExtendedVirtual uint64
+}
+
+// readHost reads the machine from kernel32. Windows has no load average — the
+// concept does not exist in the NT scheduler — so `load` stays null there
+// rather than being faked from the processor queue length.
+func readHost(_ context.Context) (reading, error) {
+	r := reading{diskPath: systemDrive(), kernel: kernelVersion()}
+
+	r.cpu = windowsCPUSample()
+	if used, total, ok := windowsMemory(); ok {
+		r.memUsed, r.memTotal = u64(used), u64(total)
+	}
+	if ms, ok := tickCount64(); ok {
+		r.uptimeS = i64(int64(ms / 1000))
+	}
+	r.diskUsed, r.diskTotal = diskUsage(r.diskPath)
+	return r, nil
+}
+
+// windowsCPUSample reads GetSystemTimes, the system-wide cumulative counters.
+func windowsCPUSample() cpuSample {
+	var idle, kernel, user windows.Filetime
+	ret, _, _ := procGetSystemTime.Call(
+		uintptr(unsafe.Pointer(&idle)),
+		uintptr(unsafe.Pointer(&kernel)),
+		uintptr(unsafe.Pointer(&user)),
+	)
+	if ret == 0 {
+		return cpuSample{}
+	}
+	busy, total, ok := windowsCPU(
+		filetime(idle.HighDateTime, idle.LowDateTime),
+		filetime(kernel.HighDateTime, kernel.LowDateTime),
+		filetime(user.HighDateTime, user.LowDateTime),
+	)
+	if !ok {
+		return cpuSample{}
+	}
+	return cpuSample{ok: true, busy: busy, total: total, cpus: runtime.NumCPU()}
+}
+
+// windowsMemory reports used and total physical memory. "Available" is the
+// kernel's own figure, so used means the same thing it does on the other two
+// platforms.
+func windowsMemory() (used, total uint64, ok bool) {
+	st := memoryStatusEx{}
+	st.Length = uint32(unsafe.Sizeof(st))
+	ret, _, _ := procGlobalMemory.Call(uintptr(unsafe.Pointer(&st)))
+	if ret == 0 || st.TotalPhys == 0 || st.AvailPhys > st.TotalPhys {
+		return 0, 0, false
+	}
+	return st.TotalPhys - st.AvailPhys, st.TotalPhys, true
+}
+
+// tickCount64 is milliseconds since boot, sleep included.
+func tickCount64() (uint64, bool) {
+	ret, _, _ := procGetTickCount.Call()
+	if ret == 0 {
+		return 0, false
+	}
+	return uint64(ret), true
+}
+
+// kernelVersion is the NT version, "10.0.26100".
+func kernelVersion() string {
+	v := windows.RtlGetVersion()
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d.%d", v.MajorVersion, v.MinorVersion, v.BuildNumber)
+}
+
+// systemDrive is the volume Windows booted from, "C:\".
+func systemDrive() string {
+	if d := os.Getenv("SystemDrive"); d != "" {
+		return d + `\`
+	}
+	return `C:\`
+}
+
+// diskUsage measures the volume holding path. Free is the caller's quota-aware
+// figure, matching the Bavail the unix collectors use.
+func diskUsage(path string) (used, total *int64) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, nil
+	}
+	var freeToCaller, totalBytes, totalFree uint64
+	if err := windows.GetDiskFreeSpaceEx(p, &freeToCaller, &totalBytes, &totalFree); err != nil {
+		return nil, nil
+	}
+	if totalBytes == 0 || freeToCaller > totalBytes {
+		return nil, nil
+	}
+	return u64(totalBytes - freeToCaller), u64(totalBytes)
+}

--- a/internal/hoststats/hoststats.go
+++ b/internal/hoststats/hoststats.go
@@ -1,0 +1,181 @@
+// Package hoststats collects the load of the machine the daemon runs on: cpu,
+// load average, memory, disk, uptime and kernel. The daemon publishes it as the
+// `localhost` row of the snapshot's `hosts` collection, and step 3A.2 fills the
+// rest of that collection with the same shape read from remote daemons.
+//
+// Every reading comes from the OS directly — /proc on Linux, sysctl on macOS,
+// kernel32 on Windows — so the package builds and runs with CGO_ENABLED=0.
+package hoststats
+
+import (
+	"context"
+	"math"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// cpuSample is a cumulative CPU counter, read once per tick. A percentage is a
+// property of an interval, never of an instant, so the collector keeps the
+// previous sample and reports the work done between the two.
+//
+// Busy and Total are in whatever unit the platform counts in (jiffies on Linux,
+// 100 ns on Windows, seconds on macOS); only their ratio is used. A platform
+// that cannot count total — macOS, which has no cgo-free system-wide CPU
+// counter — leaves Total zero and PerProc set, and the denominator becomes the
+// wall time between the samples multiplied by the number of cores.
+type cpuSample struct {
+	ok    bool
+	busy  float64
+	total float64
+	cpus  int
+
+	// perProc is cumulative CPU seconds per pid. When it is set, busy is the
+	// sum over the pids present in both samples plus the whole of any pid that
+	// appeared in between — a process that exits must not take its lifetime's
+	// CPU out of one interval's delta.
+	perProc map[int]float64
+}
+
+// reading is one platform's answer for one tick. Every field is optional: a
+// container with no /proc, a denied sysctl or a busy disk leaves a hole, and a
+// hole is published as null rather than as a zero that reads like a fact.
+type reading struct {
+	kernel    string
+	uptimeS   *int64
+	load      []float64
+	memUsed   *int64
+	memTotal  *int64
+	diskUsed  *int64
+	diskTotal *int64
+	diskPath  string
+	cpu       cpuSample
+}
+
+// Collector reads the local machine's load. It is stateful because CPU percent
+// is a delta: keep one across the daemon's lifetime and call Collect once per
+// scan tick.
+type Collector struct {
+	now  func() time.Time
+	read func(context.Context) (reading, error)
+
+	mu       sync.Mutex
+	prev     cpuSample
+	prevAt   time.Time
+	havePrev bool
+}
+
+// New builds a Collector reading this OS.
+func New() *Collector {
+	return &Collector{now: time.Now, read: readHost}
+}
+
+// Collect returns the local machine as a state.Host. The identity fields the
+// daemon owns — daemon and protocol version, the port and group counts — are
+// left to the caller; everything the OS knows is filled in here.
+//
+// CPUPercent is null on the first call: one sample is not a measurement.
+func (c *Collector) Collect(ctx context.Context) (state.Host, error) {
+	r, err := c.read(ctx)
+	at := c.now()
+	h := state.Host{
+		Name:       state.LocalhostName,
+		Address:    state.LocalhostName,
+		Status:     state.HostConnected,
+		LatencyMs:  0,
+		OS:         runtime.GOOS,
+		Arch:       runtime.GOARCH,
+		Kernel:     r.kernel,
+		UptimeS:    r.uptimeS,
+		Load:       r.load,
+		MemoryUsed: r.memUsed, MemoryTotal: r.memTotal,
+		DiskUsed: r.diskUsed, DiskTotal: r.diskTotal,
+		DiskPath: r.diskPath,
+		LastSeen: at.Format(time.RFC3339),
+	}
+	h.CPUPercent = c.cpuPercent(r.cpu, at)
+	if err != nil {
+		return h, err
+	}
+	return h, nil
+}
+
+// cpuPercent folds this tick's counter into the previous one and stores it.
+func (c *Collector) cpuPercent(s cpuSample, at time.Time) *float64 {
+	if !s.ok {
+		return nil
+	}
+	c.mu.Lock()
+	prev, prevAt, have := c.prev, c.prevAt, c.havePrev
+	c.prev, c.prevAt, c.havePrev = s, at, true
+	c.mu.Unlock()
+
+	if !have {
+		return nil
+	}
+	pct, ok := percentBetween(prev, prevAt, s, at)
+	if !ok {
+		return nil
+	}
+	return &pct
+}
+
+// percentBetween is the CPU maths, shared by all three platforms.
+func percentBetween(prev cpuSample, prevAt time.Time, cur cpuSample, at time.Time) (float64, bool) {
+	busy := cur.busy - prev.busy
+	if cur.perProc != nil && prev.perProc != nil {
+		busy = perProcDelta(prev.perProc, cur.perProc)
+	}
+	if busy < 0 {
+		return 0, false
+	}
+
+	total := cur.total - prev.total
+	if cur.total == 0 && prev.total == 0 {
+		// No system-wide denominator: the interval's capacity is wall time
+		// times the number of cores.
+		cpus := cur.cpus
+		if cpus < 1 {
+			cpus = runtime.NumCPU()
+		}
+		total = at.Sub(prevAt).Seconds() * float64(cpus)
+	}
+	if total <= 0 {
+		return 0, false
+	}
+
+	pct := busy / total * 100
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+	// One decimal: a load meter that redraws on the fourth digit of a float
+	// would publish a delta on every tick forever (see state.hostsEqual).
+	return math.Round(pct*10) / 10, true
+}
+
+// perProcDelta sums the CPU time spent between two per-process samples: the
+// growth of every process alive in both, plus the whole of every process that
+// appeared in between. A process that exited contributes nothing — its last
+// slice of work is lost, which understates the interval slightly and is far
+// better than the negative total a plain sum would give.
+func perProcDelta(prev, cur map[int]float64) float64 {
+	var busy float64
+	for pid, now := range cur {
+		before, existed := prev[pid]
+		switch {
+		case !existed:
+			busy += now
+		case now > before:
+			busy += now - before
+		}
+	}
+	return busy
+}
+
+func i64(v int64) *int64  { return &v }
+func u64(v uint64) *int64 { return i64(int64(v)) }

--- a/internal/hoststats/hoststats_test.go
+++ b/internal/hoststats/hoststats_test.go
@@ -1,0 +1,175 @@
+package hoststats
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// clock is the instant the fake-clock tests start from.
+var clock = time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+
+// fakeCollector builds a Collector over a scripted clock and a scripted
+// platform reading, so the CPU maths is exercised without an OS.
+func fakeCollector(readings ...reading) *Collector {
+	now := clock
+	i := 0
+	return &Collector{
+		now: func() time.Time {
+			// Every collection advances the clock by one scan interval.
+			at := now
+			now = now.Add(2 * time.Second)
+			return at
+		},
+		read: func(context.Context) (reading, error) {
+			r := readings[i]
+			if i < len(readings)-1 {
+				i++
+			}
+			return r, nil
+		},
+	}
+}
+
+func linuxReading(busy, total float64) reading {
+	return reading{
+		kernel:  "6.8.0-40-generic",
+		uptimeS: i64(93607),
+		load:    []float64{0.42, 0.51, 0.6},
+		cpu:     cpuSample{ok: true, busy: busy, total: total},
+	}
+}
+
+// The first tick has nothing to compare against, so cpu_percent is null rather
+// than a made-up zero.
+func TestFirstCollectHasNoCPUPercent(t *testing.T) {
+	c := fakeCollector(linuxReading(100, 1000))
+	h, err := c.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if h.CPUPercent != nil {
+		t.Errorf("cpu_percent = %v on the first tick, want null", *h.CPUPercent)
+	}
+	if h.Name != state.LocalhostName || h.Address != state.LocalhostName {
+		t.Errorf("host identity = %q/%q, want localhost", h.Name, h.Address)
+	}
+	if h.Status != state.HostConnected {
+		t.Errorf("status = %q, want connected", h.Status)
+	}
+	if h.Kernel != "6.8.0-40-generic" || h.UptimeS == nil || *h.UptimeS != 93607 {
+		t.Errorf("platform fields did not survive Collect: %+v", h)
+	}
+	if h.LastSeen != clock.Format(time.RFC3339) {
+		t.Errorf("last_seen = %q, want the collection time", h.LastSeen)
+	}
+}
+
+// The second tick measures the interval between the two samples.
+func TestCPUPercentIsTheDeltaBetweenTwoSamples(t *testing.T) {
+	c := fakeCollector(linuxReading(100, 1000), linuxReading(190, 1300))
+	if _, err := c.Collect(context.Background()); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	h, err := c.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if h.CPUPercent == nil {
+		t.Fatal("cpu_percent is null on the second tick")
+	}
+	if want := 30.0; *h.CPUPercent != want { // 90 busy of 300 total
+		t.Errorf("cpu_percent = %v, want %v", *h.CPUPercent, want)
+	}
+}
+
+// A counter that went backwards — a reboot, a wrapped register — is not a
+// negative percentage. The tick reports null and the next one is correct
+// again, because the sample was still stored.
+func TestCountersGoingBackwardsPublishNull(t *testing.T) {
+	c := fakeCollector(linuxReading(500, 1000), linuxReading(100, 1200), linuxReading(160, 1400))
+	if _, err := c.Collect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	h, _ := c.Collect(context.Background())
+	if h.CPUPercent != nil {
+		t.Errorf("cpu_percent = %v after the counter reset, want null", *h.CPUPercent)
+	}
+	h, _ = c.Collect(context.Background())
+	if h.CPUPercent == nil || *h.CPUPercent != 30 {
+		t.Errorf("cpu_percent = %v after recovery, want 30", h.CPUPercent)
+	}
+}
+
+// macOS has no system-wide counter: the denominator is wall time times cores.
+// Two seconds of elapsed time on four cores is eight core-seconds, and two of
+// them spent working is 25%.
+func TestCPUPercentWithoutASystemTotalUsesWallTimeAndCores(t *testing.T) {
+	sample := func(secs float64) reading {
+		return reading{cpu: cpuSample{
+			ok: true, busy: secs, cpus: 4,
+			perProc: map[int]float64{1: secs},
+		}}
+	}
+	c := fakeCollector(sample(10), sample(12))
+	if _, err := c.Collect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	h, _ := c.Collect(context.Background())
+	if h.CPUPercent == nil || *h.CPUPercent != 25 {
+		t.Errorf("cpu_percent = %v, want 25", h.CPUPercent)
+	}
+}
+
+// A platform that cannot read its CPU at all publishes null for it and keeps
+// everything else.
+func TestUnreadableCPUIsNull(t *testing.T) {
+	c := fakeCollector(reading{kernel: "unknown"}, reading{kernel: "unknown"})
+	if _, err := c.Collect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	h, _ := c.Collect(context.Background())
+	if h.CPUPercent != nil {
+		t.Errorf("cpu_percent = %v with no CPU counter, want null", *h.CPUPercent)
+	}
+}
+
+func TestPercentIsClampedToOneDecimal(t *testing.T) {
+	prev := cpuSample{ok: true, busy: 0, total: 0, cpus: 1}
+	cur := cpuSample{ok: true, busy: 0.123456, cpus: 1}
+	got, ok := percentBetween(prev, clock, cur, clock.Add(time.Second))
+	if !ok || got != 12.3 {
+		t.Errorf("percentBetween = %v, %v, want 12.3", got, ok)
+	}
+}
+
+// The real collector on this machine must answer, whatever the OS is, and must
+// answer twice with a percentage the second time.
+func TestLiveCollectorFillsTheRowTwice(t *testing.T) {
+	c := New()
+	if _, err := c.Collect(context.Background()); err != nil {
+		t.Fatalf("first Collect: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	h, err := c.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("second Collect: %v", err)
+	}
+	if h.OS == "" || h.Arch == "" {
+		t.Errorf("os/arch empty: %+v", h)
+	}
+	if h.MemoryTotal == nil || *h.MemoryTotal <= 0 {
+		t.Errorf("memory_total_bytes = %v, want the machine's RAM", h.MemoryTotal)
+	}
+	if h.DiskTotal == nil || *h.DiskTotal <= 0 {
+		t.Errorf("disk_total_bytes = %v, want the size of %q", h.DiskTotal, h.DiskPath)
+	}
+	if h.UptimeS == nil || *h.UptimeS <= 0 {
+		t.Errorf("uptime_s = %v, want seconds since boot", h.UptimeS)
+	}
+	if h.CPUPercent == nil {
+		t.Error("cpu_percent is null on the second live collection")
+	}
+}

--- a/internal/hoststats/parse.go
+++ b/internal/hoststats/parse.go
@@ -1,0 +1,224 @@
+package hoststats
+
+import (
+	"strconv"
+	"strings"
+)
+
+// This file holds the pure parsers, deliberately free of build tags: every
+// platform's text and byte formats are decoded here so the tests for all three
+// run on whatever machine `go test ./...` happens to be.
+
+// parseProcStat reads Linux /proc/stat and returns the cumulative busy and
+// total jiffies of the aggregate "cpu" line.
+//
+//	cpu  user nice system idle iowait irq softirq steal guest guest_nice
+//
+// Idle time is idle + iowait: a core waiting on disk is not doing work. guest
+// and guest_nice are already counted inside user and nice, so they are dropped
+// rather than added twice.
+func parseProcStat(data string) (busy, total float64, ok bool) {
+	for line := range strings.SplitSeq(data, "\n") {
+		if !strings.HasPrefix(line, "cpu ") && !strings.HasPrefix(line, "cpu\t") {
+			continue
+		}
+		fields := strings.Fields(line)[1:]
+		if len(fields) < 4 {
+			return 0, 0, false
+		}
+		if len(fields) > 8 {
+			fields = fields[:8]
+		}
+		var sum, idle float64
+		for i, f := range fields {
+			v, err := strconv.ParseFloat(f, 64)
+			if err != nil {
+				return 0, 0, false
+			}
+			sum += v
+			if i == 3 || i == 4 { // idle, iowait
+				idle += v
+			}
+		}
+		return sum - idle, sum, true
+	}
+	return 0, 0, false
+}
+
+// parseLoadavg reads Linux /proc/loadavg: "0.42 0.51 0.60 1/523 12345".
+func parseLoadavg(data string) ([]float64, bool) {
+	fields := strings.Fields(data)
+	if len(fields) < 3 {
+		return nil, false
+	}
+	out := make([]float64, 3)
+	for i := range out {
+		v, err := strconv.ParseFloat(fields[i], 64)
+		if err != nil {
+			return nil, false
+		}
+		out[i] = v
+	}
+	return out, true
+}
+
+// parseUptime reads Linux /proc/uptime: "12345.67 98765.43" (seconds since
+// boot, then idle seconds summed over all cores).
+func parseUptime(data string) (int64, bool) {
+	fields := strings.Fields(data)
+	if len(fields) == 0 {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil || v < 0 {
+		return 0, false
+	}
+	return int64(v), true
+}
+
+// parseMeminfo reads Linux /proc/meminfo and returns used and total bytes.
+//
+// "Used" is total minus MemAvailable, the kernel's own estimate of what a new
+// workload could claim without swapping. It is the number `free -h` prints as
+// "available" and the only one that treats reclaimable page cache honestly. On
+// a kernel too old to publish it (< 3.14) the classic free + buffers + cached
+// sum stands in.
+func parseMeminfo(data string) (used, total int64, ok bool) {
+	vals := map[string]int64{}
+	for line := range strings.SplitSeq(data, "\n") {
+		key, rest, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			continue
+		}
+		v, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		// Every size in /proc/meminfo is kB; the few unitless counters are
+		// not sizes and are never read here.
+		vals[key] = v * 1024
+	}
+
+	total, ok = vals["MemTotal"]
+	if !ok || total <= 0 {
+		return 0, 0, false
+	}
+	available, ok := vals["MemAvailable"]
+	if !ok {
+		available = vals["MemFree"] + vals["Buffers"] + vals["Cached"]
+	}
+	if available > total {
+		available = total
+	}
+	return total - available, total, true
+}
+
+// parsePSTimes reads the output of `ps -A -o pid=,time=` on macOS, one process
+// per line: "  501    40:18.12". The value is cumulative CPU time, so a pair of
+// samples gives the work done in between.
+func parsePSTimes(data string) (map[int]float64, bool) {
+	out := map[int]float64{}
+	for line := range strings.SplitSeq(data, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		secs, ok := parseCPUTime(fields[1])
+		if !ok {
+			continue
+		}
+		out[pid] = secs
+	}
+	return out, len(out) > 0
+}
+
+// parseCPUTime decodes ps's cumulative time column: "MM:SS.ss", or
+// "HH:MM:SS.ss" / "D-HH:MM:SS" once a process has been running long enough.
+func parseCPUTime(s string) (float64, bool) {
+	if d, rest, found := strings.Cut(s, "-"); found {
+		days, err := strconv.ParseFloat(d, 64)
+		if err != nil {
+			return 0, false
+		}
+		rest, ok := parseCPUTime(rest)
+		if !ok {
+			return 0, false
+		}
+		return days*86400 + rest, true
+	}
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, false
+	}
+	var total float64
+	for _, p := range parts {
+		v, err := strconv.ParseFloat(p, 64)
+		if err != nil || v < 0 {
+			return 0, false
+		}
+		total = total*60 + v
+	}
+	return total, true
+}
+
+// parseSysctlLoadavg decodes darwin's `vm.loadavg`, a struct loadavg:
+//
+//	fixpt_t ldavg[3]; long fscale;
+//
+// fscale is read from the tail so the padding before a 64-bit long does not
+// have to be assumed, and falls back to the FSCALE the kernel has used since
+// 4.4BSD when the struct is short or the scale is zero.
+func parseSysctlLoadavg(raw []byte) ([]float64, bool) {
+	if len(raw) < 12 {
+		return nil, false
+	}
+	scale := float64(2048)
+	if len(raw) >= 20 {
+		if v := float64(le32(raw[len(raw)-8:])); v > 0 {
+			scale = v
+		}
+	} else if len(raw) >= 16 {
+		if v := float64(le32(raw[12:])); v > 0 {
+			scale = v
+		}
+	}
+	out := make([]float64, 3)
+	for i := range out {
+		out[i] = float64(le32(raw[i*4:])) / scale
+	}
+	return out, true
+}
+
+func le32(b []byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}
+
+func le64(b []byte) uint64 {
+	return uint64(le32(b)) | uint64(le32(b[4:]))<<32
+}
+
+// filetime folds a Windows FILETIME's two halves into the 100-nanosecond
+// counter they encode. GetSystemTimes hands back three of them.
+func filetime(high, low uint32) uint64 {
+	return uint64(high)<<32 | uint64(low)
+}
+
+// windowsCPU turns GetSystemTimes' three counters into the cumulative busy and
+// total this collector compares between ticks. The kernel counter already
+// includes the idle time, so total is kernel + user and busy is what is left
+// once idle is taken out.
+func windowsCPU(idle, kernel, user uint64) (busy, total float64, ok bool) {
+	t := kernel + user
+	if t == 0 || idle > t {
+		return 0, 0, false
+	}
+	return float64(t - idle), float64(t), true
+}

--- a/internal/hoststats/parse_test.go
+++ b/internal/hoststats/parse_test.go
@@ -1,0 +1,252 @@
+package hoststats
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// Two consecutive /proc/stat reads from an idle-ish Linux box, one second
+// apart. The maths that turns them into a percentage is the whole of the Linux
+// CPU collector, so it is pinned here rather than left to a live machine.
+const (
+	procStatT0 = `cpu  1256789 3421 298765 18904321 45678 0 12345 0 0 0
+cpu0 314197 855 74691 4726080 11419 0 3086 0 0 0
+cpu1 314197 855 74691 4726080 11419 0 3086 0 0 0
+intr 987654321 12 0 0
+ctxt 1234567890
+btime 1757000000
+processes 987654
+procs_running 2
+procs_blocked 0
+`
+	procStatT1 = `cpu  1256889 3421 298815 18904821 45678 0 12345 0 0 0
+cpu0 314222 855 74703 4726205 11419 0 3086 0 0 0
+intr 987654999 12 0 0
+`
+)
+
+func TestParseProcStatComputesBusyAndTotal(t *testing.T) {
+	busy, total, ok := parseProcStat(procStatT0)
+	if !ok {
+		t.Fatal("parseProcStat did not find the aggregate cpu line")
+	}
+	// user+nice+system+idle+iowait+irq+softirq+steal
+	wantTotal := 1256789.0 + 3421 + 298765 + 18904321 + 45678 + 0 + 12345 + 0
+	wantBusy := wantTotal - 18904321 - 45678
+	if total != wantTotal || busy != wantBusy {
+		t.Errorf("parseProcStat = busy %v total %v, want %v / %v", busy, total, wantBusy, wantTotal)
+	}
+}
+
+// The percentage is the ratio of the two deltas: 150 busy jiffies out of 650.
+func TestProcStatPercentBetweenTwoSamples(t *testing.T) {
+	b0, t0, _ := parseProcStat(procStatT0)
+	b1, t1, _ := parseProcStat(procStatT1)
+
+	prev := cpuSample{ok: true, busy: b0, total: t0}
+	cur := cpuSample{ok: true, busy: b1, total: t1}
+	got, ok := percentBetween(prev, clock, cur, clock.Add(time.Second))
+	if !ok {
+		t.Fatal("percentBetween refused two good samples")
+	}
+	want := math.Round((150.0/650.0*100)*10) / 10 // 23.1
+	if got != want {
+		t.Errorf("cpu percent = %v, want %v", got, want)
+	}
+}
+
+func TestParseProcStatRejectsRubbish(t *testing.T) {
+	for _, in := range []string{"", "intr 1 2 3\n", "cpu  x y z w\n", "cpu  1 2\n"} {
+		if _, _, ok := parseProcStat(in); ok {
+			t.Errorf("parseProcStat(%q) accepted a line it cannot use", in)
+		}
+	}
+}
+
+func TestParseLoadavg(t *testing.T) {
+	load, ok := parseLoadavg("0.42 0.51 0.60 1/523 12345\n")
+	if !ok {
+		t.Fatal("parseLoadavg refused a good /proc/loadavg")
+	}
+	want := []float64{0.42, 0.51, 0.60}
+	for i := range want {
+		if load[i] != want[i] {
+			t.Errorf("load = %v, want %v", load, want)
+			break
+		}
+	}
+	if _, ok := parseLoadavg("0.42 0.51\n"); ok {
+		t.Error("parseLoadavg accepted a truncated line")
+	}
+}
+
+func TestParseUptime(t *testing.T) {
+	got, ok := parseUptime("93607.42 712345.11\n")
+	if !ok || got != 93607 {
+		t.Errorf("parseUptime = %d, %v, want 93607, true", got, ok)
+	}
+	if _, ok := parseUptime("\n"); ok {
+		t.Error("parseUptime accepted an empty file")
+	}
+}
+
+const meminfo = `MemTotal:       32762136 kB
+MemFree:         1029412 kB
+MemAvailable:   23068672 kB
+Buffers:          512000 kB
+Cached:         18874368 kB
+SwapCached:            0 kB
+Active:         12345678 kB
+`
+
+func TestParseMeminfoUsesMemAvailable(t *testing.T) {
+	used, total, ok := parseMeminfo(meminfo)
+	if !ok {
+		t.Fatal("parseMeminfo refused a good /proc/meminfo")
+	}
+	wantTotal := int64(32762136) * 1024
+	wantUsed := wantTotal - int64(23068672)*1024
+	if total != wantTotal || used != wantUsed {
+		t.Errorf("parseMeminfo = used %d total %d, want %d / %d", used, total, wantUsed, wantTotal)
+	}
+}
+
+// Kernels before 3.14 have no MemAvailable; free + buffers + cached stands in.
+func TestParseMeminfoFallsBackWithoutMemAvailable(t *testing.T) {
+	old := `MemTotal:       32762136 kB
+MemFree:         1029412 kB
+Buffers:          512000 kB
+Cached:         18874368 kB
+`
+	used, total, ok := parseMeminfo(old)
+	if !ok {
+		t.Fatal("parseMeminfo refused a pre-3.14 /proc/meminfo")
+	}
+	wantUsed := (int64(32762136) - 1029412 - 512000 - 18874368) * 1024
+	if used != wantUsed || total != int64(32762136)*1024 {
+		t.Errorf("parseMeminfo = used %d total %d, want used %d", used, total, wantUsed)
+	}
+}
+
+func TestParseMeminfoWithoutMemTotalFails(t *testing.T) {
+	if _, _, ok := parseMeminfo("MemFree: 100 kB\n"); ok {
+		t.Error("parseMeminfo accepted a file with no MemTotal")
+	}
+}
+
+// A captured `ps -A -o pid=,time=` from macOS: kernel_task, a couple of user
+// processes, and one that has been running for days.
+const psSample = `    0  40:18.12
+    1   0:01.42
+  501  24:55.63
+  623 2-03:14:15
+  bad  0:01.00
+`
+
+func TestParsePSTimes(t *testing.T) {
+	got, ok := parsePSTimes(psSample)
+	if !ok {
+		t.Fatal("parsePSTimes refused a good ps table")
+	}
+	if len(got) != 4 {
+		t.Fatalf("parsePSTimes returned %d rows, want 4 (the unparseable pid is dropped)", len(got))
+	}
+	if want := 40*60 + 18.12; got[0] != want {
+		t.Errorf("pid 0 = %v, want %v", got[0], want)
+	}
+	if want := 2*86400 + 3*3600 + 14*60 + 15.0; got[623] != want {
+		t.Errorf("pid 623 = %v, want %v", got[623], want)
+	}
+	if _, ok := parsePSTimes("no rows here\n"); ok {
+		t.Error("parsePSTimes accepted output with no process in it")
+	}
+}
+
+func TestParseCPUTimeRejectsNonsense(t *testing.T) {
+	for _, in := range []string{"", "12", "1:2:3:4", "a:b", "-1:00"} {
+		if _, ok := parseCPUTime(in); ok {
+			t.Errorf("parseCPUTime(%q) accepted a value it cannot read", in)
+		}
+	}
+}
+
+// A process that exits between two samples takes its lifetime's CPU with it;
+// one that starts brings its whole (short) lifetime. Neither may push the
+// interval's total negative.
+func TestPerProcDeltaHandlesChurn(t *testing.T) {
+	prev := map[int]float64{1: 100, 2: 5000, 3: 10}
+	cur := map[int]float64{1: 101.5, 3: 10, 4: 0.25} // pid 2 exited, pid 4 is new
+	if got, want := perProcDelta(prev, cur), 1.75; math.Abs(got-want) > 1e-9 {
+		t.Errorf("perProcDelta = %v, want %v", got, want)
+	}
+}
+
+// darwin's `vm.loadavg` is a struct loadavg: three fixed-point values and the
+// scale to divide them by. This is the 24 bytes an arm64 kernel returns for a
+// load of 1.5 / 0.75 / 0.25 at the classic FSCALE of 2048.
+func TestParseSysctlLoadavg(t *testing.T) {
+	raw := make([]byte, 24)
+	put32(raw[0:], 3072)  // 1.5
+	put32(raw[4:], 1536)  // 0.75
+	put32(raw[8:], 512)   // 0.25
+	put32(raw[16:], 2048) // fscale, first word of the 64-bit long
+	got, ok := parseSysctlLoadavg(raw)
+	if !ok {
+		t.Fatal("parseSysctlLoadavg refused a well-formed struct")
+	}
+	want := []float64{1.5, 0.75, 0.25}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("load = %v, want %v", got, want)
+		}
+	}
+	if _, ok := parseSysctlLoadavg(raw[:8]); ok {
+		t.Error("parseSysctlLoadavg accepted a truncated struct")
+	}
+}
+
+func put32(b []byte, v uint32) {
+	b[0], b[1], b[2], b[3] = byte(v), byte(v>>8), byte(v>>16), byte(v>>24)
+}
+
+// GetSystemTimes hands back three FILETIMEs, split into two 32-bit halves, and
+// counts idle time inside the kernel total. This is the decoding a Windows
+// daemon does every tick, checked on whatever OS the tests run on.
+func TestWindowsCPUFromFiletimes(t *testing.T) {
+	// idle 40 s, kernel 60 s (idle included), user 20 s, in 100 ns units.
+	const unit = 10_000_000
+	idle := uint64(40 * unit)
+	kernel := uint64(60 * unit)
+	user := uint64(20 * unit)
+
+	if got := filetime(uint32(idle>>32), uint32(idle)); got != idle {
+		t.Fatalf("filetime round trip = %d, want %d", got, idle)
+	}
+
+	busy, total, ok := windowsCPU(idle, kernel, user)
+	if !ok {
+		t.Fatal("windowsCPU refused a good sample")
+	}
+	if total != float64(80*unit) || busy != float64(40*unit) {
+		t.Errorf("windowsCPU = busy %v total %v, want %v / %v",
+			busy, total, float64(40*unit), float64(80*unit))
+	}
+
+	// The same counters one second later, with half a second of work done.
+	prev := cpuSample{ok: true, busy: busy, total: total}
+	cur := cpuSample{ok: true, busy: busy + 0.5*unit, total: total + 1*unit}
+	pct, ok := percentBetween(prev, clock, cur, clock.Add(time.Second))
+	if !ok || pct != 50 {
+		t.Errorf("windows cpu percent = %v, %v, want 50", pct, ok)
+	}
+}
+
+func TestWindowsCPURejectsImpossibleCounters(t *testing.T) {
+	if _, _, ok := windowsCPU(100, 0, 0); ok {
+		t.Error("windowsCPU accepted an idle time with no total")
+	}
+	if _, _, ok := windowsCPU(200, 100, 50); ok {
+		t.Error("windowsCPU accepted more idle than total")
+	}
+}

--- a/internal/mcpserver/fakedaemon/fakedaemon.go
+++ b/internal/mcpserver/fakedaemon/fakedaemon.go
@@ -306,6 +306,7 @@ func completeDelta(d state.Delta) state.Delta {
 	d.Tunnels = completeChange(d.Tunnels)
 	d.Proxies = completeChange(d.Proxies)
 	d.Sessions = completeChange(d.Sessions)
+	d.Hosts = completeChange(d.Hosts)
 	return d
 }
 

--- a/internal/mcpserver/fakedaemon/fixture.go
+++ b/internal/mcpserver/fakedaemon/fixture.go
@@ -15,6 +15,7 @@ type Fixture struct {
 	Ports         []state.Port
 	Groups        []state.Group
 	Sessions      []state.SessionRecord
+	Hosts         []state.Host
 }
 
 // FixtureTime is the instant every fixture pretends it is.
@@ -33,7 +34,24 @@ func DefaultFixture() Fixture {
 		Ports:        DefaultPorts(),
 		Groups:       DefaultGroups(),
 		Sessions:     DefaultSessions(),
+		Hosts:        DefaultHosts(),
 	}
+}
+
+// DefaultHosts is the fixture's `hosts` collection: the one row every daemon
+// publishes for the machine it runs on, with the load of a developer laptop
+// halfway through a working day.
+func DefaultHosts() []state.Host {
+	return []state.Host{{
+		Name: state.LocalhostName, Address: state.LocalhostName,
+		Status: state.HostConnected, DaemonVersion: "0.5.1", ProtocolVersion: "1.0.0",
+		LatencyMs: 0, OS: "linux", Arch: "amd64", Kernel: "6.8.0-40-generic",
+		UptimeS: i64p(93_600), CPUPercent: f64p(12.4),
+		Load:       []float64{1.24, 0.98, 0.71},
+		MemoryUsed: i64p(9 << 30), MemoryTotal: i64p(32 << 30),
+		DiskUsed: i64p(412 << 30), DiskTotal: i64p(931 << 30), DiskPath: "/",
+		Ports: 6, Groups: 2, LastSeen: FixtureTime,
+	}}
 }
 
 // DefaultPorts is the fixture's port table, sorted by port the way a scan
@@ -177,6 +195,10 @@ func ManyPorts(n int) []state.Port {
 }
 
 func strp(s string) *string { return &s }
-func intp(i int) *int       { return &i }
+
+func i64p(v int64) *int64 { return &v }
+
+func f64p(v float64) *float64 { return &v }
+func intp(i int) *int         { return &i }
 
 func srcp(s state.GroupSource) *state.GroupSource { return &s }

--- a/internal/mcpserver/fakedaemon/handlers.go
+++ b/internal/mcpserver/fakedaemon/handlers.go
@@ -69,6 +69,7 @@ func (f *Fake) snapshot() state.Snapshot {
 		Tunnels:       []state.Tunnel{},
 		Proxies:       []state.Proxy{},
 		Sessions:      orEmpty(f.fixture.Sessions),
+		Hosts:         orEmpty(f.fixture.Hosts),
 	}
 }
 

--- a/internal/scanner/attribute_test.go
+++ b/internal/scanner/attribute_test.go
@@ -25,6 +25,7 @@ func openStore(t *testing.T) *store.Store {
 // loopWith builds a loop over a fixed scan result, backed by st.
 func loopWith(st Store, rows ...ports.ListeningPort) *Loop {
 	l := New(Options{
+		HostStats:     fixedHost,
 		DaemonVersion: "test",
 		Store:         st,
 		Scan: func(Include) ([]ports.ListeningPort, error) {
@@ -99,6 +100,7 @@ func TestScanRecordsHistoryFromTheDiff(t *testing.T) {
 	up := ports.ListeningPort{Port: 8123, PID: 42, Process: "python3", Command: "python3 -m http.server"}
 	var rows []ports.ListeningPort
 	l := New(Options{
+		HostStats:     fixedHost,
 		DaemonVersion: "test",
 		Store:         st,
 		Scan: func(Include) ([]ports.ListeningPort, error) {
@@ -193,6 +195,7 @@ func TestRemembersNewlySeenRoots(t *testing.T) {
 func TestInvalidateForcesTheNextReadToRescan(t *testing.T) {
 	scans := 0
 	l := New(Options{
+		HostStats:     fixedHost,
 		DaemonVersion: "test",
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			scans++

--- a/internal/scanner/health_test.go
+++ b/internal/scanner/health_test.go
@@ -47,6 +47,7 @@ func healthLoop(t *testing.T, dir string, port int) (*Loop, *[]state.Event, *syn
 	var seen []state.Event
 
 	l := New(Options{
+		HostStats:     fixedHost,
 		DaemonVersion: "test",
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			return []ports.ListeningPort{{
@@ -159,6 +160,7 @@ func TestNoHealthPathMeansNoProbe(t *testing.T) {
 	writeConfig(t, dir, "name: plain\nservices:\n  - name: api\n    port: "+strconv.Itoa(port)+"\n")
 
 	l := New(Options{
+		HostStats:     fixedHost,
 		DaemonVersion: "test",
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			return []ports.ListeningPort{{

--- a/internal/scanner/hosts_test.go
+++ b/internal/scanner/hosts_test.go
@@ -1,0 +1,173 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// movingHost is a collector whose cpu percent climbs on every call, the way a
+// real machine's does.
+func movingHost() func(context.Context) (state.Host, error) {
+	var mu sync.Mutex
+	pct := 0.0
+	return func(context.Context) (state.Host, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		pct += 1.5
+		p := pct
+		return state.Host{Kernel: "test-kernel", CPUPercent: &p}, nil
+	}
+}
+
+// Every snapshot names this machine, with the collection's counts and the
+// daemon's own versions filled in by the loop.
+func TestScanPublishesLocalhost(t *testing.T) {
+	l := New(Options{
+		DaemonVersion:   "9.9.9",
+		ProtocolVersion: "1.0.0",
+		HostStats:       fixedHost,
+		Demand:          func() (int, Include) { return 1, Include{} },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{
+				{Port: 3000, BindAddress: "127.0.0.1", PID: 1},
+				{Port: 5173, BindAddress: "127.0.0.1", PID: 2},
+			}, nil
+		},
+	})
+	l.scanAndPublish(Include{})
+
+	snap := l.Cached()
+	if len(snap.Hosts) != 1 {
+		t.Fatalf("hosts = %+v, want one row", snap.Hosts)
+	}
+	h := snap.Hosts[0]
+	if h.Name != state.LocalhostName || h.Address != state.LocalhostName {
+		t.Errorf("host identity = %q/%q, want localhost/localhost", h.Name, h.Address)
+	}
+	if h.Status != state.HostConnected || h.LatencyMs != 0 {
+		t.Errorf("localhost status = %q latency %d, want connected / 0", h.Status, h.LatencyMs)
+	}
+	if h.DaemonVersion != "9.9.9" || h.ProtocolVersion != "1.0.0" {
+		t.Errorf("versions = %q/%q, want the daemon's own", h.DaemonVersion, h.ProtocolVersion)
+	}
+	if h.Ports != 2 {
+		t.Errorf("ports = %d, want the 2 in the snapshot", h.Ports)
+	}
+	if h.Kernel != "test-kernel" {
+		t.Errorf("kernel = %q, want the collector's answer", h.Kernel)
+	}
+	if h.LastSeen != snap.At {
+		t.Errorf("last_seen = %q, want the scan time %q", h.LastSeen, snap.At)
+	}
+}
+
+// A client that subscribes before the first scan still finds localhost: the
+// row is identity even when there is no load to report yet.
+func TestCachedSnapshotBeforeTheFirstScanNamesLocalhost(t *testing.T) {
+	l := New(Options{DaemonVersion: "9.9.9", ProtocolVersion: "1.0.0", HostStats: fixedHost})
+	snap := l.Cached()
+	if len(snap.Hosts) != 1 || snap.Hosts[0].Name != state.LocalhostName {
+		t.Fatalf("hosts before the first scan = %+v, want localhost", snap.Hosts)
+	}
+	if snap.Hosts[0].CPUPercent != nil {
+		t.Error("cpu_percent must be null before anything has been measured")
+	}
+}
+
+// A collector that fails is not a scan failure: the row is still published,
+// with the reason on it and the load null.
+func TestHostStatsFailureStillPublishesLocalhost(t *testing.T) {
+	l := New(Options{
+		HostStats: func(context.Context) (state.Host, error) {
+			return state.Host{}, errors.New("/proc is not mounted")
+		},
+		Demand: func() (int, Include) { return 1, Include{} },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 1}}, nil
+		},
+	})
+	l.scanAndPublish(Include{})
+
+	hosts := l.Cached().Hosts
+	if len(hosts) != 1 {
+		t.Fatalf("hosts = %+v, want the localhost row anyway", hosts)
+	}
+	if hosts[0].Status != state.HostConnected {
+		t.Errorf("status = %q, want connected: the daemon is talking to itself", hosts[0].Status)
+	}
+	if hosts[0].StatusReason == nil || *hosts[0].StatusReason != "/proc is not mounted" {
+		t.Errorf("status_reason = %v, want the collector's error", hosts[0].StatusReason)
+	}
+	if hosts[0].CPUPercent != nil {
+		t.Error("cpu_percent must be null when the collection failed")
+	}
+}
+
+// Host load moves on nearly every tick. It is published — one `hosts` delta
+// per tick, to every subscriber whatever their `include` — but it must not
+// snap the scan interval back to the base, or a subscribed daemon would run a
+// full port scan every two seconds forever.
+func TestHostOnlyChangePublishesWithoutResettingTheBackoff(t *testing.T) {
+	var published []state.Delta
+	l := New(Options{
+		HostStats: movingHost(),
+		Demand:    func() (int, Include) { return 1, Include{} },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 1}}, nil
+		},
+		Publish: func(prev, next state.Snapshot, _ []state.Event) {
+			published = append(published, state.Diff(prev, next))
+		},
+	})
+
+	for i := 0; i < 5; i++ {
+		l.scanAndPublish(Include{})
+	}
+
+	if got, want := l.Status().IntervalMs, int(SubscribedMaxInterval/time.Millisecond); got != want {
+		t.Errorf("interval = %dms after five host-only ticks, want the %dms cap", got, want)
+	}
+	if len(published) != 5 {
+		t.Fatalf("published %d deltas, want one per tick", len(published))
+	}
+	last := published[len(published)-1]
+	if len(last.Hosts.Updated) != 1 {
+		t.Fatalf("the last delta carried %+v, want one host update", last.Hosts)
+	}
+	if len(last.Ports.Added)+len(last.Ports.Updated)+len(last.Ports.Removed) != 0 {
+		t.Errorf("a host-only tick published port changes: %+v", last.Ports)
+	}
+	if l.Status().Seq != 5 {
+		t.Errorf("seq = %d, want one per published tick", l.Status().Seq)
+	}
+}
+
+// A tick where nothing moved at all — ports the same, machine the same —
+// publishes nothing and keeps its sequence number.
+func TestFullyUnchangedTickPublishesNothing(t *testing.T) {
+	published := 0
+	l := New(Options{
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return 1, Include{} },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 1}}, nil
+		},
+		Publish: func(state.Snapshot, state.Snapshot, []state.Event) { published++ },
+	})
+	l.scanAndPublish(Include{})
+	seq := l.Status().Seq
+	l.scanAndPublish(Include{})
+	l.scanAndPublish(Include{})
+	if published != 1 {
+		t.Errorf("published %d times, want only the first tick", published)
+	}
+	if l.Status().Seq != seq {
+		t.Errorf("seq moved to %d on an unchanged tick, want %d", l.Status().Seq, seq)
+	}
+}

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"sync"
 	"time"
 
 	"github.com/raskrebs/sonar/internal/docker"
 	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/hoststats"
 	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/state"
 )
@@ -35,6 +37,8 @@ const (
 	HealthCadence = 10 * time.Second
 	// HealthTimeout bounds a single probe.
 	HealthTimeout = 2 * time.Second
+	// HostStatsTimeout bounds one collection of the machine's own load.
+	HostStatsTimeout = 3 * time.Second
 )
 
 // Include is the per-subscriber opt-in from `state.subscribe {include}`.
@@ -54,9 +58,12 @@ type Publisher func(prev, next state.Snapshot, events []state.Event)
 // Options configures a Loop. Only Scan is defaulted; the rest may be zero.
 type Options struct {
 	DaemonVersion string
-	Logger        *slog.Logger
-	Demand        Demand
-	Publish       Publisher
+	// ProtocolVersion is the wire version published on the localhost row of
+	// the `hosts` collection. The daemon sets it; a bare Loop leaves it empty.
+	ProtocolVersion string
+	Logger          *slog.Logger
+	Demand          Demand
+	Publish         Publisher
 
 	// Store persists renames, group pins, known `.sonar.yaml` roots and the
 	// port history ring. Nil means the loop scans without a database.
@@ -72,6 +79,12 @@ type Options struct {
 	// daemon installs it from an OnStart hook, after the loop exists. Nil
 	// publishes an empty collection.
 	Sessions func(ports []state.Port) []state.SessionRecord
+
+	// HostStats collects the machine's own load once per tick — cpu, load,
+	// memory, disk, uptime. Tests inject a fake; production leaves it nil and
+	// gets hoststats.Collect, whose CPU percent is a delta across the scan
+	// interval and therefore needs the same collector every tick.
+	HostStats func(ctx context.Context) (state.Host, error)
 
 	// Scan overrides the OS scan. Tests inject a fake; production leaves it nil
 	// and gets ports.Scan + docker.EnrichPorts + ports.Enrich.
@@ -141,6 +154,9 @@ func New(opts Options) *Loop {
 	}
 	if opts.Probe == nil {
 		opts.Probe = ports.ProbeHealth
+	}
+	if opts.HostStats == nil {
+		opts.HostStats = hoststats.New().Collect
 	}
 	now := opts.Now
 	if now == nil {
@@ -224,6 +240,10 @@ func (l *Loop) Cached() state.Snapshot {
 			Tunnels:       []state.Tunnel{},
 			Proxies:       []state.Proxy{},
 			Sessions:      []state.SessionRecord{},
+			// Even before the first scan `hosts` names this machine: a client
+			// that subscribes at startup must not have to special-case an
+			// empty collection to find localhost.
+			Hosts: []state.Host{l.identityRow()},
 		}
 	}
 	return l.snap
@@ -340,6 +360,9 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 
 	sessionRows := l.sessions(rows)
 
+	// The machine's own load, read outside the mutex: on macOS it forks `ps`.
+	host := l.collectHost()
+
 	// Configured health comes after attribution because it is the groups that
 	// say which port has a `health:` path. It runs on every tick regardless of
 	// `include`: a health path in a `.sonar.yaml` is part of what the service
@@ -364,6 +387,9 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 		l.lastHealthAt = l.lastScanAt
 	}
 
+	host.Ports, host.Groups = len(rows), len(groupRows)
+	host.LastSeen = l.lastScanAt.Format(time.RFC3339)
+
 	next = state.Snapshot{
 		At:            l.lastScanAt.Format(time.RFC3339),
 		DaemonVersion: l.opts.DaemonVersion,
@@ -374,14 +400,31 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 		Tunnels:  []state.Tunnel{},
 		Proxies:  []state.Proxy{},
 		Sessions: sessionRows,
+		// One row until step 3A.2 registers remote hosts.
+		Hosts: []state.Host{host},
 	}
 
 	if l.haveSnap && !snapshotChanged(prev, next, include.Stats) {
-		// Nothing to publish: keep the previous seq and back the interval off.
-		next.Seq = prev.Seq
+		if !hostChanged(prev, next) {
+			// Nothing to publish: keep the previous seq and back the interval
+			// off.
+			next.Seq = prev.Seq
+			l.snap = next
+			l.interval = backoff(l.interval, l.maxIntervalLocked())
+			return next, prev, false, nil
+		}
+		// Only the machine's own load moved. It is published — host load is
+		// state, not an opt-in statistic, so it reaches every subscriber
+		// whatever their `include` (contract §22's rule for configured
+		// health) — but it does not snap the interval back to the base. CPU
+		// percent moves on almost every tick, and letting it reset the
+		// backoff would pin a subscribed daemon to a full port scan every two
+		// seconds forever.
+		l.seq++
+		next.Seq = l.seq
 		l.snap = next
 		l.interval = backoff(l.interval, l.maxIntervalLocked())
-		return next, prev, false, nil
+		return next, prev, true, nil
 	}
 
 	l.seq++
@@ -390,6 +433,46 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	l.haveSnap = true
 	l.interval = BaseInterval
 	return next, prev, true, nil
+}
+
+// collectHost reads this machine's load for the tick. A failure is not a scan
+// failure: the row is published anyway, with the reason attached and every
+// load field null, because `hosts` always names localhost.
+func (l *Loop) collectHost() state.Host {
+	ctx, cancel := context.WithTimeout(context.Background(), HostStatsTimeout)
+	defer cancel()
+
+	h, err := l.opts.HostStats(ctx)
+	if err != nil {
+		l.opts.Logger.Warn("host stats failed", "error", err)
+		reason := err.Error()
+		h.StatusReason = &reason
+	}
+	h.Name, h.Address, h.Status = state.LocalhostName, state.LocalhostName, state.HostConnected
+	h.DaemonVersion, h.ProtocolVersion = l.opts.DaemonVersion, l.opts.ProtocolVersion
+	return h
+}
+
+// identityRow is the localhost row before any load has been collected: who
+// this daemon is, with every measurement still null.
+func (l *Loop) identityRow() state.Host {
+	return state.Host{
+		Name:            state.LocalhostName,
+		Address:         state.LocalhostName,
+		Status:          state.HostConnected,
+		DaemonVersion:   l.opts.DaemonVersion,
+		ProtocolVersion: l.opts.ProtocolVersion,
+		OS:              runtime.GOOS,
+		Arch:            runtime.GOARCH,
+		LastSeen:        l.now().Format(time.RFC3339),
+	}
+}
+
+// hostChanged reports whether the `hosts` collection moved between two
+// snapshots.
+func hostChanged(prev, next state.Snapshot) bool {
+	d := state.DiffHosts(prev.Hosts, next.Hosts)
+	return len(d.Added) > 0 || len(d.Updated) > 0 || len(d.Removed) > 0
 }
 
 // healthDue reports whether the health cadence has elapsed.

--- a/internal/scanner/loop_test.go
+++ b/internal/scanner/loop_test.go
@@ -70,7 +70,8 @@ func TestLoopBacksOffThenSnapsBack(t *testing.T) {
 	rows := []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 100, Process: "node"}}
 
 	l := New(Options{
-		Demand: func() (int, Include) { return 1, Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return 1, Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -103,7 +104,8 @@ func TestLoopBacksOffThenSnapsBack(t *testing.T) {
 // RPC reads only and may back all the way off to 10 s.
 func TestBackoffCapsAtMaxInterval(t *testing.T) {
 	l := New(Options{
-		Demand: func() (int, Include) { return 0, Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return 0, Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 1}}, nil
 		},
@@ -122,7 +124,8 @@ func TestBackoffCapsAtMaxInterval(t *testing.T) {
 func TestBackoffCapsAtFiveSecondsWithASubscriber(t *testing.T) {
 	subs := 0
 	l := New(Options{
-		Demand: func() (int, Include) { return subs, Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return subs, Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 1}}, nil
 		},
@@ -154,7 +157,8 @@ func TestPublishesAddAndRemove(t *testing.T) {
 
 	var published []state.Delta
 	l := New(Options{
-		Demand: func() (int, Include) { return 1, Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return 1, Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -194,7 +198,8 @@ func TestSeqIsMonotonic(t *testing.T) {
 	var mu sync.Mutex
 	n := 0
 	l := New(Options{
-		Demand: func() (int, Include) { return 1, Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return 1, Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -235,7 +240,8 @@ func TestScanErrorKeepsLastGoodState(t *testing.T) {
 	var events []state.Event
 
 	l := New(Options{
-		Demand: func() (int, Include) { return 1, Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return 1, Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			if fail.Load() {
 				return nil, errors.New("lsof: not found")
@@ -272,7 +278,8 @@ func TestScanErrorKeepsLastGoodState(t *testing.T) {
 func TestSnapshotUsesTheCacheWithinTTL(t *testing.T) {
 	var scans atomic.Int64
 	l := New(Options{
-		Demand: func() (int, Include) { return 0, Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return 0, Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			scans.Add(1)
 			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 7}}, nil
@@ -297,7 +304,8 @@ func TestLoopParksWithNoSubscribers(t *testing.T) {
 	var subs atomic.Int64
 
 	l := New(Options{
-		Demand: func() (int, Include) { return int(subs.Load()), Include{} },
+		HostStats: fixedHost,
+		Demand:    func() (int, Include) { return int(subs.Load()), Include{} },
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			scans.Add(1)
 			return nil, nil
@@ -322,4 +330,11 @@ func TestLoopParksWithNoSubscribers(t *testing.T) {
 	if scans.Load() == 0 {
 		t.Fatal("loop did not scan after a subscriber arrived")
 	}
+}
+
+// fixedHost is a host collector that answers the same row every time, so a
+// test's seq and deltas move only when the ports it fakes do. The production
+// collector reports live cpu, which changes on nearly every tick.
+func fixedHost(context.Context) (state.Host, error) {
+	return state.Host{Kernel: "test-kernel", OS: "testos", Arch: "testarch"}, nil
 }

--- a/internal/scanner/sessions_test.go
+++ b/internal/scanner/sessions_test.go
@@ -40,6 +40,7 @@ func TestScanStampsPortSessionAndPublishesTheCollection(t *testing.T) {
 	reg := sessionRegistry{pid: 11, session: agent}
 
 	l := New(Options{
+		HostStats: fixedHost,
 		Scan: func(Include) ([]ports.ListeningPort, error) {
 			return []ports.ListeningPort{
 				{Port: 3000, PID: 11, Process: "python3", Command: "python3 -m http.server"},
@@ -84,7 +85,7 @@ func TestScanStampsPortSessionAndPublishesTheCollection(t *testing.T) {
 // Without a provider the collection is an empty array, never null: the wire
 // shape is fixed whether or not anything owns sessions in this build.
 func TestSnapshotSessionsAreNeverNull(t *testing.T) {
-	l := New(Options{Scan: func(Include) ([]ports.ListeningPort, error) { return nil, nil }})
+	l := New(Options{HostStats: fixedHost, Scan: func(Include) ([]ports.ListeningPort, error) { return nil, nil }})
 	snap, err := l.Snapshot(Include{})
 	if err != nil {
 		t.Fatalf("Snapshot: %v", err)

--- a/internal/state/delta.go
+++ b/internal/state/delta.go
@@ -1,8 +1,8 @@
 package state
 
 // Change is one collection's diff. Added and Updated carry full objects;
-// Removed carries keys (Port.Key() for ports, Name for groups, ID for the
-// rest). All three always marshal as arrays, never null.
+// Removed carries keys (Port.Key() for ports, Name for groups and hosts, ID
+// for the rest). All three always marshal as arrays, never null.
 type Change[T any] struct {
 	Added   []T      `json:"added"`
 	Updated []T      `json:"updated"`
@@ -19,6 +19,7 @@ type Delta struct {
 	Tunnels         Change[Tunnel]        `json:"tunnels"`
 	Proxies         Change[Proxy]         `json:"proxies"`
 	Sessions        Change[SessionRecord] `json:"sessions"`
+	Hosts           Change[Host]          `json:"hosts"`
 }
 
 // Event is a discrete notification, sent alongside deltas when a subscriber

--- a/internal/state/diff.go
+++ b/internal/state/diff.go
@@ -35,7 +35,30 @@ func diff(prev, next Snapshot, withStats bool) Delta {
 		Sessions: diffKeyed(prev.Sessions, next.Sessions,
 			func(s SessionRecord) string { return s.ID },
 			func(a, b SessionRecord) bool { return reflect.DeepEqual(a, b) }),
+		Hosts: DiffHosts(prev.Hosts, next.Hosts),
 	}
+}
+
+// DiffHosts is the `hosts` collection's diff, keyed by name. It is exported
+// because the scanner asks the same question on its own — "did only the
+// machine's load move?" — when it decides whether a tick is worth publishing.
+func DiffHosts(prev, next []Host) Change[Host] {
+	return diffKeyed(prev, next, func(h Host) string { return h.Name }, hostsEqual)
+}
+
+// hostsEqual decides whether a host row changed. Host load is state, not an
+// opt-in statistic: it is compared the same way for Diff and DiffWithStats, so
+// a subscriber that asked for neither stats nor health still sees the machine's
+// cpu and memory move (contract §22's rule for configured health).
+//
+// LastSeen and LatencyMs are excluded for the reason §25 excludes health
+// latency: both move on every tick by construction, and comparing them would
+// publish a `hosts` delta forever on a machine where nothing is happening. The
+// newest values still ride out with the next real change.
+func hostsEqual(a, b Host) bool {
+	a.LastSeen, b.LastSeen = "", ""
+	a.LatencyMs, b.LatencyMs = 0, 0
+	return reflect.DeepEqual(a, b)
 }
 
 // diffPorts keys ports by Key() and treats a PID change as remove + add.

--- a/internal/state/host.go
+++ b/internal/state/host.go
@@ -1,0 +1,67 @@
+package state
+
+// LocalhostName is the reserved name of the machine the daemon runs on. It is
+// always present in Snapshot.Hosts, and every row a client sees without a
+// registered remote host carries it.
+const LocalhostName = "localhost"
+
+// Host status values. localhost is always Connected; the rest describe an SSH
+// bridge to a registered remote host (milestone 3, step 3A.2 onwards).
+const (
+	HostConnecting   = "connecting"
+	HostConnected    = "connected"
+	HostUnreachable  = "unreachable"
+	HostOutdated     = "outdated"
+	HostIncompatible = "incompatible"
+)
+
+// AllHostStatuses is the enum used by schema generation.
+var AllHostStatuses = []string{
+	HostConnecting, HostConnected, HostUnreachable, HostOutdated, HostIncompatible,
+}
+
+// Host is one machine sonar knows about: its identity, the state of the
+// connection to it, and its load. The daemon publishes exactly one Host for
+// itself, named "localhost"; step 3A.2 adds the registered remote hosts.
+//
+// Every load field is a pointer because a platform, or a moment, may not be
+// able to answer:
+//
+//   - CPUPercent is null on the first tick everywhere. It is a delta between
+//     two samples, and one sample is no measurement.
+//   - Load is null on Windows, which has no load average. On Linux and macOS
+//     it is exactly three entries: 1, 5 and 15 minutes.
+//   - UptimeS, Memory* and Disk* are null only when the underlying read fails
+//     (a container with no /proc, a permission error); all three platforms
+//     provide them.
+//   - StatusReason is null while nothing is wrong. For localhost it carries
+//     the collector's error when a tick could not read the machine's load.
+//
+// Kernel is the release string ("6.8.0-40-generic", "25.6.0", "10.0.26100")
+// and is empty, not null, when the platform lookup fails.
+type Host struct {
+	Name            string    `json:"name"`
+	Address         string    `json:"address"`
+	Status          string    `json:"status" jsonschema:"enum=connecting,enum=connected,enum=unreachable,enum=outdated,enum=incompatible"`
+	StatusReason    *string   `json:"status_reason" jsonschema:"nullable"`
+	DaemonVersion   string    `json:"daemon_version"`
+	ProtocolVersion string    `json:"protocol_version"`
+	LatencyMs       int64     `json:"latency_ms"`
+	OS              string    `json:"os"`
+	Arch            string    `json:"arch"`
+	Kernel          string    `json:"kernel"`
+	UptimeS         *int64    `json:"uptime_s" jsonschema:"nullable"`
+	CPUPercent      *float64  `json:"cpu_percent" jsonschema:"nullable"`
+	Load            []float64 `json:"load" jsonschema:"nullable"`
+	MemoryUsed      *int64    `json:"memory_used_bytes" jsonschema:"nullable"`
+	MemoryTotal     *int64    `json:"memory_total_bytes" jsonschema:"nullable"`
+	DiskUsed        *int64    `json:"disk_used_bytes" jsonschema:"nullable"`
+	DiskTotal       *int64    `json:"disk_total_bytes" jsonschema:"nullable"`
+	DiskPath        string    `json:"disk_path"`
+	Ports           int       `json:"ports"`
+	Groups          int       `json:"groups"`
+	LastSeen        string    `json:"last_seen"`
+}
+
+// Key is the delta identity: the host name.
+func (h Host) Key() string { return h.Name }

--- a/internal/state/host_test.go
+++ b/internal/state/host_test.go
@@ -1,0 +1,126 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func hostRow(name string) Host {
+	return Host{
+		Name: name, Address: name, Status: HostConnected,
+		DaemonVersion: "0.5.1", ProtocolVersion: "1.0.0",
+		OS: "linux", Arch: "amd64", Kernel: "6.8.0-40-generic",
+		UptimeS: i64(93607), CPUPercent: f64(12.4),
+		Load:       []float64{1.24, 0.98, 0.71},
+		MemoryUsed: i64(9 << 30), MemoryTotal: i64(32 << 30),
+		DiskUsed: i64(412 << 30), DiskTotal: i64(931 << 30), DiskPath: "/",
+		Ports: 6, Groups: 2, LastSeen: "2026-09-06T10:00:00Z",
+	}
+}
+
+func i64(v int64) *int64     { return &v }
+func f64(v float64) *float64 { return &v }
+
+// Hosts are keyed by name, so the same machine reporting new load is an update
+// and never an add-plus-remove.
+func TestDiffKeysHostsByName(t *testing.T) {
+	prev := Snapshot{Hosts: []Host{hostRow("localhost"), hostRow("hetzner")}}
+	next := Snapshot{Hosts: []Host{hostRow("localhost")}}
+	next.Hosts[0].CPUPercent = f64(80)
+
+	d := Diff(prev, next)
+	if len(d.Hosts.Updated) != 1 || d.Hosts.Updated[0].Name != "localhost" {
+		t.Fatalf("updated = %+v, want the localhost row", d.Hosts.Updated)
+	}
+	if len(d.Hosts.Removed) != 1 || d.Hosts.Removed[0] != "hetzner" {
+		t.Fatalf("removed = %v, want [hetzner]", d.Hosts.Removed)
+	}
+	if len(d.Hosts.Added) != 0 {
+		t.Fatalf("added = %+v, want none", d.Hosts.Added)
+	}
+}
+
+// Host load is state, not an opt-in statistic: a stats-only change is an
+// update for a subscriber that asked for stats and for one that did not, so
+// the machine's load reaches every client (contract §22's rule for configured
+// health).
+func TestHostStatsChangeIsNotGatedByInclude(t *testing.T) {
+	prev := Snapshot{Hosts: []Host{hostRow("localhost")}}
+	next := Snapshot{Hosts: []Host{hostRow("localhost")}}
+	next.Hosts[0].CPUPercent = f64(80)
+	next.Hosts[0].MemoryUsed = i64(11 << 30)
+
+	for name, d := range map[string]Delta{
+		"Diff":          Diff(prev, next),
+		"DiffWithStats": DiffWithStats(prev, next),
+	} {
+		if len(d.Hosts.Updated) != 1 {
+			t.Errorf("%s published %d host updates, want 1", name, len(d.Hosts.Updated))
+			continue
+		}
+		if got := *d.Hosts.Updated[0].CPUPercent; got != 80 {
+			t.Errorf("%s published cpu_percent %v, want 80", name, got)
+		}
+	}
+}
+
+// last_seen and latency move on every tick by construction. Comparing them
+// would publish a `hosts` delta forever on a machine where nothing happens —
+// the reason §25 keeps health latency out of the port comparison.
+func TestDiffIgnoresLastSeenAndLatencyAlone(t *testing.T) {
+	prev := Snapshot{Hosts: []Host{hostRow("localhost")}}
+	next := Snapshot{Hosts: []Host{hostRow("localhost")}}
+	next.Hosts[0].LastSeen = "2026-09-06T10:00:02Z"
+	next.Hosts[0].LatencyMs = 37
+
+	if d := Diff(prev, next); len(d.Hosts.Updated) != 0 {
+		t.Fatalf("a tick that only moved the clock published %+v", d.Hosts.Updated)
+	}
+
+	// A real change carries the newest clock and latency out with it.
+	next.Hosts[0].CPUPercent = f64(80)
+	d := Diff(prev, next)
+	if len(d.Hosts.Updated) != 1 {
+		t.Fatalf("updated = %+v, want one row", d.Hosts.Updated)
+	}
+	if d.Hosts.Updated[0].LastSeen != "2026-09-06T10:00:02Z" || d.Hosts.Updated[0].LatencyMs != 37 {
+		t.Errorf("the published row lost its newest clock: %+v", d.Hosts.Updated[0])
+	}
+}
+
+// Every collection marshals as an array, never null (contract §5).
+func TestHostChangeMarshalsAsArrays(t *testing.T) {
+	raw, err := json.Marshal(Diff(Snapshot{}, Snapshot{}).Hosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(raw); got != `{"added":[],"updated":[],"removed":[]}` {
+		t.Errorf("empty host change = %s", got)
+	}
+}
+
+// Nullable fields are null on the wire, not zero: a machine whose load could
+// not be read must not look idle.
+func TestHostNullsSurviveJSON(t *testing.T) {
+	raw, err := json.Marshal(Host{Name: LocalhostName})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{
+		"status_reason", "uptime_s", "cpu_percent", "load",
+		"memory_used_bytes", "memory_total_bytes", "disk_used_bytes", "disk_total_bytes",
+	} {
+		v, ok := got[key]
+		if !ok {
+			t.Errorf("%s is absent; it must be present and null", key)
+			continue
+		}
+		if v != nil {
+			t.Errorf("%s = %v, want null", key, v)
+		}
+	}
+}

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -1,7 +1,9 @@
 package state
 
 // Snapshot is the full published state at one sequence number. Contract §5
-// fixes the five collections and the top-level ExposuresActive counter.
+// fixes the five collections and the top-level ExposuresActive counter; the
+// remote-hosts design adds a sixth, `hosts`, which always carries at least the
+// daemon's own machine.
 type Snapshot struct {
 	Seq             uint64          `json:"seq"`
 	At              string          `json:"at"`
@@ -12,4 +14,5 @@ type Snapshot struct {
 	Tunnels         []Tunnel        `json:"tunnels"`
 	Proxies         []Proxy         `json:"proxies"`
 	Sessions        []SessionRecord `json:"sessions"`
+	Hosts           []Host          `json:"hosts"`
 }


### PR DESCRIPTION
Roadmap step 3A.1 (milestone 3).

- `state.Host` (name, address, status, versions, latency, os/arch/kernel, uptime, cpu_percent, load, memory, disk, counts, last_seen); `Snapshot.hosts` and `Delta.hosts` keyed by name, `localhost` always present.
- `internal/hoststats`: Linux from `/proc` and statfs; macOS from sysctl plus a per-pid `ps` CPU diff (Mach host statistics need cgo, and `kern.proc` CPU fields are zero on XNU); Windows from `GetSystemTimes`, `GlobalMemoryStatusEx`, `GetTickCount64` and `GetDiskFreeSpaceEx`. No new dependencies, `CGO_ENABLED=0` kept.
- Collected once per scan tick outside the lock, published to every subscriber regardless of `include`; a host-only change sends one delta and does not reset the scan backoff.
- `sonar host` (needs the daemon, which holds the previous CPU sample).
- Schema regenerated.