### PR TITLE
fix: serialize scans so a rename cannot be reverted by a tick that started before it

### DIFF
--- a/internal/cmd/terminal_windows.go
+++ b/internal/cmd/terminal_windows.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	kernel32                       = syscall.NewLazyDLL("kernel32.dll")
-	procGetConsoleMode             = kernel32.NewProc("GetConsoleMode")
-	procSetConsoleMode             = kernel32.NewProc("SetConsoleMode")
+	kernel32                               = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleMode                     = kernel32.NewProc("GetConsoleMode")
+	procSetConsoleMode                     = kernel32.NewProc("SetConsoleMode")
 	enableVirtualTerminalProcessing uint32 = 0x0004
 )
 

--- a/internal/daemon/client/subscribe.go
+++ b/internal/daemon/client/subscribe.go
@@ -44,12 +44,16 @@ type Subscription struct {
 	// for.
 	Events <-chan state.Event
 
-	c       *Client
-	deltas  chan state.Delta
-	events  chan state.Event
-	once    sync.Once
-	dropped bool
+	c      *Client
+	deltas chan state.Delta
+	events chan state.Event
+
+	// mu makes delivery and close mutually exclusive: the read loop must not
+	// send on a channel that Unsubscribe (or a dropped connection) is closing
+	// at the same moment.
 	mu      sync.Mutex
+	closed  bool
+	dropped bool
 }
 
 // Subscribe registers for state deltas. The returned Subscription carries the
@@ -117,17 +121,23 @@ func (s *Subscription) remove() {
 }
 
 func (s *Subscription) close() {
-	s.once.Do(func() {
-		close(s.deltas)
-		if s.events != nil {
-			close(s.events)
-		}
-	})
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	close(s.deltas)
+	if s.events != nil {
+		close(s.events)
+	}
 }
 
 // deliver routes one notification onto the right channel. A full channel drops
 // the message and sets Dropped rather than blocking the read loop, which would
-// stall every other call on this connection.
+// stall every other call on this connection. The sends hold s.mu so they cannot
+// race a concurrent close; they are non-blocking, so holding it cannot stall
+// the read loop either.
 func (s *Subscription) deliver(msg rpc.Message) {
 	switch msg.Method {
 	case rpc.MethodStateDelta:
@@ -135,10 +145,15 @@ func (s *Subscription) deliver(msg rpc.Message) {
 		if err := json.Unmarshal(msg.Params, &d); err != nil {
 			return
 		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.closed {
+			return
+		}
 		select {
 		case s.deltas <- d:
 		default:
-			s.markDropped()
+			s.dropped = true
 		}
 	case rpc.MethodStateEvent:
 		if s.events == nil {
@@ -148,16 +163,15 @@ func (s *Subscription) deliver(msg rpc.Message) {
 		if err := json.Unmarshal(msg.Params, &e); err != nil {
 			return
 		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.closed {
+			return
+		}
 		select {
 		case s.events <- e:
 		default:
-			s.markDropped()
+			s.dropped = true
 		}
 	}
-}
-
-func (s *Subscription) markDropped() {
-	s.mu.Lock()
-	s.dropped = true
-	s.mu.Unlock()
 }

--- a/internal/daemon/client/subscribe_test.go
+++ b/internal/daemon/client/subscribe_test.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// TestDeliverRacesClose pins the fix for the panic PR #68 hit in CI: the read
+// loop delivers a notification while the consumer unsubscribes, and the
+// delivery must not send on the channels close() has just closed.
+func TestDeliverRacesClose(t *testing.T) {
+	delta := rpc.Message{Method: rpc.MethodStateDelta, Params: json.RawMessage(`{"seq":1}`)}
+	event := rpc.Message{Method: rpc.MethodStateEvent, Params: json.RawMessage(`{"kind":"port_up"}`)}
+
+	for i := 0; i < 200; i++ {
+		s := &Subscription{
+			deltas: make(chan state.Delta, 1),
+			events: make(chan state.Event, 1),
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("deliver panicked against a concurrent close: %v", r)
+				}
+			}()
+			for j := 0; j < 50; j++ {
+				s.deliver(delta)
+				s.deliver(event)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			s.close()
+		}()
+		wg.Wait()
+
+		// close is idempotent, and a delivery after it is a no-op.
+		s.close()
+		s.deliver(delta)
+	}
+}
+
+// TestDeliverDropsWhenFull keeps the Dropped() contract: a full channel drops
+// the message instead of blocking the read loop.
+func TestDeliverDropsWhenFull(t *testing.T) {
+	s := &Subscription{deltas: make(chan state.Delta, 1)}
+	msg := rpc.Message{Method: rpc.MethodStateDelta, Params: json.RawMessage(`{"seq":1}`)}
+
+	s.deliver(msg)
+	if s.Dropped() {
+		t.Fatal("a delivery into a free buffer must not count as dropped")
+	}
+	if len(s.deltas) != 1 {
+		t.Fatalf("want 1 buffered delta, got %d", len(s.deltas))
+	}
+
+	s.deliver(msg)
+	if !s.Dropped() {
+		t.Fatal("a delivery into a full buffer must set Dropped")
+	}
+}
+
+// TestDeliverAfterCloseIsQuiet makes sure a late notification is dropped
+// silently rather than panicking or being counted as a dropped message.
+func TestDeliverAfterCloseIsQuiet(t *testing.T) {
+	s := &Subscription{
+		deltas: make(chan state.Delta, 1),
+		events: make(chan state.Event, 1),
+	}
+	s.close()
+	s.deliver(rpc.Message{Method: rpc.MethodStateDelta, Params: json.RawMessage(`{"seq":1}`)})
+	s.deliver(rpc.Message{Method: rpc.MethodStateEvent, Params: json.RawMessage(`{"kind":"port_up"}`)})
+	if s.Dropped() {
+		t.Fatal("a notification after close is not a dropped message")
+	}
+}

--- a/internal/daemon/handlers_store.go
+++ b/internal/daemon/handlers_store.go
@@ -160,12 +160,20 @@ func handleConfigPath(_ context.Context, _ *Request) (any, error) {
 	return rpc.ConfigPathResult{Path: config.Path()}, nil
 }
 
-// republish makes a write visible immediately: the cached scan is dropped and
-// a fresh one is published, so the delta carrying the new name reaches
-// subscribers before the caller's own next `sonar list`.
+// republish makes a write visible before its own reply is. It scans and
+// publishes synchronously, so by the time the handler returns the delta
+// carrying the change is already queued on every subscriber's connection —
+// ahead of this call's response, which the same writer queues afterwards —
+// and the caller's own next read is served from a snapshot that has it.
+//
+// Contract §18 only asks that a rename or an assign take effect "in the next
+// publish", with an immediate rescan so the caller sees it. Replying *after*
+// that publish is what turns "the next delta carries the rename" from a race
+// into a guarantee: a subscriber cannot receive the acknowledgement before the
+// delta that justifies it, and a client that reads straight after the reply
+// cannot be served the state from before its own write.
 func republish(rt *Runtime) {
-	rt.Scanner.Invalidate()
-	if _, err := rt.Scanner.Snapshot(scanner.Include{}); err != nil {
+	if _, err := rt.Scanner.Rescan(scanner.Include{}); err != nil {
 		rt.Logger.Warn("rescanning after a write", "error", err)
 	}
 }

--- a/internal/daemon/handlers_store_test.go
+++ b/internal/daemon/handlers_store_test.go
@@ -47,8 +47,9 @@ func TestRenameShowsUpInTheNextDelta(t *testing.T) {
 		t.Fatalf("first delta = %+v, want the unrenamed port", first.Ports)
 	}
 
-	// The rescan the write triggers publishes before the reply is written, so
-	// the delta and the response have to be collected together.
+	// The rescan the write triggers publishes before the reply is written
+	// (contract §18, see republish), so the delta and the response have to be
+	// collected together.
 	res, delta := c.renameCollectingDelta(t, rpc.PortsRenameParams{
 		Selector: rpc.Selector{Port: intp(8123)}, Name: strp("storefront"),
 	})
@@ -342,7 +343,17 @@ func TestWritesWithoutADatabaseFail(t *testing.T) {
 }
 
 // renameCollectingDelta sends ports.rename and returns both its result and the
-// state.delta the write triggered, which arrives first.
+// state.delta that carried the rename, which the daemon publishes before it
+// writes the reply (contract §18, see republish).
+//
+// It keeps the last delta that actually moved a port, not the last delta of any
+// kind. `hosts` carries this machine's own cpu, load and memory, so a
+// subscribed connection gets a delta on ticks where no port changed at all, and
+// one of those can land between the rename's delta and the reply. Asserting on
+// whichever delta happened to arrive last made this test read a load-only
+// notification and call the rename missing; the last port-moving delta before
+// the reply is the thing §18 actually promises, and it also catches a later
+// delta putting the old name back.
 func (c *testClient) renameCollectingDelta(t *testing.T, p rpc.PortsRenameParams) (rpc.PortsRenameResult, state.Delta) {
 	t.Helper()
 	id := c.send("ports.rename", p)
@@ -355,10 +366,14 @@ func (c *testClient) renameCollectingDelta(t *testing.T, p rpc.PortsRenameParams
 		m := c.read()
 		switch {
 		case m.IsNotification() && m.Method == rpc.MethodStateDelta:
-			if err := json.Unmarshal(m.Params, &delta); err != nil {
+			var d state.Delta
+			if err := json.Unmarshal(m.Params, &d); err != nil {
 				t.Fatalf("decoding state.delta: %v", err)
 			}
-			seen = true
+			if len(d.Ports.Added)+len(d.Ports.Updated)+len(d.Ports.Removed) == 0 {
+				continue
+			}
+			delta, seen = d, true
 		case m.IsResponse() && string(m.ID) == id:
 			if m.Error != nil {
 				t.Fatalf("ports.rename: %v", m.Error)
@@ -371,6 +386,6 @@ func (c *testClient) renameCollectingDelta(t *testing.T, p rpc.PortsRenameParams
 			}
 		}
 	}
-	t.Fatal("no state.delta followed the rename")
+	t.Fatal("no state.delta carrying a port change followed the rename")
 	return res, delta
 }

--- a/internal/daemon/kill_handlers.go
+++ b/internal/daemon/kill_handlers.go
@@ -112,8 +112,7 @@ func afterKill(req *Request, dryRun bool) {
 // A kill is rare and deliberate; one scan is the right price for acting on what
 // is listening now.
 func killSnapshot(req *Request) (state.Snapshot, error) {
-	req.Runtime.Scanner.Invalidate()
-	snap, err := req.Runtime.Scanner.Snapshot(scanner.Include{})
+	snap, err := req.Runtime.Scanner.Rescan(scanner.Include{})
 	if err != nil {
 		return state.Snapshot{}, rpc.NewError(rpc.CodeInternal, "scan failed: "+err.Error(),
 			"check `sonar daemon log` for the scanner error")

--- a/internal/docker/graph.go
+++ b/internal/docker/graph.go
@@ -36,9 +36,9 @@ func BuildDockerGraph(listening []ports.ListeningPort) ([]ports.Connection, erro
 	}
 
 	// Build container name → host port and display name mappings
-	containerHostPort := make(map[string]int)        // first host port per container
-	containerDisplay := make(map[string]string)       // display name per container
-	containerPortMap := make(map[string]map[int]int)  // container: containerPort→hostPort
+	containerHostPort := make(map[string]int)           // first host port per container
+	containerDisplay := make(map[string]string)         // display name per container
+	containerPortMap := make(map[string]map[int]int)    // container: containerPort→hostPort
 	containerListening := make(map[string]map[int]bool) // container: set of listening container ports
 	for _, lp := range dockerPorts {
 		name := lp.DockerContainer

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -123,6 +123,19 @@ type Loop struct {
 
 	attr attribution
 
+	// scanMu serializes a whole scan — the OS call, the attribution that
+	// reads the store, the commit into the cache and the publish — against
+	// every other scan. Without it only the commit was serialized, and two
+	// scans could overlap: the tick a read woke could load the rename table
+	// *before* `ports.rename` wrote to it and still commit *after* the
+	// rescan the write triggered, overwriting the renamed snapshot with the
+	// stale one and publishing a delta that put the old display_name back.
+	// Holding it end to end makes the rule "a scan that starts after a write
+	// sees it, and a scan that started before one can never land after it"
+	// true by construction, and keeps delta seq order the same as publish
+	// order.
+	scanMu sync.Mutex
+
 	mu           sync.Mutex
 	subs         int
 	snap         state.Snapshot
@@ -303,8 +316,11 @@ func (l *Loop) Run(ctx context.Context) {
 }
 
 // scanAndPublish runs one scan, updates the cache, adapts the interval and
-// publishes when something changed.
+// publishes when something changed. One scan at a time (see scanMu).
 func (l *Loop) scanAndPublish(include Include) {
+	l.scanMu.Lock()
+	defer l.scanMu.Unlock()
+
 	next, prev, changed, err := l.scanLocked(include)
 	if err != nil {
 		l.opts.Logger.Warn("scan failed, keeping last good state", "error", err)
@@ -594,19 +610,37 @@ func (l *Loop) nowRFC3339() string { return l.now().Format(time.RFC3339) }
 // caller asked for; otherwise it scans now. Either way it wakes the loop, so
 // reading state snaps the interval back to the base (spec, "Scanner loop").
 func (l *Loop) Snapshot(include Include) (state.Snapshot, error) {
-	l.mu.Lock()
-	fresh := l.haveSnap && l.now().Sub(l.lastScanAt) < CacheTTL
-	covers := !include.Stats || l.snapHasStats()
-	snap := l.snap
-	l.mu.Unlock()
-
 	defer l.Wake()
 
-	if fresh && covers {
+	if snap, ok := l.cached(include); ok {
 		return snap, nil
 	}
+	return l.scanNow(include)
+}
 
-	next, prev, changed, err := l.scanLocked(include)
+// Rescan scans now whatever the cache says, publishes the change it finds and
+// only then returns. It is what a write path calls: `ports.rename`,
+// `groups.assign` and the group config writes need the delta carrying the
+// change to be on the wire before their own reply is (contract §18), and a
+// kill needs its selectors resolved against what is listening this instant.
+//
+// It is not Invalidate + Snapshot. That pair has a window between the two
+// calls: a tick landing in it refreshes lastScanAt from a scan that began
+// before the write, Snapshot then finds the cache "fresh" and serves it, and
+// the write reaches no one until the next tick — up to SubscribedMaxInterval
+// later. Rescan closes the window by holding scanMu across both halves.
+func (l *Loop) Rescan(include Include) (state.Snapshot, error) {
+	defer l.Wake()
+	return l.scanNow(include)
+}
+
+// scanNow is the uncached half of both: one scan under scanMu, published
+// before it returns.
+func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
+	l.scanMu.Lock()
+	defer l.scanMu.Unlock()
+
+	next, prev, changed, err := l.scanLocked(l.withDemand(include))
 	if err != nil {
 		if prev.Seq > 0 {
 			// A failed rescan still serves the last good state.
@@ -618,6 +652,29 @@ func (l *Loop) Snapshot(include Include) (state.Snapshot, error) {
 		l.publish(prev, next, deriveEvents(prev, next, l.nowRFC3339()))
 	}
 	return next, nil
+}
+
+// cached returns the cached snapshot when it is younger than CacheTTL and
+// already carries everything the caller asked for.
+func (l *Loop) cached(include Include) (state.Snapshot, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fresh := l.haveSnap && l.now().Sub(l.lastScanAt) < CacheTTL
+	covers := !include.Stats || l.snapHasStats()
+	return l.snap, fresh && covers
+}
+
+// withDemand widens an RPC caller's include with what the subscribers want.
+// A scan started by a read is published like any other, so it has to collect
+// what a tick would: without this a `sonar list` in the middle of a subscribed
+// session would publish a snapshot with the stats stripped out, and every
+// subscriber that opted into them would see them blink away and back.
+func (l *Loop) withDemand(include Include) Include {
+	_, want := l.opts.Demand()
+	return Include{
+		Stats:  include.Stats || want.Stats,
+		Health: include.Health || want.Health,
+	}
 }
 
 // snapHasStats reports whether the cached snapshot carries stats. Caller holds


### PR DESCRIPTION
Scans now run under one mutex end-to-end (scan, attribute, commit, publish), so a tick that started before a rename or assign can no longer commit after the handler and revert it. `republish` and `killSnapshot` use a new `Rescan` that always scans and publishes before returning, replacing the racy `Invalidate` + `Snapshot` pair. The rename test now ignores host-load-only deltas.