### PR TITLE
feat: bridge to registered ssh hosts and multiplex their state into the local stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,9 +431,9 @@ The daemon measures its own machine on the scan cadence and publishes it as the
 percent, load average, memory and the disk holding `/`. CPU percent is the work
 done between two scans, so it is null until the daemon has scanned twice; a
 figure a platform cannot produce — the load average on Windows, which has none —
-is null rather than zero. Registered remote hosts join the same table in
-milestone 3. The command needs a running daemon: it is the daemon that holds the
-previous sample a percentage is measured against.
+is null rather than zero. Every host registered with `sonar remote add` joins
+the same table with its own load. The command needs a running daemon: it is the
+daemon that holds the previous sample a percentage is measured against.
 
 ### `sonar remote install`
 
@@ -458,6 +458,40 @@ the daemon, which is what makes an install and an update the same command.
 The target goes to `ssh` untouched: a `Host` alias from `~/.ssh/config` works,
 and so do the `ProxyJump`, `IdentityFile` and `Port` it sets. `--identity` and
 `--ssh-arg` are there for the flags a config does not cover.
+
+### `sonar remote`
+
+```sh
+sonar remote add deploy@203.0.113.7            # name taken from the target
+sonar remote add hetzner deploy@203.0.113.7    # or given
+sonar remote list                              # status, latency, version, load
+sonar remote remove hetzner
+
+sonar list --host hetzner                      # that host's ports
+sonar info 3000 --host hetzner
+```
+
+A registered host runs the same daemon, and the daemon on this machine keeps
+one SSH connection to it — `ssh <target> sonar daemon stdio` — and multiplexes
+what it reports into the state every client already reads. Nothing new listens
+anywhere: the remote daemon's socket stays private to the SSH user, and clients
+never speak SSH themselves.
+
+Every row now carries the host it came from. Local rows say `localhost` and
+keep the keys they always had, so nothing that reads sonar today changes;
+remote rows say the registered name and are keyed `<host>/<port>:<bind>`, which
+is what lets port 3000 on two machines be two rows. A subscriber sees only
+localhost unless it asks for more (`state.subscribe {"hosts": ["*"]}`).
+
+The target goes to `ssh` untouched, so `~/.ssh/config` aliases, `ProxyJump` and
+identities all apply; `--ssh-arg`, `--identity` and `--port` cover what a config
+does not. sonar stores no password and no key. A host that goes away keeps its
+row and its status while the daemon retries, backing off from one second to
+thirty for as long as it stays registered.
+
+`--host` also still takes a bare `user@host` that sonar knows nothing about: it
+falls back to the agentless `ssh` + `ss`/`lsof` scan and prints a hint to
+`sonar remote install`.
 
 ### The daemon
 

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -599,6 +599,9 @@
     },
     "Event": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "kind": {
           "type": "string"
         },
@@ -870,6 +873,9 @@
     },
     "Group": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -920,6 +926,7 @@
       },
       "type": "object",
       "required": [
+        "host",
         "name",
         "source",
         "root_dir",
@@ -1150,6 +1157,9 @@
     },
     "GroupsInspectResult": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -1206,6 +1216,7 @@
       },
       "type": "object",
       "required": [
+        "host",
         "name",
         "source",
         "root_dir",
@@ -1842,6 +1853,9 @@
     },
     "Port": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "port": {
           "type": "integer"
         },
@@ -2032,6 +2046,7 @@
       },
       "type": "object",
       "required": [
+        "host",
         "port",
         "bind_address",
         "ip_version",
@@ -2505,6 +2520,9 @@
     },
     "Proxy": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "id": {
           "type": "string"
         },
@@ -2535,6 +2553,7 @@
       },
       "type": "object",
       "required": [
+        "host",
         "id",
         "service_port",
         "listen_port",
@@ -2545,6 +2564,69 @@
         "connections",
         "requests"
       ]
+    },
+    "RemoteAddParams": {
+      "properties": {
+        "target": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "ssh_args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "identity": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "remote_bin": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "target"
+      ]
+    },
+    "RemoteAddResult": {
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "host": {
+          "$ref": "#/definitions/Host"
+        }
+      },
+      "type": "object",
+      "required": [
+        "ok",
+        "host"
+      ]
+    },
+    "RemoteCallParams": {
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": true
+      },
+      "type": "object",
+      "required": [
+        "host",
+        "method"
+      ]
+    },
+    "RemoteCallResult": {
+      "description": "The remote daemon's own result for `method`, returned verbatim."
     },
     "RemoteInstallChunk": {
       "properties": {
@@ -2654,6 +2736,31 @@
         "ok",
         "affected",
         "subscription_id"
+      ]
+    },
+    "RemoteListResult": {
+      "properties": {
+        "hosts": {
+          "items": {
+            "$ref": "#/definitions/Host"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "hosts"
+      ]
+    },
+    "RemoteRemoveParams": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name"
       ]
     },
     "RemoteScanParams": {
@@ -3142,6 +3249,9 @@
         "detected": {
           "type": "boolean"
         },
+        "host": {
+          "type": "string"
+        },
         "first_seen": {
           "type": "string"
         },
@@ -3169,6 +3279,7 @@
         "worktree",
         "branch",
         "detected",
+        "host",
         "first_seen",
         "last_seen",
         "runs",
@@ -3324,6 +3435,12 @@
       "properties": {
         "include": {
           "$ref": "#/definitions/Include"
+        },
+        "hosts": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -3335,6 +3452,12 @@
         },
         "events": {
           "type": "boolean"
+        },
+        "hosts": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -3422,6 +3545,9 @@
     },
     "Tunnel": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "id": {
           "type": "string"
         },
@@ -3494,6 +3620,7 @@
       },
       "type": "object",
       "required": [
+        "host",
         "id",
         "target_port",
         "target_group",
@@ -3856,6 +3983,22 @@
         "$ref": "#/definitions/PortsWaitEnd"
       }
     },
+    "remote.add": {
+      "params": {
+        "$ref": "#/definitions/RemoteAddParams"
+      },
+      "result": {
+        "$ref": "#/definitions/RemoteAddResult"
+      }
+    },
+    "remote.call": {
+      "params": {
+        "$ref": "#/definitions/RemoteCallParams"
+      },
+      "result": {
+        "$ref": "#/definitions/RemoteCallResult"
+      }
+    },
     "remote.install": {
       "params": {
         "$ref": "#/definitions/RemoteInstallParams"
@@ -3868,6 +4011,22 @@
       },
       "stream_end": {
         "$ref": "#/definitions/RemoteInstallEnd"
+      }
+    },
+    "remote.list": {
+      "params": {
+        "$ref": "#/definitions/Empty"
+      },
+      "result": {
+        "$ref": "#/definitions/RemoteListResult"
+      }
+    },
+    "remote.remove": {
+      "params": {
+        "$ref": "#/definitions/RemoteRemoveParams"
+      },
+      "result": {
+        "$ref": "#/definitions/OKResult"
       }
     },
     "remote.scan": {

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -2570,6 +2570,9 @@
         "target": {
           "type": "string"
         },
+        "host": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },

--- a/internal/cmd/daemon_stdio.go
+++ b/internal/cmd/daemon_stdio.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"syscall"
+
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/spf13/cobra"
+)
+
+var daemonStdioNoAutostart bool
+
+var daemonStdioCmd = &cobra.Command{
+	Use:   "stdio",
+	Short: "Serve the daemon protocol over stdin/stdout",
+	Long: `Serve the daemon's JSON-RPC protocol over this process's stdin and stdout.
+
+The framing and the methods are identical to the socket: one JSON message per
+line, the same daemon.hello handshake, the same state.subscribe stream. It is
+the far end of a remote host's bridge, which the local daemon opens as
+
+  ssh <host> sonar daemon stdio
+
+and then drives with the ordinary client. Nothing new listens anywhere: the
+daemon's socket stays 0600 to the SSH user, and this process is the only thing
+that reaches it.
+
+It connects to the daemon already running on this machine, starting one with
+` + "`sonar serve --detach`" + ` if there is none, so a bridge shares state with
+the CLI, the tray and the desktop app on the same host rather than running a
+second scanner beside them.`,
+	Args: cobra.NoArgs,
+	RunE: runDaemonStdio,
+}
+
+func init() {
+	daemonStdioCmd.Flags().BoolVar(&daemonStdioNoAutostart, "no-autostart", false,
+		"Fail instead of starting a daemon when none is running")
+	daemonCmd.AddCommand(daemonStdioCmd)
+}
+
+func runDaemonStdio(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	socket := daemon.SocketPath()
+
+	conn, err := daemon.Dial(socket)
+	if err != nil {
+		if daemonStdioNoAutostart {
+			return fmt.Errorf("%w (socket %s)", client.ErrNotRunning, socket)
+		}
+		if err := client.Autostart(cmd.Context(), "", socket); err != nil {
+			return err
+		}
+		conn, err = daemon.Dial(socket)
+		if err != nil {
+			return fmt.Errorf("%w: started it but could not connect to %s: %v",
+				client.ErrNotRunning, socket, err)
+		}
+	}
+	defer conn.Close()
+
+	return pump(conn, os.Stdin, os.Stdout)
+}
+
+// pump copies bytes between the pipes and the socket until either side closes.
+// It parses nothing: the protocol on the socket is the protocol on the wire,
+// so a method this build has never heard of still works across the bridge.
+func pump(conn net.Conn, in io.Reader, out io.Writer) error {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(conn, in)
+		// Our stdin ended: tell the daemon so it can finish what it is writing
+		// and close, rather than waiting on a peer that is gone.
+		if cw, ok := conn.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		} else {
+			_ = conn.Close()
+		}
+	}()
+
+	_, err := io.Copy(out, conn)
+	<-done
+	if err != nil && !isClosedPipe(err) {
+		return err
+	}
+	return nil
+}
+
+// isClosedPipe reports whether an error is the ordinary end of a bridge: the
+// far side hung up, or our own stdout went away because ssh exited. Neither is
+// worth a non-zero exit status.
+func isClosedPipe(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.EPIPE)
+}

--- a/internal/cmd/host.go
+++ b/internal/cmd/host.go
@@ -23,8 +23,9 @@ var hostCmd = &cobra.Command{
 	Short: "Show the machine sonar is watching and its load",
 	Long: `Show the hosts sonar knows about: their cpu, load average, memory and disk.
 
-Today that is this machine, published as ` + "`localhost`" + `. Registered remote
-hosts join the same table in milestone 3.
+This machine is published as ` + "`localhost`" + `; every host registered with
+` + "`sonar remote add`" + ` joins the same table with its own load and the state of
+its connection.
 
 Examples:
   sonar host          # the table

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -29,7 +29,19 @@ var infoCmd = &cobra.Command{
 		bindIP, _ := cmd.Flags().GetString("ip")
 
 		var lp *ports.ListeningPort
-		if infoHost != "" {
+		if c := routeRemote(cmd.Context(), infoHost); c != nil {
+			defer c.Close()
+			var res rpc.PortsInspectResult
+			err := remoteCall(cmd.Context(), c, infoHost, "ports.inspect", rpc.Selector{
+				Port:        &port,
+				BindAddress: strPtrOrNil(bindIP),
+			}, &res)
+			if err != nil {
+				return err
+			}
+			remote := state.ToListening(res.Port)
+			lp = &remote
+		} else if infoHost != "" {
 			all, scanErr := ports.ScanRemote(infoHost)
 			if scanErr != nil {
 				return scanErr
@@ -179,7 +191,12 @@ func printField(label, value string) {
 }
 
 func init() {
-	infoCmd.Flags().String("host", "", "Query a remote host via SSH (e.g. user@hostname)")
+	infoCmd.Flags().String("host", "",
+		"Read a registered `host` through the daemon, or query any user@hostname over SSH")
+	_ = infoCmd.RegisterFlagCompletionFunc("host",
+		func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return remoteHostNames(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+		})
 	infoCmd.Flags().String("ip", "", "Specify bind address when a port is bound to multiple IPs")
 	rootCmd.AddCommand(infoCmd)
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -51,7 +51,12 @@ func init() {
 	listCmd.Flags().BoolVar(&allColumnsFlag, "all-columns", false, "Display all available columns")
 	listCmd.Flags().BoolVar(&healthFlag, "health", false, "Run HTTP health checks on each port")
 	listCmd.Flags().BoolVar(&statsFlag, "stats", false, "Include resource stats (CPU, memory, threads, uptime, state)")
-	listCmd.Flags().StringVar(&hostFlag, "host", "", "Scan a remote host via SSH (e.g. user@hostname)")
+	listCmd.Flags().StringVar(&hostFlag, "host", "",
+		"Read a registered `host` through the daemon, or scan any user@hostname over SSH")
+	_ = listCmd.RegisterFlagCompletionFunc("host",
+		func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return remoteHostNames(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+		})
 	listCmd.Flags().BoolVarP(&ipv4Flag, "ipv4", "4", false, "Show only IPv4 ports")
 	listCmd.Flags().BoolVarP(&ipv6Flag, "ipv6", "6", false, "Show only IPv6 ports")
 	listCmd.Flags().StringVar(&groupFlag, "group", "", "Show only ports in this `group`")
@@ -260,8 +265,27 @@ func listPorts(ctx context.Context, q listQuery) ([]ports.ListeningPort, *groups
 		return nil, nil, errors.New("--session and --host cannot be combined: a session is local daemon state")
 	}
 	if hostFlag != "" {
-		// A remote host is scanned over SSH; the local daemon knows nothing
-		// about it.
+		// A registered host has a daemon and a bridge, so its ports come back
+		// through the local daemon already attributed, named and grouped. The
+		// SSH scan below is the fallback for a host that has neither.
+		if c := routeRemote(ctx, hostFlag); c != nil {
+			defer c.Close()
+			var res rpc.PortsListResult
+			err := remoteCall(ctx, c, hostFlag, "ports.list", rpc.PortsListParams{
+				Group:     strPtrOrNil(q.group),
+				Filter:    strPtrOrNil(q.filter),
+				All:       q.showApps,
+				IPVersion: strPtrOrNil(q.ipVersion),
+				Include:   listInclude(statsFlag, healthFlag),
+			}, &res)
+			if err != nil {
+				return nil, nil, err
+			}
+			return state.ToListeningAll(res.Ports), nil, nil
+		}
+
+		// A remote host with no daemon is scanned over SSH; the local daemon
+		// knows nothing about it.
 		results, err := ports.ScanRemote(hostFlag)
 		if err != nil {
 			return nil, nil, err

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	// The remote-host connection manager registers its RPC handlers and its
+	// OnStart hook from its own init(), so `sonar serve` in this binary knows
+	// how to bridge to a registered host (contract §8).
+	_ "github.com/raskrebs/sonar/internal/remote"
+)
 
 // remoteCmd is the parent of the `sonar remote …` family (spec 3, "CLI"): the
 // subcommands that register, list and set up the hosts sonar manages over SSH.
@@ -8,6 +15,15 @@ import "github.com/spf13/cobra"
 var remoteCmd = &cobra.Command{
 	Use:   "remote",
 	Short: "Manage the remote hosts sonar watches over SSH",
+	Long: `Manage the machines sonar watches besides this one.
+
+A registered host runs the same daemon; the local daemon keeps one SSH
+connection to it and multiplexes its ports, groups and load into the state the
+CLI and the app already read. Every row carries the host it came from, so
+'sonar list --host hetzner' and the app's host switcher are the same data.
+
+Host names are lowercase letters, digits and dashes. The target is what ssh
+receives, verbatim: a user@host, or an alias from your ~/.ssh/config.`,
 }
 
 func init() {

--- a/internal/cmd/remote_add.go
+++ b/internal/cmd/remote_add.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/selfupdate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	remoteAddName     string
+	remoteAddPort     int
+	remoteAddIdentity string
+	remoteAddSSHArgs  []string
+	remoteAddBinary   string
+	remoteAddJSON     bool
+)
+
+var remoteAddCmd = &cobra.Command{
+	Use:   "add [name] <user@host>",
+	Short: "Register a host and start bridging to it",
+	Long: `Register an SSH host. The daemon connects to it immediately and keeps the
+connection up, reconnecting with backoff for as long as the host stays
+registered.
+
+The name comes from the first of two arguments, from --name, or — with neither
+— from the host part of the target. The target itself is handed to ssh
+unchanged, so jump hosts, aliases and identities from your ~/.ssh/config apply
+exactly as they do from a shell. sonar stores no password and no key.
+
+Examples:
+  sonar remote add deploy@203.0.113.7
+  sonar remote add hetzner deploy@203.0.113.7
+  sonar remote add deploy@203.0.113.7 --name hetzner
+  sonar remote add box --ssh-arg -J --ssh-arg bastion
+  sonar remote add deploy@box --identity ~/.ssh/id_ed25519 --port 2222`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runRemoteAdd,
+}
+
+func init() {
+	remoteAddCmd.Flags().StringVar(&remoteAddName, "name", "",
+		"Name to address the host by (default: the host part of the target)")
+	remoteAddCmd.Flags().IntVar(&remoteAddPort, "port", 0, "SSH port")
+	remoteAddCmd.Flags().StringVar(&remoteAddIdentity, "identity", "", "SSH identity file")
+	remoteAddCmd.Flags().StringArrayVar(&remoteAddSSHArgs, "ssh-arg", nil,
+		"Extra argument for ssh; repeat for each one")
+	remoteAddCmd.Flags().StringVar(&remoteAddBinary, "remote-bin", "",
+		"Path to sonar on the remote host (default: sonar, from its PATH)")
+	remoteAddCmd.Flags().BoolVar(&remoteAddJSON, "json", false, "Output as JSON")
+	remoteCmd.AddCommand(remoteAddCmd)
+}
+
+func runRemoteAdd(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
+	// Two arguments are `<name> <target>`, the form the spec's CLI table and
+	// `sonar remote install` both print. One argument is the target alone,
+	// with --name as the optional override.
+	name, target := remoteAddName, args[0]
+	if len(args) == 2 {
+		if remoteAddName != "" && remoteAddName != args[0] {
+			return fmt.Errorf("the name is given twice: %q as an argument and %q as --name",
+				args[0], remoteAddName)
+		}
+		name, target = args[0], args[1]
+	}
+
+	c, err := connectDaemonForRemote(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	var res rpc.RemoteAddResult
+	err = c.Call(cmd.Context(), "remote.add", rpc.RemoteAddParams{
+		Target:    target,
+		Name:      name,
+		SSHArgs:   remoteAddSSHArgs,
+		Identity:  remoteAddIdentity,
+		Port:      remoteAddPort,
+		RemoteBin: remoteAddBinary,
+	}, &res)
+	if err != nil {
+		return cliError(err)
+	}
+
+	if remoteAddJSON {
+		return writeJSON(res)
+	}
+	fmt.Fprintf(os.Stdout, "Registered %s as %s.\n",
+		res.Host.Address, display.Cyan(res.Host.Name))
+	fmt.Fprintf(os.Stdout, "Connecting; `sonar remote list` shows the status.\n")
+	return nil
+}
+
+// connectDaemonForRemote dials the daemon, starting one if needed. Every
+// `sonar remote` subcommand needs it: the bridges live in the daemon, so there
+// is nothing a daemon-less path could report.
+func connectDaemonForRemote(ctx context.Context) (*client.Client, error) {
+	c, err := client.Connect(ctx, client.ClientInfo{Name: "cli", Version: selfupdate.Version})
+	if err != nil {
+		return nil, fmt.Errorf("remote hosts need a running daemon: %w", err)
+	}
+	return c, nil
+}

--- a/internal/cmd/remote_list.go
+++ b/internal/cmd/remote_list.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var remoteListJSON bool
+
+var remoteListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "Show the registered hosts and their connections",
+	Long: `Show every registered host: whether its bridge is up, how long a round trip
+takes, what version of sonar it runs, and how loaded it is.
+
+Status is one of connecting, connected, unreachable, outdated or incompatible.
+An unreachable host keeps its row and keeps retrying; the reason column says
+what ssh or the remote daemon reported.`,
+	Args: cobra.NoArgs,
+	RunE: runRemoteList,
+}
+
+func init() {
+	remoteListCmd.Flags().BoolVar(&remoteListJSON, "json", false, "Output as JSON")
+	remoteCmd.AddCommand(remoteListCmd)
+}
+
+func runRemoteList(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+
+	hosts, err := readRemoteHosts(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if remoteListJSON {
+		return writeJSON(map[string]any{"hosts": hosts})
+	}
+	renderRemoteHosts(os.Stdout, hosts)
+	return nil
+}
+
+// readRemoteHosts asks the daemon for the registered hosts. It never starts
+// one: with no daemon there are no bridges, and "no hosts registered" would be
+// a different, wrong answer from "cannot tell".
+func readRemoteHosts(ctx context.Context) ([]state.Host, error) {
+	c, err := dialDaemon(ctx)
+	if err != nil {
+		if errors.Is(err, client.ErrNotRunning) {
+			return nil, errors.New(
+				"remote hosts need a running daemon; start one with `sonar serve --detach`")
+		}
+		return nil, err
+	}
+	defer c.Close()
+
+	var res rpc.RemoteListResult
+	if err := c.Call(ctx, "remote.list", rpc.Empty{}, &res); err != nil {
+		return nil, cliError(err)
+	}
+	return res.Hosts, nil
+}
+
+func renderRemoteHosts(w io.Writer, hosts []state.Host) {
+	if len(hosts) == 0 {
+		fmt.Fprintln(w, "No remote hosts registered. `sonar remote add <user@host>` registers one.")
+		return
+	}
+	fmt.Fprintf(w, "%-14s %-24s %-14s %-9s %-10s %-6s %s\n",
+		display.Bold("NAME"), display.Bold("TARGET"), display.Bold("STATUS"),
+		display.Bold("LATENCY"), display.Bold("VERSION"), display.Bold("PORTS"),
+		display.Bold("LOAD"))
+	for _, h := range hosts {
+		fmt.Fprintf(w, "%-14s %-24s %-14s %-9s %-10s %-6d %s\n",
+			display.Cyan(h.Name), h.Address, hostStatus(h.Status),
+			remoteLatency(h), dashIfEmpty(h.DaemonVersion), h.Ports,
+			hostLoad(h.Load))
+		if h.StatusReason != nil && *h.StatusReason != "" && h.Status != state.HostConnected {
+			fmt.Fprintf(w, "  %s %s\n", display.Dim("↳"), display.Dim(*h.StatusReason))
+		}
+	}
+}
+
+// remoteLatency prints the round trip, or a dash while the host is not
+// answering — a stale number would read as a live one.
+func remoteLatency(h state.Host) string {
+	if h.Status != state.HostConnected || h.LatencyMs <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d ms", h.LatencyMs)
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/cmd/remote_remove.go
+++ b/internal/cmd/remote_remove.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/spf13/cobra"
+)
+
+var remoteRemoveCmd = &cobra.Command{
+	Use:     "remove <name>",
+	Aliases: []string{"rm"},
+	Short:   "Unregister a host and drop its rows",
+	Long: `Unregister a host. Its SSH connection is torn down, its ports, groups and
+sessions leave the state every client reads, and it is removed from the config.
+
+Nothing on the remote host is changed: the daemon there keeps running until it
+idles out on its own.`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeRemoteHost,
+	RunE:              runRemoteRemove,
+}
+
+func init() {
+	remoteCmd.AddCommand(remoteRemoveCmd)
+}
+
+func runRemoteRemove(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
+	c, err := connectDaemonForRemote(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if err := c.Call(cmd.Context(), "remote.remove", rpc.RemoteRemoveParams{Name: args[0]}, nil); err != nil {
+		return cliError(err)
+	}
+	fmt.Fprintf(os.Stdout, "Removed %s.\n", args[0])
+	return nil
+}
+
+// completeRemoteHost completes a registered host name. It stays silent when
+// the daemon is not running: a completion is not the place to start one.
+func completeRemoteHost(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	hosts, err := readRemoteHosts(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	names := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		names = append(names, h.Name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/cmd/remote_route.go
+++ b/internal/cmd/remote_route.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// This file is the CLI's half of the two `--host` paths the remote-hosts
+// design keeps side by side:
+//
+//   - A *registered* host has a daemon and a bridge. Its reads are forwarded
+//     through the local daemon's `remote.call`, so they come back as the same
+//     rows a local read does, already attributed and named.
+//   - Anything else is the agentless fallback that has always been there:
+//     ssh + ss/lsof, read-only, no daemon on either side.
+//
+// The rule is the spec's: "a registered host always uses the daemon path",
+// and the fallback prints a hint to `sonar remote install`.
+
+// remoteFallbackOnce keeps the install hint to one line per invocation.
+var remoteFallbackOnce sync.Once
+
+// routeRemote resolves what `--host <name>` should do. It returns a connected
+// daemon client when the name is registered, and nil when the caller should
+// take the agentless SSH path.
+func routeRemote(ctx context.Context, name string) *client.Client {
+	if name == "" || noDaemonFlag {
+		return nil
+	}
+	c, err := dialDaemon(ctx)
+	if err != nil {
+		// No daemon, so no bridges: there is nothing to route through and the
+		// SSH scan is the only thing that can answer.
+		return nil
+	}
+
+	var res rpc.RemoteListResult
+	if err := c.Call(ctx, "remote.list", rpc.Empty{}, &res); err != nil {
+		c.Close()
+		return nil
+	}
+	for _, h := range res.Hosts {
+		if h.Name == name {
+			return c
+		}
+	}
+	c.Close()
+	noteRemoteFallback(name)
+	return nil
+}
+
+// noteRemoteFallback tells the user, once, that this host is being scanned the
+// slow way and how to stop that.
+func noteRemoteFallback(name string) {
+	remoteFallbackOnce.Do(func() {
+		fmt.Fprintf(os.Stderr,
+			"note: %s is not a registered host — scanning it over ssh.\n"+
+				"      `sonar remote add %s` registers it; `sonar remote install <name>` puts a daemon on it\n",
+			name, name)
+	})
+}
+
+// remoteCall forwards one method to a registered host's daemon and decodes the
+// result. It is the CLI's use of `remote.call`: reads go through it unchanged,
+// so a remote `ports.list` is the same call with the same params as a local
+// one.
+func remoteCall(ctx context.Context, c *client.Client, host, method string, params, out any) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	var result rpc.RemoteCallResult
+	if err := c.Call(ctx, "remote.call", rpc.RemoteCallParams{
+		Host:   host,
+		Method: method,
+		Params: raw,
+	}, &result); err != nil {
+		return cliError(err)
+	}
+	if out == nil || len(result) == 0 {
+		return nil
+	}
+	return json.Unmarshal(result, out)
+}
+
+// remoteHostNames is what shell completion offers for `--host`. It is silent
+// when the daemon is not running.
+func remoteHostNames(ctx context.Context) []string {
+	hosts, err := readRemoteHosts(ctx)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(hosts)+1)
+	names = append(names, state.LocalhostName)
+	for _, h := range hosts {
+		names = append(names, h.Name)
+	}
+	return names
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	Daemon   DaemonConfig   `yaml:"daemon"`
 	Color    *bool          `yaml:"color"`    // pointer: nil = unset, distinguishes from explicit false
 	Services map[int]string `yaml:"services"` // port -> label, merged over built-in table
+	// Remote holds the registered SSH hosts the daemon bridges to (see
+	// remote.go).
+	Remote RemoteConfig `yaml:"remote"`
 }
 
 // DefaultIdleTimeout is how long `sonar serve` stays up with no clients, no
@@ -88,7 +91,10 @@ func Load() (*Config, []string) {
 		return &Config{}, []string{fmt.Sprintf("ignoring %s: %v", Path(), err)}
 	}
 
-	return cfg, validate(cfg)
+	warnings := validate(cfg)
+	hosts, hostWarnings := validateHosts(cfg.Remote.Hosts)
+	cfg.Remote.Hosts = hosts
+	return cfg, append(warnings, hostWarnings...)
 }
 
 const template = `# sonar configuration
@@ -117,6 +123,14 @@ const template = `# sonar configuration
 # services:         # label custom/unknown ports (port: name)
 #   9000: php-fpm
 #   5050: my-dashboard
+
+# remote:           # hosts reached over SSH; written by 'sonar remote add'
+#   hosts:
+#     - name: hetzner            # [a-z0-9-]+, how you address it everywhere
+#       target: deploy@203.0.113.7   # what ssh receives, verbatim
+#       ssh_args: ["-J", "bastion"]
+#       identity: ~/.ssh/id_ed25519
+#       remote_bin: ~/.local/bin/sonar
 
 # Environment overrides (no config key; set them in your shell):
 #   SONAR_DB       path to the database of names, pins and history

--- a/internal/config/remote.go
+++ b/internal/config/remote.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This file is the `remote.hosts` half of the user config: the registered SSH
+// hosts the daemon keeps a bridge to. It is written by `sonar remote add`,
+// editable by hand, and read by the daemon's connection manager on start and
+// on every `remote.add`/`remote.remove`.
+//
+// Reads go through Load (the typed Config); writes go through the map store,
+// so a key this build does not know about survives the round trip.
+
+// RemoteConfig is the `remote:` block of the user config.
+type RemoteConfig struct {
+	Hosts []RemoteHost `yaml:"hosts"`
+}
+
+// RemoteHost is one registered SSH host. Nothing here is a secret: identities
+// and agents are the user's own `ssh` configuration, and sonar never stores a
+// password.
+type RemoteHost struct {
+	// Name is how the host is addressed everywhere else: `--host <name>`, the
+	// `host` field on every row it contributes, and the "<name>/" prefix on
+	// its delta keys. Lowercase letters, digits and dashes.
+	Name string `yaml:"name" json:"name"`
+	// Target is what `ssh` receives, verbatim: "deploy@203.0.113.7", or a
+	// `~/.ssh/config` alias. sonar never resolves it as DNS itself.
+	Target string `yaml:"target" json:"target"`
+	// SSHArgs are extra arguments placed before the target ("-J bastion").
+	SSHArgs []string `yaml:"ssh_args,omitempty" json:"ssh_args,omitempty"`
+	// Identity is an `ssh -i` key file. Empty leaves key selection to ssh.
+	Identity string `yaml:"identity,omitempty" json:"identity,omitempty"`
+	// Port is an `ssh -p` port. Zero leaves it to ssh.
+	Port int `yaml:"port,omitempty" json:"port,omitempty"`
+	// RemoteBin is the sonar binary to run on the far side. Empty means
+	// "sonar", found on the login shell's PATH.
+	RemoteBin string `yaml:"remote_bin,omitempty" json:"remote_bin,omitempty"`
+}
+
+// hostNamePattern is the spec's rule: host names are [a-z0-9-]+, unique, and
+// never resolved as DNS by sonar.
+var hostNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// ValidHostName reports whether name is a usable remote host name.
+func ValidHostName(name string) bool { return hostNamePattern.MatchString(name) }
+
+// DefaultHostName derives a host name from an SSH target: the host part,
+// lowercased, with everything outside [a-z0-9-] turned into a dash. It is what
+// `sonar remote add deploy@203.0.113.7` uses when no --name is given.
+func DefaultHostName(target string) string {
+	t := target
+	if _, after, ok := strings.Cut(t, "@"); ok {
+		t = after
+	}
+	t = strings.ToLower(strings.TrimSpace(t))
+	var b strings.Builder
+	for _, r := range t {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	name := strings.Trim(b.String(), "-")
+	for strings.Contains(name, "--") {
+		name = strings.ReplaceAll(name, "--", "-")
+	}
+	return name
+}
+
+// RemoteHosts reads the registered hosts, dropping any entry that is not
+// usable and returning a warning for each. A missing config is no hosts and no
+// warnings.
+func RemoteHosts() ([]RemoteHost, []string) {
+	cfg, _ := Load()
+	return validateHosts(cfg.Remote.Hosts)
+}
+
+func validateHosts(in []RemoteHost) ([]RemoteHost, []string) {
+	var warnings []string
+	seen := map[string]bool{}
+	out := make([]RemoteHost, 0, len(in))
+	for _, h := range in {
+		h.Name = strings.TrimSpace(h.Name)
+		h.Target = strings.TrimSpace(h.Target)
+		switch {
+		case !ValidHostName(h.Name):
+			warnings = append(warnings,
+				fmt.Sprintf("config: invalid remote host name %q — ignoring (names are [a-z0-9-]+)", h.Name))
+		case h.Target == "":
+			warnings = append(warnings,
+				fmt.Sprintf("config: remote host %q has no target — ignoring", h.Name))
+		case seen[h.Name]:
+			warnings = append(warnings,
+				fmt.Sprintf("config: duplicate remote host %q — ignoring the second one", h.Name))
+		default:
+			seen[h.Name] = true
+			out = append(out, h)
+		}
+	}
+	return out, warnings
+}
+
+// SaveRemoteHosts writes the host list to `remote.hosts`, leaving every other
+// setting — and every key this build does not know about — untouched.
+func SaveRemoteHosts(hosts []RemoteHost) error {
+	if hosts == nil {
+		hosts = []RemoteHost{}
+	}
+	value, err := yamlValue(hosts)
+	if err != nil {
+		return err
+	}
+	_, err = Apply(map[string]any{"remote": map[string]any{"hosts": value}})
+	return err
+}
+
+// yamlValue round-trips a typed value into the plain map/slice form the config
+// store writes, so the file keeps its normal YAML shape rather than gaining a
+// Go-specific encoding.
+func yamlValue(v any) (any, error) {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("encoding remote hosts: %w", err)
+	}
+	var out any
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("encoding remote hosts: %w", err)
+	}
+	if out == nil {
+		return []any{}, nil
+	}
+	return normalize(out), nil
+}
+
+// UnmarshalYAML accepts both forms of a `remote.hosts` entry: the mapping this
+// build writes, and the bare `user@host` string cross-spec contract §4
+// originally specified. A scalar becomes a host whose name is derived from the
+// target, so a config written before `sonar remote add` existed keeps working
+// and is upgraded in place the next time the list is saved.
+func (h *RemoteHost) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		var target string
+		if err := node.Decode(&target); err != nil {
+			return err
+		}
+		*h = RemoteHost{Name: DefaultHostName(target), Target: target}
+		return nil
+	}
+	type plain RemoteHost
+	var p plain
+	if err := node.Decode(&p); err != nil {
+		return err
+	}
+	*h = RemoteHost(p)
+	return nil
+}

--- a/internal/daemon/client/client.go
+++ b/internal/daemon/client/client.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
+	"io"
 	"strconv"
 	"strings"
 	"sync"
@@ -58,7 +58,7 @@ func (e *ProtocolMismatchError) Error() string {
 
 // Client is a connection to the daemon. It is safe for concurrent use.
 type Client struct {
-	conn   net.Conn
+	conn   io.ReadWriteCloser
 	enc    *rpc.Encoder
 	socket string
 	hello  rpc.DaemonHelloResult
@@ -105,7 +105,19 @@ func Dial(ctx context.Context, info ClientInfo) (*Client, error) {
 	return Connect(ctx, info)
 }
 
-func handshake(ctx context.Context, conn net.Conn, socket string, info ClientInfo) (*Client, error) {
+// Attach speaks the daemon protocol over an already-open stream instead of a
+// socket this package dialled. The remote-host bridge uses it: the stream is
+// the stdin/stdout of `ssh <host> sonar daemon stdio`, and the protocol on it
+// is byte-for-byte the one on the local socket, so the whole client — calls,
+// subscriptions, streams — works unchanged over SSH.
+//
+// label names the connection in errors and in Socket(); it is not dialled.
+// Closing the Client closes rwc.
+func Attach(ctx context.Context, rwc io.ReadWriteCloser, label string, info ClientInfo) (*Client, error) {
+	return handshake(ctx, rwc, label, info)
+}
+
+func handshake(ctx context.Context, conn io.ReadWriteCloser, socket string, info ClientInfo) (*Client, error) {
 	c := &Client{
 		conn:    conn,
 		enc:     rpc.NewEncoder(conn),

--- a/internal/daemon/conn.go
+++ b/internal/daemon/conn.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
 )
 
 // QueueSize bounds a connection's outbound queue. A client that stops reading
@@ -38,6 +39,10 @@ type Conn struct {
 	subscribed bool
 	include    scanner.Include
 	events     bool
+	// hosts is the `state.subscribe {hosts}` filter. The zero value is
+	// localhost only, so a client that never sends the field reads exactly the
+	// stream it read before remote hosts existed.
+	hosts state.HostFilter
 
 	mu             sync.Mutex
 	client         string

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -111,7 +111,7 @@ func handleSnapshot(_ context.Context, req *Request) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	snap, err := req.Runtime.Scanner.Snapshot(include)
+	snap, err := req.Runtime.Scanner.SnapshotAll(include)
 	if err != nil {
 		return nil, rpc.NewError(rpc.CodeInternal, "scan failed: "+err.Error(),
 			"check `sonar daemon log` for the scanner error")

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
 )
 
 // The core method set for step 1A.1. Namespaces owned by later steps register
@@ -115,7 +116,7 @@ func handleSnapshot(_ context.Context, req *Request) (any, error) {
 		return nil, rpc.NewError(rpc.CodeInternal, "scan failed: "+err.Error(),
 			"check `sonar daemon log` for the scanner error")
 	}
-	return filterSnapshot(snap, include), nil
+	return filterSnapshot(snap, include, state.ParseHostFilter(p.Hosts)), nil
 }
 
 func handleSubscribe(_ context.Context, req *Request) (any, error) {
@@ -134,7 +135,7 @@ func handleSubscribe(_ context.Context, req *Request) (any, error) {
 	// first would hold the reply for the length of a stats collection — seconds
 	// on a busy machine — and the first snapshot would still be a delta behind
 	// by the time it arrived.
-	req.Runtime.Server().subscribe(req.Conn, req.ID, include, p.Events)
+	req.Runtime.Server().subscribe(req.Conn, req.ID, include, p.Events, state.ParseHostFilter(p.Hosts))
 	return nil, ErrResponseSent
 }
 

--- a/internal/daemon/hosts_test.go
+++ b/internal/daemon/hosts_test.go
@@ -24,7 +24,7 @@ func TestFilterSnapshotKeepsHosts(t *testing.T) {
 		Ports: []state.Port{{Port: 3000, Stats: &state.Stats{CPUPercent: 4}}},
 		Hosts: []state.Host{testHost(12.5)},
 	}
-	got := filterSnapshot(snap, scanner.Include{})
+	got := filterSnapshot(snap, scanner.Include{}, state.LocalOnly())
 	if len(got.Hosts) != 1 || got.Hosts[0].CPUPercent == nil {
 		t.Fatalf("hosts = %+v, want the row with its load", got.Hosts)
 	}
@@ -35,7 +35,7 @@ func TestFilterSnapshotKeepsHosts(t *testing.T) {
 
 // Every collection is an array on the wire, never null (contract §5).
 func TestFilterSnapshotNeverLeavesHostsNull(t *testing.T) {
-	got := filterSnapshot(state.Snapshot{}, scanner.Include{})
+	got := filterSnapshot(state.Snapshot{}, scanner.Include{}, state.LocalOnly())
 	raw, err := json.Marshal(got)
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestHostOnlyDeltaIsSentWithoutInclude(t *testing.T) {
 	prev := state.Snapshot{Hosts: []state.Host{testHost(12.5)}}
 	next := state.Snapshot{Seq: 2, Hosts: []state.Host{testHost(41)}}
 
-	msg := marshalDelta(prev, next, scanner.Include{})
+	msg := marshalDelta(prev, next, scanner.Include{}, state.LocalOnly())
 	if msg == nil {
 		t.Fatal("a host-only delta was dropped for a subscriber with no include")
 	}
@@ -81,7 +81,7 @@ func TestHostOnlyDeltaIsSentWithoutInclude(t *testing.T) {
 // A tick where nothing at all moved is still not sent.
 func TestEmptyDeltaIsStillDropped(t *testing.T) {
 	snap := state.Snapshot{Hosts: []state.Host{testHost(12.5)}}
-	if msg := marshalDelta(snap, snap, scanner.Include{}); msg != nil {
+	if msg := marshalDelta(snap, snap, scanner.Include{}, state.LocalOnly()); msg != nil {
 		t.Errorf("an empty delta was sent: %s", msg)
 	}
 }

--- a/internal/daemon/remote_hosts_test.go
+++ b/internal/daemon/remote_hosts_test.go
@@ -1,0 +1,195 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// remoteRows is what a connected bridge contributes: rows already tagged with
+// the host name, plus that host's own row in the hosts collection.
+func remoteRows(host string, port int) state.Rows {
+	return state.Rows{
+		Ports: []state.Port{{
+			Port: port, BindAddress: "127.0.0.1", PID: 4242,
+			Process: "node", DisplayName: "node", Type: state.TypeUser,
+			ExposedURLs: []string{},
+		}},
+		Groups: []state.Group{{Name: "api", Status: "running", Members: []int{port}}},
+		Hosts:  []state.Host{{Name: state.LocalhostName, Status: state.HostConnected}},
+	}.Tag(host).Normalize()
+}
+
+// TestSubscribeDefaultsToLocalhost is the backward-compatibility guarantee: a
+// client that never learned about `hosts` reads exactly the stream it always
+// read, remote hosts registered or not.
+func TestSubscribeDefaultsToLocalhost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+	h.loop.SetRemote(func() state.Rows { return remoteRows("hetzner", 3000) })
+	h.setRows(ports.ListeningPort{Port: 8080, BindAddress: "127.0.0.1", PID: 1, Process: "go"})
+
+	c := h.dial(ctx)
+	var snap state.Snapshot
+	if err := c.call("state.subscribe", rpc.StateSubscribeParams{}, &snap); err != nil {
+		t.Fatalf("state.subscribe: %v", err)
+	}
+	for _, p := range snap.Ports {
+		if p.Host != state.LocalhostName {
+			t.Errorf("snapshot carries a %s row without being asked: %+v", p.Host, p)
+		}
+	}
+	for _, host := range snap.Hosts {
+		if host.Name != state.LocalhostName {
+			t.Errorf("hosts = %+v, want only localhost", snap.Hosts)
+		}
+	}
+}
+
+// TestSubscribeStarSeesEveryHost is the app's "all hosts" view.
+func TestSubscribeStarSeesEveryHost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+	h.loop.SetRemote(func() state.Rows { return remoteRows("hetzner", 3000) })
+
+	c := h.dial(ctx)
+	var snap state.Snapshot
+	if err := c.call("state.subscribe", rpc.StateSubscribeParams{Hosts: []string{"*"}}, &snap); err != nil {
+		t.Fatalf("state.subscribe: %v", err)
+	}
+
+	var found bool
+	for _, p := range snap.Ports {
+		if p.Host == "hetzner" {
+			found = true
+			if want := "hetzner/3000:127.0.0.1"; p.Key() != want {
+				t.Errorf("remote key = %q, want %q", p.Key(), want)
+			}
+		}
+	}
+	if !found {
+		t.Errorf(`ports = %+v, want the hetzner row under hosts: ["*"]`, snap.Ports)
+	}
+	if len(snap.Hosts) != 2 {
+		t.Errorf("hosts = %+v, want localhost and hetzner", snap.Hosts)
+	}
+}
+
+// TestSnapshotHostsFilter checks the same option on the unary read.
+func TestSnapshotHostsFilter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+	h.loop.SetRemote(func() state.Rows { return remoteRows("hetzner", 3000) })
+	h.setRows(ports.ListeningPort{Port: 8080, BindAddress: "127.0.0.1", PID: 1, Process: "go"})
+
+	c := h.dial(ctx)
+	var only state.Snapshot
+	if err := c.call("state.snapshot", rpc.StateSnapshotParams{Hosts: []string{"hetzner"}}, &only); err != nil {
+		t.Fatalf("state.snapshot: %v", err)
+	}
+	if len(only.Ports) != 1 || only.Ports[0].Host != "hetzner" {
+		t.Errorf("ports = %+v, want only hetzner's", only.Ports)
+	}
+	if len(only.Hosts) != 1 || only.Hosts[0].Name != "hetzner" {
+		t.Errorf("hosts = %+v, want only hetzner's row", only.Hosts)
+	}
+}
+
+// TestRemoteChangePublishesADelta is the multiplexer end to end inside the
+// daemon: a bridge reporting a new remote port reaches a subscriber that asked
+// for that host, without a local scan having found anything.
+func TestRemoteChangePublishesADelta(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+
+	var rows state.Rows
+	h.loop.SetRemote(func() state.Rows { return rows })
+	h.setRows(ports.ListeningPort{Port: 8080, BindAddress: "127.0.0.1", PID: 1, Process: "go"})
+
+	c := h.dial(ctx)
+	var snap state.Snapshot
+	if err := c.call("state.subscribe", rpc.StateSubscribeParams{Hosts: []string{"*"}}, &snap); err != nil {
+		t.Fatalf("state.subscribe: %v", err)
+	}
+
+	rows = remoteRows("hetzner", 3000)
+	h.loop.RemoteChanged()
+
+	for {
+		msg := c.read()
+		if !msg.IsNotification() || msg.Method != rpc.MethodStateDelta {
+			continue
+		}
+		var d state.Delta
+		if err := json.Unmarshal(msg.Params, &d); err != nil {
+			t.Fatal(err)
+		}
+		for _, p := range d.Ports.Added {
+			if p.Host == "hetzner" && p.Port == 3000 {
+				return
+			}
+		}
+	}
+}
+
+// TestRemoteRowsAreInvisibleToALocalSubscriber is the same transition seen by
+// the default subscriber: nothing at all, because it asked about localhost.
+func TestRemoteRowsAreInvisibleToALocalSubscriber(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+
+	var rows state.Rows
+	h.loop.SetRemote(func() state.Rows { return rows })
+	h.setRows(ports.ListeningPort{Port: 8080, BindAddress: "127.0.0.1", PID: 1, Process: "go"})
+
+	c := h.dial(ctx)
+	var snap state.Snapshot
+	if err := c.call("state.subscribe", rpc.StateSubscribeParams{}, &snap); err != nil {
+		t.Fatalf("state.subscribe: %v", err)
+	}
+
+	before := h.srv.loop.Status().Seq
+	rows = remoteRows("hetzner", 3000)
+	h.loop.RemoteChanged()
+	if after := h.srv.loop.Status().Seq; after == before {
+		t.Fatal("the remote change did not publish at all")
+	}
+
+	// The delta the remote change produced is empty for this subscriber, so
+	// the only thing it can be sent is a later local one. Prove that by asking
+	// a question and checking nothing came first.
+	var res rpc.DaemonStatusResult
+	if err := c.call("daemon.status", rpc.Empty{}, &res); err != nil {
+		t.Fatalf("daemon.status: %v", err)
+	}
+}
+
+// TestEventsAreFilteredByHost: a subscriber that did not ask for a host must
+// not be woken by that host's port_up.
+func TestEventsAreFilteredByHost(t *testing.T) {
+	local := marshalEvents([]state.Event{{Kind: "port_up", Host: "hetzner"}},
+		scanner.Include{}, state.LocalOnly())
+	if len(local) != 0 {
+		t.Errorf("a localhost subscriber got %d remote events", len(local))
+	}
+	all := marshalEvents([]state.Event{{Kind: "port_up", Host: "hetzner"}},
+		scanner.Include{}, state.AllHosts())
+	if len(all) != 1 {
+		t.Errorf(`a "*" subscriber got %d events, want 1`, len(all))
+	}
+	untagged := marshalEvents([]state.Event{{Kind: "port_up"}},
+		scanner.Include{}, state.LocalOnly())
+	if len(untagged) != 1 {
+		t.Errorf("an untagged event is a local one and should be delivered")
+	}
+}

--- a/internal/daemon/remote_hosts_test.go
+++ b/internal/daemon/remote_hosts_test.go
@@ -214,3 +214,64 @@ func TestEventsAreFilteredByHost(t *testing.T) {
 		t.Errorf("an untagged event is a local one and should be delivered")
 	}
 }
+
+// TestSelectorsDefaultToLocalhost is the rule step 3A.4 will build a `host`
+// field on top of: a read or a kill that names no host resolves against this
+// machine, so a port that also exists on a registered host does not suddenly
+// become ambiguous for a caller that never heard of remote hosts.
+func TestSelectorsDefaultToLocalhost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := newHarness(t, ctx)
+
+	// The same port number on both machines.
+	h.loop.SetRemote(func() state.Rows { return remoteRows("hetzner", 3000) })
+	h.setRows(ports.ListeningPort{Port: 3000, BindAddress: "127.0.0.1", PID: 1, Process: "go"})
+
+	// A scan has to have happened before Cached has anything to say.
+	rescanned, err := h.loop.Rescan(scanner.Include{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanned, err := h.loop.Snapshot(scanner.Include{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The scanner's own read paths — what every selector-resolving handler
+	// uses — see one row, not two.
+	for name, snap := range map[string]state.Snapshot{
+		"Cached":   h.loop.Cached(),
+		"Snapshot": scanned,
+		"Rescan":   rescanned,
+	} {
+		matches := 0
+		for _, p := range snap.Ports {
+			if p.Port == 3000 {
+				matches++
+			}
+			if !state.IsLocalhost(p.Host) {
+				t.Errorf("%s returned a %q row: %+v", name, p.Host, p)
+			}
+		}
+		if matches != 1 {
+			t.Errorf("%s matched port 3000 %d times, want 1", name, matches)
+		}
+		for _, host := range snap.Hosts {
+			if !state.IsLocalhost(host.Name) {
+				t.Errorf("%s returned the %q host row", name, host.Name)
+			}
+		}
+	}
+
+	c := h.dial(ctx)
+	var list rpc.PortsListResult
+	if err := c.call("ports.list", rpc.PortsListParams{}, &list); err != nil {
+		t.Fatalf("ports.list: %v", err)
+	}
+	for _, p := range list.Ports {
+		if !state.IsLocalhost(p.Host) {
+			t.Errorf("ports.list leaked a %q row without being asked", p.Host)
+		}
+	}
+}

--- a/internal/daemon/remote_hosts_test.go
+++ b/internal/daemon/remote_hosts_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
@@ -10,6 +11,26 @@ import (
 	"github.com/raskrebs/sonar/internal/scanner"
 	"github.com/raskrebs/sonar/internal/state"
 )
+
+// remoteSource is the scanner's Remote seam under a mutex: the scan goroutine
+// reads it while the test writes it, exactly as the real connection manager
+// does.
+type remoteSource struct {
+	mu   sync.Mutex
+	rows state.Rows
+}
+
+func (r *remoteSource) set(rows state.Rows) {
+	r.mu.Lock()
+	r.rows = rows
+	r.mu.Unlock()
+}
+
+func (r *remoteSource) get() state.Rows {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rows
+}
 
 // remoteRows is what a connected bridge contributes: rows already tagged with
 // the host name, plus that host's own row in the hosts collection.
@@ -111,8 +132,8 @@ func TestRemoteChangePublishesADelta(t *testing.T) {
 	defer cancel()
 	h := newHarness(t, ctx)
 
-	var rows state.Rows
-	h.loop.SetRemote(func() state.Rows { return rows })
+	src := &remoteSource{}
+	h.loop.SetRemote(src.get)
 	h.setRows(ports.ListeningPort{Port: 8080, BindAddress: "127.0.0.1", PID: 1, Process: "go"})
 
 	c := h.dial(ctx)
@@ -121,7 +142,7 @@ func TestRemoteChangePublishesADelta(t *testing.T) {
 		t.Fatalf("state.subscribe: %v", err)
 	}
 
-	rows = remoteRows("hetzner", 3000)
+	src.set(remoteRows("hetzner", 3000))
 	h.loop.RemoteChanged()
 
 	for {
@@ -148,8 +169,8 @@ func TestRemoteRowsAreInvisibleToALocalSubscriber(t *testing.T) {
 	defer cancel()
 	h := newHarness(t, ctx)
 
-	var rows state.Rows
-	h.loop.SetRemote(func() state.Rows { return rows })
+	src := &remoteSource{}
+	h.loop.SetRemote(src.get)
 	h.setRows(ports.ListeningPort{Port: 8080, BindAddress: "127.0.0.1", PID: 1, Process: "go"})
 
 	c := h.dial(ctx)
@@ -159,7 +180,7 @@ func TestRemoteRowsAreInvisibleToALocalSubscriber(t *testing.T) {
 	}
 
 	before := h.srv.loop.Status().Seq
-	rows = remoteRows("hetzner", 3000)
+	src.set(remoteRows("hetzner", 3000))
 	h.loop.RemoteChanged()
 	if after := h.srv.loop.Status().Seq; after == before {
 		t.Fatal("the remote change did not publish at all")

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -608,7 +608,11 @@ type RemoteListResult struct {
 // everything else uses: `--host <name>`, the `host` field on every row, and
 // the "<name>/" prefix on that host's delta keys.
 type RemoteAddParams struct {
-	Target    string   `json:"target"`
+	Target string `json:"target"`
+	// Host is an accepted alias of Target, for clients that call the SSH
+	// destination "host" rather than "target". Target wins when both are set
+	// and they differ.
+	Host      string   `json:"host,omitempty"`
 	Name      string   `json:"name,omitempty"`
 	SSHArgs   []string `json:"ssh_args,omitempty"`
 	Identity  string   `json:"identity,omitempty"`

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"encoding/json"
 
+	"github.com/invopop/jsonschema"
 	"github.com/raskrebs/sonar/internal/groups"
 	"github.com/raskrebs/sonar/internal/state"
 )
@@ -93,11 +94,19 @@ type DaemonSchemaResult struct {
 
 type StateSnapshotParams struct {
 	Include Include `json:"include,omitempty"`
+	// Hosts selects which machines' rows the reply carries. Absent or empty is
+	// localhost only, which is what every client written before remote hosts
+	// existed asks for; ["*"] is every registered host; any other list is
+	// exactly that set of names, so a client that wants localhost alongside a
+	// remote host names both (remote-hosts spec, "Multiplexing").
+	Hosts []string `json:"hosts,omitempty"`
 }
 
 type StateSubscribeParams struct {
 	Include Include `json:"include,omitempty"`
 	Events  bool    `json:"events,omitempty"`
+	// Hosts is StateSnapshotParams.Hosts, per subscriber.
+	Hosts []string `json:"hosts,omitempty"`
 }
 
 // ----------------------------------------------------------------- ports ---
@@ -585,6 +594,68 @@ type RemoteInstallEnd struct {
 	// remote's systemd user session would end at logout, taking the daemon
 	// with it. Empty when lingering is already on or does not apply.
 	LingerHint string `json:"linger_hint,omitempty"`
+}
+
+// RemoteListResult is every registered host, whatever its connection state,
+// with the load the bridge last read from it.
+type RemoteListResult struct {
+	Hosts []state.Host `json:"hosts"`
+}
+
+// RemoteAddParams registers an SSH host. Target is what `ssh` receives,
+// verbatim — a `user@host` or a `~/.ssh/config` alias; sonar never resolves it
+// as DNS. Name defaults to the host part of the target and is the key
+// everything else uses: `--host <name>`, the `host` field on every row, and
+// the "<name>/" prefix on that host's delta keys.
+type RemoteAddParams struct {
+	Target    string   `json:"target"`
+	Name      string   `json:"name,omitempty"`
+	SSHArgs   []string `json:"ssh_args,omitempty"`
+	Identity  string   `json:"identity,omitempty"`
+	Port      int      `json:"port,omitempty"`
+	RemoteBin string   `json:"remote_bin,omitempty"`
+}
+
+type RemoteAddResult struct {
+	OK   bool       `json:"ok"`
+	Host state.Host `json:"host"`
+}
+
+type RemoteRemoveParams struct {
+	Name string `json:"name"`
+}
+
+// RemoteCallParams forwards one method to a registered host's daemon. Writes
+// are forwarded like any other method (remote-hosts spec, decision 3).
+type RemoteCallParams struct {
+	Host   string          `json:"host"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// RemoteCallResult is whatever the remote daemon returned for the forwarded
+// method, passed through unchanged. Its shape is `method`'s result, so the
+// schema leaves it unconstrained rather than pretending it is one type.
+type RemoteCallResult json.RawMessage
+
+func (r RemoteCallResult) MarshalJSON() ([]byte, error) {
+	if len(r) == 0 {
+		return []byte("null"), nil
+	}
+	return r, nil
+}
+
+func (r *RemoteCallResult) UnmarshalJSON(b []byte) error {
+	*r = append((*r)[:0], b...)
+	return nil
+}
+
+// JSONSchema keeps the generated document honest: the result of a forwarded
+// call is the result of whatever method was forwarded.
+func (RemoteCallResult) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Description: "The remote daemon's own result for `method`, returned verbatim.",
+	}
 }
 
 // ---------------------------------------------------------------- expose ---

--- a/internal/daemon/rpc/schema.go
+++ b/internal/daemon/rpc/schema.go
@@ -130,7 +130,7 @@ type Document struct {
 func namedTypes() []any {
 	return []any{
 		state.Port{}, state.Group{}, state.Tunnel{}, state.Proxy{},
-		state.Session{}, state.SessionRecord{}, state.Claim{},
+		state.Session{}, state.SessionRecord{}, state.Claim{}, state.Host{},
 		state.Snapshot{}, state.Delta{}, state.Event{}, state.Service{},
 		state.Stats{}, state.Health{}, state.Docker{}, state.Run{},
 		state.KillResult{},
@@ -327,6 +327,10 @@ func init() {
 	Describe("remote.scan", RemoteScanParams{}, RemoteScanResult{}, nil, nil)
 	Describe("remote.install", RemoteInstallParams{}, RemoteInstallResult{},
 		RemoteInstallChunk{}, RemoteInstallEnd{})
+	Describe("remote.list", Empty{}, RemoteListResult{}, nil, nil)
+	Describe("remote.add", RemoteAddParams{}, RemoteAddResult{}, nil, nil)
+	Describe("remote.remove", RemoteRemoveParams{}, OKResult{}, nil, nil)
+	Describe("remote.call", RemoteCallParams{}, RemoteCallResult{}, nil, nil)
 
 	// Expose (spec 3).
 	Describe("expose.create", ExposeCreateParams{}, ExposeCreateResult{}, nil, nil)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -377,11 +377,11 @@ func (s *Server) demand() (int, scanner.Include) {
 // asked for arrive in the first delta rather than delaying the reply by a scan.
 // The delta's seq is the cached snapshot's seq plus one, so the §15 resync rule
 // is unchanged.
-func (s *Server) subscribe(c *Conn, id json.RawMessage, include scanner.Include, events bool) {
+func (s *Server) subscribe(c *Conn, id json.RawMessage, include scanner.Include, events bool, hosts state.HostFilter) {
 	s.subsMu.Lock()
 	snap := s.loop.Cached()
-	c.subscribed, c.include, c.events = true, include, events
-	filtered := filterSnapshot(snap, include)
+	c.subscribed, c.include, c.events, c.hosts = true, include, events, hosts
+	filtered := filterSnapshot(snap, include, hosts)
 	raw, err := json.Marshal(filtered)
 	if err == nil {
 		msg, mErr := json.Marshal(rpc.Response{JSONRPC: rpc.Version, ID: id, Result: raw})
@@ -401,7 +401,7 @@ func (s *Server) subscribe(c *Conn, id json.RawMessage, include scanner.Include,
 // unsubscribe drops a connection's subscription.
 func (s *Server) unsubscribe(c *Conn) {
 	s.subsMu.Lock()
-	c.subscribed, c.include, c.events = false, scanner.Include{}, false
+	c.subscribed, c.include, c.events, c.hosts = false, scanner.Include{}, false, state.HostFilter{}
 	s.subsMu.Unlock()
 	s.touch()
 	s.loop.Wake()
@@ -419,17 +419,18 @@ func (s *Server) publish(prev, next state.Snapshot, events []state.Event) {
 		events = append(s.takePending(), events...)
 	}
 
-	deltaCache := map[scanner.Include][]byte{}
-	eventCache := map[scanner.Include][][]byte{}
+	deltaCache := map[viewKey][]byte{}
+	eventCache := map[viewKey][][]byte{}
 
 	for _, c := range s.conns {
 		if !c.subscribed {
 			continue
 		}
-		msg, ok := deltaCache[c.include]
+		view := viewKey{include: c.include, hosts: c.hosts.Key()}
+		msg, ok := deltaCache[view]
 		if !ok {
-			msg = marshalDelta(prev, next, c.include)
-			deltaCache[c.include] = msg
+			msg = marshalDelta(prev, next, c.include, c.hosts)
+			deltaCache[view] = msg
 		}
 		if msg != nil {
 			c.enqueue(msg)
@@ -437,15 +438,23 @@ func (s *Server) publish(prev, next state.Snapshot, events []state.Event) {
 		if !c.events || len(events) == 0 {
 			continue
 		}
-		msgs, ok := eventCache[c.include]
+		msgs, ok := eventCache[view]
 		if !ok {
-			msgs = marshalEvents(events, c.include)
-			eventCache[c.include] = msgs
+			msgs = marshalEvents(events, c.include, c.hosts)
+			eventCache[view] = msgs
 		}
 		for _, m := range msgs {
 			c.enqueue(m)
 		}
 	}
+}
+
+// viewKey identifies one subscriber's view of the stream: what it opted into
+// collecting and which hosts it asked to see. The delta is marshalled once per
+// distinct view rather than once per subscriber.
+type viewKey struct {
+	include scanner.Include
+	hosts   string
 }
 
 // listeningForEvents reports whether any subscriber asked for events. Caller
@@ -459,19 +468,25 @@ func (s *Server) listeningForEvents() bool {
 	return false
 }
 
+// BroadcastEvent sends one event to every subscriber that asked for events and
+// can see the host it happened on. The remote-host bridge uses it to forward a
+// remote daemon's events into the local stream.
+func (s *Server) BroadcastEvent(ev state.Event) { s.broadcastEvent(ev) }
+
 // broadcastEvent sends one event to every subscriber that asked for events.
 func (s *Server) broadcastEvent(ev state.Event) {
 	s.subsMu.RLock()
 	defer s.subsMu.RUnlock()
-	cache := map[scanner.Include][][]byte{}
+	cache := map[viewKey][][]byte{}
 	for _, c := range s.conns {
 		if !c.subscribed || !c.events {
 			continue
 		}
-		msgs, ok := cache[c.include]
+		view := viewKey{include: c.include, hosts: c.hosts.Key()}
+		msgs, ok := cache[view]
 		if !ok {
-			msgs = marshalEvents([]state.Event{ev}, c.include)
-			cache[c.include] = msgs
+			msgs = marshalEvents([]state.Event{ev}, c.include, c.hosts)
+			cache[view] = msgs
 		}
 		for _, m := range msgs {
 			c.enqueue(m)
@@ -482,7 +497,9 @@ func (s *Server) broadcastEvent(ev state.Event) {
 // marshalDelta builds one state.delta notification for a given include set.
 // It returns nil when the delta is empty for this subscriber, so a client that
 // asked for neither stats nor health is not woken by a stats-only tick.
-func marshalDelta(prev, next state.Snapshot, include scanner.Include) []byte {
+func marshalDelta(prev, next state.Snapshot, include scanner.Include, hosts state.HostFilter) []byte {
+	prev = state.FilterSnapshot(prev, hosts)
+	next = state.FilterSnapshot(next, hosts)
 	var d state.Delta
 	if include.Stats {
 		d = state.DiffWithStats(prev, next)
@@ -508,10 +525,14 @@ func marshalDelta(prev, next state.Snapshot, include scanner.Include) []byte {
 	return msg
 }
 
-// marshalEvents builds one state.event notification per event.
-func marshalEvents(events []state.Event, include scanner.Include) [][]byte {
+// marshalEvents builds one state.event notification per event, skipping the
+// ones that happened on a host this subscriber did not ask to see.
+func marshalEvents(events []state.Event, include scanner.Include, hosts state.HostFilter) [][]byte {
 	out := make([][]byte, 0, len(events))
 	for _, ev := range events {
+		if !hosts.Allows(ev.Host) {
+			continue
+		}
 		if ev.Port != nil {
 			p := filterPort(*ev.Port, include)
 			ev.Port = &p
@@ -543,7 +564,8 @@ func emptyDelta(d state.Delta) bool {
 // filterSnapshot strips the enrichments this subscriber did not ask for, so
 // `include` is honest even when another subscriber made the scanner collect
 // them.
-func filterSnapshot(snap state.Snapshot, include scanner.Include) state.Snapshot {
+func filterSnapshot(snap state.Snapshot, include scanner.Include, hosts state.HostFilter) state.Snapshot {
+	snap = state.FilterSnapshot(snap, hosts)
 	snap.Ports = filterPorts(snap.Ports, include)
 	if snap.Groups == nil {
 		snap.Groups = []state.Group{}
@@ -557,10 +579,12 @@ func filterSnapshot(snap state.Snapshot, include scanner.Include) state.Snapshot
 	if snap.Sessions == nil {
 		snap.Sessions = []state.SessionRecord{}
 	}
-	// `hosts` is never filtered. A machine's load is state the daemon
-	// collects for itself on every tick, not an enrichment a subscriber opts
-	// into, so it reaches every subscriber whatever their `include` — the
-	// rule contract §22 set for configured health.
+	// `hosts` is never filtered by `include`. A machine's load is state the
+	// daemon collects for itself on every tick, not an enrichment a
+	// subscriber opts into, so it reaches every subscriber whatever their
+	// `include` — the rule contract §22 set for configured health. The
+	// `hosts` *filter* above is a different question: it decides which
+	// machines this subscriber asked about at all.
 	if snap.Hosts == nil {
 		snap.Hosts = []state.Host{}
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -379,7 +379,7 @@ func (s *Server) demand() (int, scanner.Include) {
 // is unchanged.
 func (s *Server) subscribe(c *Conn, id json.RawMessage, include scanner.Include, events bool, hosts state.HostFilter) {
 	s.subsMu.Lock()
-	snap := s.loop.Cached()
+	snap := s.loop.CachedAll()
 	c.subscribed, c.include, c.events, c.hosts = true, include, events, hosts
 	filtered := filterSnapshot(snap, include, hosts)
 	raw, err := json.Marshal(filtered)

--- a/internal/daemon/stdio_integration_test.go
+++ b/internal/daemon/stdio_integration_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+// Integration tests for `sonar daemon stdio`, the far end of a remote host's
+// bridge. They run the real binary as a subprocess and speak JSON-RPC over its
+// pipes — the same thing the local daemon does through ssh, minus the ssh.
+package daemon_test
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// stdioStream is a spawned `sonar daemon stdio` seen as one bidirectional
+// stream, which is exactly how the bridge sees it.
+type stdioStream struct {
+	cmd *exec.Cmd
+	in  io.WriteCloser
+	out io.ReadCloser
+}
+
+func (s *stdioStream) Read(b []byte) (int, error)  { return s.out.Read(b) }
+func (s *stdioStream) Write(b []byte) (int, error) { return s.in.Write(b) }
+func (s *stdioStream) Close() error {
+	_ = s.in.Close()
+	_ = s.out.Close()
+	if s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+	}
+	_ = s.cmd.Wait()
+	return nil
+}
+
+// startStdio runs `sonar daemon stdio` against this env's socket.
+func (e *env) startStdio(t *testing.T) *stdioStream {
+	t.Helper()
+	cmd := e.command("daemon", "stdio")
+	cmd.WaitDelay = waitDelay
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = testWriter{t}
+	ownProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting `sonar daemon stdio`: %v", err)
+	}
+	s := &stdioStream{cmd: cmd, in: in, out: out}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(b []byte) (int, error) {
+	w.t.Logf("daemon stdio: %s", b)
+	return len(b), nil
+}
+
+// TestStdioSpeaksTheSameProtocol is the bridge's contract with the far side:
+// the stream carries the ordinary daemon protocol, handshake, reads and
+// subscriptions included.
+func TestStdioSpeaksTheSameProtocol(t *testing.T) {
+	e := newEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	c, err := client.Attach(ctx, e.startStdio(t), "stdio", client.ClientInfo{
+		Name: "daemon", Version: "itest",
+	})
+	if err != nil {
+		t.Fatalf("handshake over stdio: %v", err)
+	}
+	defer c.Close()
+
+	hello := c.Hello()
+	if hello.ProtocolVersion != rpc.ProtocolVersion {
+		t.Errorf("protocol_version = %q, want %q", hello.ProtocolVersion, rpc.ProtocolVersion)
+	}
+	if hello.Socket != e.socket {
+		t.Errorf("socket = %q, want the daemon this bridge proxied to (%q)", hello.Socket, e.socket)
+	}
+
+	var snap state.Snapshot
+	if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{}, &snap); err != nil {
+		t.Fatalf("state.snapshot over stdio: %v", err)
+	}
+	if len(snap.Hosts) == 0 || snap.Hosts[0].Name != state.LocalhostName {
+		t.Errorf("hosts = %+v, want the far side's localhost row", snap.Hosts)
+	}
+	for _, p := range snap.Ports {
+		if p.Host != state.LocalhostName {
+			t.Errorf("the far side tagged a row %q; it should only know localhost", p.Host)
+		}
+	}
+
+	sub, err := c.Subscribe(ctx, client.SubscribeOptions{Events: true})
+	if err != nil {
+		t.Fatalf("state.subscribe over stdio: %v", err)
+	}
+	if sub.Snapshot.DaemonVersion == "" {
+		t.Error("the subscription snapshot has no daemon_version")
+	}
+}
+
+// TestStdioSharesTheRunningDaemon proves the rule the spec fixes: the bridge
+// does not start a second scanner beside the daemon already on that host, it
+// proxies to it. Two stdio bridges and the socket all report one pid.
+func TestStdioSharesTheRunningDaemon(t *testing.T) {
+	e := newEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	direct := e.connect(ctx).Hello().PID
+
+	for i := 0; i < 2; i++ {
+		c, err := client.Attach(ctx, e.startStdio(t), "stdio", client.ClientInfo{
+			Name: "daemon", Version: "itest",
+		})
+		if err != nil {
+			t.Fatalf("handshake over stdio: %v", err)
+		}
+		if got := c.Hello().PID; got != direct {
+			t.Errorf("stdio bridge %d reported pid %d, want the running daemon's %d", i, got, direct)
+		}
+		c.Close()
+	}
+}
+
+// TestStdioAutostartsTheDaemon is the spec's autostart rule: a bridge to a host
+// where nothing is running starts the daemon rather than failing.
+func TestStdioAutostartsTheDaemon(t *testing.T) {
+	e := newEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	c, err := client.Attach(ctx, e.startStdio(t), "stdio", client.ClientInfo{
+		Name: "daemon", Version: "itest",
+	})
+	if err != nil {
+		t.Fatalf("handshake over stdio with no daemon running: %v", err)
+	}
+	pid := c.Hello().PID
+	c.Close()
+	t.Cleanup(func() { e.stopDaemon(pid) })
+
+	if pid <= 0 {
+		t.Errorf("pid = %d, want the autostarted daemon's", pid)
+	}
+}
+
+// TestStdioRefusesWithNoAutostart covers the opt-out.
+func TestStdioRefusesWithNoAutostart(t *testing.T) {
+	e := newEnv(t)
+	cmd := e.command("daemon", "stdio", "--no-autostart")
+	cmd.WaitDelay = waitDelay
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("want a failure with no daemon running, got:\n%s", out)
+	}
+}

--- a/internal/remote/bridge.go
+++ b/internal/remote/bridge.go
@@ -1,0 +1,433 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// bridge is one registered host: the connect/subscribe/reconnect goroutine,
+// the rows that host currently contributes, and the Host row describing the
+// connection itself.
+//
+// Everything a reader needs is behind mu and is a value copy, so the manager
+// can assemble the published rows without ever waiting on a network.
+type bridge struct {
+	cfg Host
+	// version is what this daemon calls itself in daemon.hello on the far
+	// side. Immutable for the life of the bridge.
+	version string
+	logger  *slog.Logger
+	dial    Dialer
+	// onChange is called whenever this host's rows or status changed. The
+	// manager forwards it to the scanner, which republishes.
+	onChange func()
+	// onEvent forwards one of the remote daemon's events into the local
+	// stream, already tagged with this host's name.
+	onEvent func(state.Event)
+	// now and after are the clock seams the reconnect tests drive.
+	now func() time.Time
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu sync.RWMutex
+	// snap is the remote daemon's own state, as it describes itself: rows
+	// tagged "localhost", keys unprefixed. Tagging happens on the way out, in
+	// Rows, so the delta arithmetic on this side stays the remote's own.
+	snap    state.Snapshot
+	haveSub bool
+	status  state.Host
+	// cli is the live client, used to forward remote.call. Nil while
+	// disconnected.
+	cli *client.Client
+}
+
+func newBridge(cfg Host, version string, dial Dialer, logger *slog.Logger, onChange func(), onEvent func(state.Event)) *bridge {
+	b := &bridge{
+		cfg:      cfg,
+		version:  version,
+		logger:   logger,
+		dial:     dial,
+		onChange: onChange,
+		onEvent:  onEvent,
+		now:      time.Now,
+		done:     make(chan struct{}),
+	}
+	b.status = state.Host{
+		Name:     cfg.Name,
+		Address:  cfg.Target,
+		Status:   state.HostConnecting,
+		LastSeen: b.now().Format(time.RFC3339),
+	}
+	return b
+}
+
+// start runs the connect loop until stop is called.
+func (b *bridge) start(ctx context.Context) {
+	ctx, b.cancel = context.WithCancel(ctx)
+	go func() {
+		defer close(b.done)
+		b.run(ctx)
+	}()
+}
+
+// stop tears the bridge down and waits for its goroutine.
+func (b *bridge) stop() {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	b.closeClient()
+	<-b.done
+}
+
+// Rows is this host's contribution to the published state: its ports, groups
+// and sessions tagged with the host name, plus exactly one Host row.
+//
+// A disconnected host contributes no ports and no groups — showing the last
+// state of a machine we can no longer see would be a lie clients cannot detect
+// — but it always contributes its Host row, so a host stays in the switcher
+// with its status while it is unreachable.
+func (b *bridge) Rows() state.Rows {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	host := b.status
+	if !b.haveSub {
+		return state.Rows{Hosts: []state.Host{host}}
+	}
+	rows := state.Rows{
+		Ports:    b.snap.Ports,
+		Groups:   b.snap.Groups,
+		Tunnels:  b.snap.Tunnels,
+		Proxies:  b.snap.Proxies,
+		Sessions: b.snap.Sessions,
+	}.Tag(b.cfg.Name)
+	host.Ports, host.Groups = len(rows.Ports), len(rows.Groups)
+	rows.Hosts = []state.Host{host}
+	return rows
+}
+
+// HostRow is the connection's own status row.
+func (b *bridge) HostRow() state.Host {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	h := b.status
+	if b.haveSub {
+		h.Ports, h.Groups = len(b.snap.Ports), len(b.snap.Groups)
+	}
+	return h
+}
+
+// Config is the host as it is registered.
+func (b *bridge) Config() Host {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.cfg
+}
+
+// Call forwards one method to this host's daemon and returns the result
+// verbatim. It fails fast while the bridge is down rather than queueing: a
+// caller wants to know that the host is unreachable, not to block on it.
+func (b *bridge) Call(ctx context.Context, method string, params json.RawMessage) (json.RawMessage, error) {
+	b.mu.RLock()
+	cli := b.cli
+	status, reason := b.status.Status, b.status.StatusReason
+	b.mu.RUnlock()
+
+	if cli == nil {
+		detail := "host " + b.cfg.Name + " is " + status
+		if reason != nil && *reason != "" {
+			detail += ": " + *reason
+		}
+		return nil, rpc.NewError(rpc.CodeNotFound, detail,
+			"`sonar remote list` shows the connection; `sonar remote install "+b.cfg.Name+"` puts a daemon on it")
+	}
+	var out json.RawMessage
+	if err := cli.Call(ctx, method, params, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// run is the connect / subscribe / reconnect loop. It never gives up: a host
+// the user registered stays registered until they remove it, and a laptop that
+// is closed for the night reconnects when it opens.
+func (b *bridge) run(ctx context.Context) {
+	backoff := ReconnectMin
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		b.setStatus(state.HostConnecting, "")
+
+		err := b.session(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err == nil {
+			// A clean end of stream is still a disconnect; retry promptly,
+			// because a bridge that ended cleanly is one whose remote daemon
+			// idled out or was restarted.
+			backoff = ReconnectMin
+		} else {
+			b.logger.Debug("remote host disconnected",
+				"host", b.cfg.Name, "error", err, "retry_in", backoff.String())
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff = nextBackoff(backoff)
+	}
+}
+
+// nextBackoff doubles the delay, capped at ReconnectMax.
+func nextBackoff(d time.Duration) time.Duration {
+	next := d * ReconnectFactor
+	if next > ReconnectMax {
+		return ReconnectMax
+	}
+	if next < ReconnectMin {
+		return ReconnectMin
+	}
+	return next
+}
+
+// session is one connection's whole life: dial, handshake, subscribe, follow
+// the stream. It returns when the bridge is gone.
+//
+// A session that got as far as subscribing resets the caller's backoff, so a
+// host that works and then drops retries in a second rather than in whatever
+// the last failure had backed off to.
+func (b *bridge) session(ctx context.Context) error {
+	stream, err := b.dial(ctx, b.cfg)
+	if err != nil {
+		b.fail(state.HostUnreachable, err)
+		return err
+	}
+
+	helloCtx, cancel := context.WithTimeout(ctx, HandshakeTimeout)
+	started := b.now()
+	cli, err := client.Attach(helloCtx, stream, "ssh://"+b.cfg.Target, client.ClientInfo{
+		Name:      "daemon",
+		Version:   b.localVersion(),
+		Keepalive: true,
+	})
+	cancel()
+	if err != nil {
+		_ = stream.Close()
+		var mismatch *client.ProtocolMismatchError
+		if errors.As(err, &mismatch) {
+			b.fail(state.HostIncompatible, err)
+		} else {
+			b.fail(state.HostUnreachable, err)
+		}
+		return err
+	}
+	latency := b.now().Sub(started)
+	defer func() {
+		cli.Close()
+		b.closeClient()
+	}()
+
+	hello := cli.Hello()
+	b.mu.Lock()
+	b.cli = cli
+	b.status.DaemonVersion = hello.DaemonVersion
+	b.status.ProtocolVersion = hello.ProtocolVersion
+	b.mu.Unlock()
+
+	sub, err := cli.Subscribe(ctx, client.SubscribeOptions{Events: true, Buffer: 256})
+	if err != nil {
+		b.fail(state.HostUnreachable, err)
+		return err
+	}
+
+	b.mu.Lock()
+	b.snap = sub.Snapshot
+	b.haveSub = true
+	b.status.Status = state.HostConnected
+	b.status.StatusReason = nil
+	b.status.LatencyMs = latency.Milliseconds()
+	b.adoptRemoteHostRow(sub.Snapshot)
+	b.mu.Unlock()
+	b.logger.Info("remote host connected",
+		"host", b.cfg.Name, "target", b.cfg.Target,
+		"daemon_version", hello.DaemonVersion, "latency_ms", latency.Milliseconds())
+	b.onChange()
+
+	return b.follow(ctx, cli, sub)
+}
+
+// follow applies deltas until the bridge drops. Every applied delta publishes,
+// which is what puts a remote port on a local client's screen.
+func (b *bridge) follow(ctx context.Context, cli *client.Client, sub *client.Subscription) error {
+	ping := time.NewTicker(PingInterval)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case d, ok := <-sub.Deltas:
+			if !ok {
+				b.drop(cli.Err())
+				return cli.Err()
+			}
+			b.mu.Lock()
+			gap := b.snap.Seq != 0 && d.Seq > b.snap.Seq+1
+			b.snap = state.Apply(b.snap, d)
+			b.status.LastSeen = b.now().Format(time.RFC3339)
+			b.adoptRemoteHostRow(b.snap)
+			b.mu.Unlock()
+			if gap || sub.Dropped() {
+				// A seq gap is the documented resync trigger (contract §15),
+				// and a dropped notification is a gap we caused ourselves.
+				// Re-establishing the session is the cheapest correct resync.
+				b.logger.Debug("remote host resyncing", "host", b.cfg.Name, "seq", d.Seq)
+				b.drop(errors.New("delta sequence gap"))
+				return nil
+			}
+			b.onChange()
+
+		case ev, ok := <-sub.Events:
+			if !ok {
+				b.drop(cli.Err())
+				return cli.Err()
+			}
+			ev.Host = b.cfg.Name
+			if ev.Port != nil {
+				p := *ev.Port
+				p.Host = b.cfg.Name
+				ev.Port = &p
+			}
+			b.onEvent(ev)
+
+		case <-ping.C:
+			pingCtx, cancel := context.WithTimeout(ctx, PingTimeout)
+			started := b.now()
+			err := cli.Call(pingCtx, "daemon.status", rpc.Empty{}, nil)
+			cancel()
+			if err != nil {
+				b.drop(err)
+				return err
+			}
+			b.mu.Lock()
+			b.status.LatencyMs = b.now().Sub(started).Milliseconds()
+			b.status.LastSeen = b.now().Format(time.RFC3339)
+			b.mu.Unlock()
+
+		case <-cli.Done():
+			b.drop(cli.Err())
+			return cli.Err()
+		}
+	}
+}
+
+// adoptRemoteHostRow copies the remote's own localhost row — its cpu, load,
+// memory, disk, os and uptime — onto this host's status row, keeping the
+// fields that describe the *connection* rather than the machine. Caller holds
+// the write lock.
+func (b *bridge) adoptRemoteHostRow(snap state.Snapshot) {
+	for _, h := range snap.Hosts {
+		if !state.IsLocalhost(h.Name) {
+			continue
+		}
+		status, reason, latency := b.status.Status, b.status.StatusReason, b.status.LatencyMs
+		daemonVersion, protocolVersion := b.status.DaemonVersion, b.status.ProtocolVersion
+		lastSeen := b.status.LastSeen
+
+		b.status = h
+		b.status.Name, b.status.Address = b.cfg.Name, b.cfg.Target
+		b.status.Status, b.status.StatusReason, b.status.LatencyMs = status, reason, latency
+		if daemonVersion != "" {
+			b.status.DaemonVersion = daemonVersion
+		}
+		if protocolVersion != "" {
+			b.status.ProtocolVersion = protocolVersion
+		}
+		if lastSeen != "" {
+			b.status.LastSeen = lastSeen
+		}
+		return
+	}
+}
+
+// drop marks the bridge unreachable and forgets the rows it was publishing.
+func (b *bridge) drop(err error) {
+	b.mu.Lock()
+	b.haveSub = false
+	b.snap = state.Snapshot{}
+	b.cli = nil
+	b.status = state.Host{
+		Name:            b.cfg.Name,
+		Address:         b.cfg.Target,
+		Status:          state.HostUnreachable,
+		StatusReason:    reasonOf(err),
+		DaemonVersion:   b.status.DaemonVersion,
+		ProtocolVersion: b.status.ProtocolVersion,
+		LastSeen:        b.status.LastSeen,
+	}
+	b.mu.Unlock()
+	b.onChange()
+}
+
+// fail records a connection that never came up.
+func (b *bridge) fail(status string, err error) {
+	b.mu.Lock()
+	b.haveSub = false
+	b.snap = state.Snapshot{}
+	b.cli = nil
+	b.status.Name, b.status.Address = b.cfg.Name, b.cfg.Target
+	b.status.Status, b.status.StatusReason = status, reasonOf(err)
+	b.status.Ports, b.status.Groups = 0, 0
+	b.mu.Unlock()
+	b.onChange()
+}
+
+// setStatus updates the status word without touching the load fields.
+func (b *bridge) setStatus(status, reason string) {
+	b.mu.Lock()
+	changed := b.status.Status != status
+	b.status.Status = status
+	if reason != "" {
+		b.status.StatusReason = &reason
+	}
+	b.mu.Unlock()
+	if changed {
+		b.onChange()
+	}
+}
+
+func (b *bridge) closeClient() {
+	b.mu.Lock()
+	cli := b.cli
+	b.cli = nil
+	b.mu.Unlock()
+	if cli != nil {
+		cli.Close()
+	}
+}
+
+// localVersion is the version this daemon reports to the remote in
+// daemon.hello.
+func (b *bridge) localVersion() string { return b.version }
+
+func reasonOf(err error) *string {
+	if err == nil {
+		return nil
+	}
+	s := err.Error()
+	return &s
+}

--- a/internal/remote/fakedaemon_test.go
+++ b/internal/remote/fakedaemon_test.go
@@ -1,0 +1,209 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// fakeDaemon is a remote sonar daemon as the bridge sees it: a newline-framed
+// JSON-RPC peer that answers daemon.hello, serves one state.subscribe and then
+// pushes whatever the test tells it to push.
+//
+// It exists so the multiplexer can be tested without SSH, without a
+// subprocess and without a second real daemon: the bridge's contract with the
+// far side is the wire, and this is the wire.
+type fakeDaemon struct {
+	t *testing.T
+
+	// protocolVersion is what daemon.hello reports. A test sets it to "2.0.0"
+	// to prove the bridge marks the host incompatible.
+	protocolVersion string
+	daemonVersion   string
+
+	mu       sync.Mutex
+	conn     net.Conn
+	enc      *rpc.Encoder
+	snap     state.Snapshot
+	seq      uint64
+	closed   bool
+	handlers map[string]func(params json.RawMessage) (any, *rpc.Error)
+
+	// subscribed carries one token per accepted state.subscribe, so a test can
+	// wait for "the bridge is following this session" without racing the
+	// goroutine that dials. A reconnect produces a second token.
+	subscribed chan struct{}
+}
+
+func newFakeDaemon(t *testing.T) *fakeDaemon {
+	return &fakeDaemon{
+		t:               t,
+		protocolVersion: rpc.ProtocolVersion,
+		daemonVersion:   "1.2.3",
+		snap: state.Snapshot{
+			Seq:      1,
+			At:       "2026-09-06T10:00:00Z",
+			Ports:    []state.Port{},
+			Groups:   []state.Group{},
+			Tunnels:  []state.Tunnel{},
+			Proxies:  []state.Proxy{},
+			Sessions: []state.SessionRecord{},
+			Hosts:    []state.Host{{Name: state.LocalhostName, Address: state.LocalhostName, Status: state.HostConnected}},
+		},
+		handlers:   map[string]func(json.RawMessage) (any, *rpc.Error){},
+		subscribed: make(chan struct{}, 16),
+	}
+}
+
+// dialer is the Dialer a test hands the manager: every dial makes a new pipe
+// and a new serving goroutine, so a reconnect really is a new session.
+func (f *fakeDaemon) dialer() Dialer {
+	return func(_ context.Context, _ Host) (io.ReadWriteCloser, error) {
+		mine, theirs := net.Pipe()
+		f.mu.Lock()
+		f.conn, f.enc, f.closed = mine, rpc.NewEncoder(mine), false
+		f.mu.Unlock()
+		go f.serve(mine)
+		return theirs, nil
+	}
+}
+
+// setSnapshot replaces the state the far side reports and pushes the delta,
+// exactly as a real daemon's scan tick would.
+func (f *fakeDaemon) setSnapshot(next state.Snapshot) {
+	f.mu.Lock()
+	prev := f.snap
+	f.seq++
+	next.Seq = f.snap.Seq + 1
+	if next.At == "" {
+		next.At = time.Now().UTC().Format(time.RFC3339)
+	}
+	f.snap = next
+	enc, closed := f.enc, f.closed
+	f.mu.Unlock()
+
+	if enc == nil || closed {
+		return
+	}
+	d := state.Diff(prev, next)
+	raw, err := json.Marshal(d)
+	if err != nil {
+		f.t.Error(err)
+		return
+	}
+	_ = enc.Encode(rpc.Notification{JSONRPC: rpc.Version, Method: rpc.MethodStateDelta, Params: raw})
+}
+
+// pushEvent sends one state.event notification.
+func (f *fakeDaemon) pushEvent(ev state.Event) {
+	f.mu.Lock()
+	enc := f.enc
+	f.mu.Unlock()
+	if enc == nil {
+		return
+	}
+	raw, _ := json.Marshal(ev)
+	_ = enc.Encode(rpc.Notification{JSONRPC: rpc.Version, Method: rpc.MethodStateEvent, Params: raw})
+}
+
+// hangUp drops the current connection, which is what a dead SSH process looks
+// like from here.
+func (f *fakeDaemon) hangUp() {
+	f.mu.Lock()
+	conn := f.conn
+	f.closed = true
+	f.mu.Unlock()
+	if conn != nil {
+		_ = conn.Close()
+	}
+}
+
+// handle installs a reply for one method, used by the remote.call tests.
+func (f *fakeDaemon) handle(method string, fn func(json.RawMessage) (any, *rpc.Error)) {
+	f.mu.Lock()
+	f.handlers[method] = fn
+	f.mu.Unlock()
+}
+
+// waitSubscribed blocks until the bridge has subscribed once more than the
+// times it already had.
+func (f *fakeDaemon) waitSubscribed(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.subscribed:
+	case <-time.After(testTimeout):
+		t.Fatal("the bridge never subscribed")
+	}
+}
+
+func (f *fakeDaemon) serve(conn net.Conn) {
+	dec := rpc.NewDecoder(conn, 4<<20)
+	for {
+		msg, err := dec.Next()
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
+				return
+			}
+			return
+		}
+		if !msg.IsRequest() {
+			continue
+		}
+		result, rpcErr := f.dispatch(msg)
+		f.mu.Lock()
+		enc := f.enc
+		f.mu.Unlock()
+		if enc == nil {
+			return
+		}
+		if rpcErr != nil {
+			_ = enc.Encode(rpc.Response{JSONRPC: rpc.Version, ID: msg.ID, Error: rpcErr})
+			continue
+		}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			return
+		}
+		_ = enc.Encode(rpc.Response{JSONRPC: rpc.Version, ID: msg.ID, Result: raw})
+	}
+}
+
+func (f *fakeDaemon) dispatch(msg rpc.Message) (any, *rpc.Error) {
+	f.mu.Lock()
+	handler := f.handlers[msg.Method]
+	f.mu.Unlock()
+	if handler != nil {
+		return handler(msg.Params)
+	}
+
+	switch msg.Method {
+	case "daemon.hello":
+		return rpc.DaemonHelloResult{
+			ProtocolVersion: f.protocolVersion,
+			DaemonVersion:   f.daemonVersion,
+			PID:             4242,
+			Capabilities:    []string{"state", "ports.read"},
+		}, nil
+	case "state.subscribe":
+		f.mu.Lock()
+		snap := f.snap
+		f.mu.Unlock()
+		select {
+		case f.subscribed <- struct{}{}:
+		default:
+		}
+		return snap, nil
+	case "daemon.status":
+		return rpc.DaemonStatusResult{PID: 4242}, nil
+	default:
+		return nil, rpc.NewError(rpc.CodeNotFound, "unknown method "+msg.Method, "")
+	}
+}

--- a/internal/remote/handlers.go
+++ b/internal/remote/handlers.go
@@ -1,0 +1,249 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// Sentinel errors the handlers turn into protocol errors.
+var (
+	ErrDuplicateHost = errors.New("a remote host with that name is already registered")
+	ErrUnknownHost   = errors.New("no remote host with that name")
+)
+
+// The manager is process-global because the daemon is: one daemon, one set of
+// bridges. It is installed by the OnStart hook and torn down by OnShutdown.
+var (
+	managerMu sync.RWMutex
+	manager   *Manager
+)
+
+// Manager returns the running connection manager, or nil before the daemon has
+// started one.
+func Current() *Manager {
+	managerMu.RLock()
+	defer managerMu.RUnlock()
+	return manager
+}
+
+func setManager(m *Manager) {
+	managerMu.Lock()
+	manager = m
+	managerMu.Unlock()
+}
+
+func init() {
+	daemon.RegisterHandler("remote.list", handleList)
+	daemon.RegisterHandler("remote.add", handleAdd)
+	daemon.RegisterHandler("remote.remove", handleRemove)
+	daemon.RegisterHandler("remote.call", handleCall)
+	daemon.RegisterCapability("remote")
+
+	daemon.OnStart(start)
+	daemon.OnShutdown(func(bool) {
+		if m := Current(); m != nil {
+			m.Stop()
+			setManager(nil)
+		}
+	})
+}
+
+// start builds the manager from the user config and wires it into the scan
+// loop. A remote host's state change republishes without a local scan, and a
+// remote event is broadcast to whoever asked to see that host.
+func start(rt *daemon.Runtime) {
+	hosts, warnings := config.RemoteHosts()
+	for _, w := range warnings {
+		rt.Logger.Warn(w)
+	}
+
+	m := NewManager(Options{
+		Version:  rt.Version,
+		Logger:   rt.Logger,
+		OnChange: rt.Scanner.RemoteChanged,
+		OnEvent:  rt.Server().BroadcastEvent,
+	})
+	setManager(m)
+	rt.Scanner.SetRemote(m.Rows)
+	m.Start(context.Background(), hosts)
+	if len(hosts) > 0 {
+		rt.Logger.Info("connecting to remote hosts", "hosts", len(hosts))
+	}
+}
+
+// saveHosts is the manager's default persistence: `remote.hosts` in the user
+// config.
+func saveHosts(hosts []Host) error { return config.SaveRemoteHosts(hosts) }
+
+// requireManager is the "the daemon is not running remote support" guard. It
+// cannot normally fail — the hook installs the manager before the first
+// connection is accepted — but a handler must never dereference nil.
+func requireManager() (*Manager, error) {
+	m := Current()
+	if m == nil {
+		return nil, rpc.NewError(rpc.CodeInternal, "the remote host manager is not running", "")
+	}
+	return m, nil
+}
+
+func handleList(_ context.Context, _ *daemon.Request) (any, error) {
+	m, err := requireManager()
+	if err != nil {
+		return nil, err
+	}
+	return rpc.RemoteListResult{Hosts: m.Hosts()}, nil
+}
+
+func handleAdd(_ context.Context, req *daemon.Request) (any, error) {
+	var p rpc.RemoteAddParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	m, err := requireManager()
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := NormalizeHost(Host{
+		Name:      p.Name,
+		Target:    p.Target,
+		SSHArgs:   p.SSHArgs,
+		Identity:  p.Identity,
+		Port:      p.Port,
+		RemoteBin: p.RemoteBin,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := m.Add(h); err != nil {
+		if errors.Is(err, ErrDuplicateHost) {
+			return nil, rpc.NewError(rpc.CodeInvalidParams,
+				"remote host "+h.Name+" is already registered",
+				"pick another --name, or `sonar remote remove "+h.Name+"` first")
+		}
+		return nil, rpc.NewError(rpc.CodeInternal, err.Error(), "")
+	}
+	return rpc.RemoteAddResult{OK: true, Host: hostRowFor(m, h)}, nil
+}
+
+func handleRemove(_ context.Context, req *daemon.Request) (any, error) {
+	var p rpc.RemoteRemoveParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	m, err := requireManager()
+	if err != nil {
+		return nil, err
+	}
+	if err := m.Remove(strings.TrimSpace(p.Name)); err != nil {
+		if errors.Is(err, ErrUnknownHost) {
+			return nil, unknownHostError(m, p.Name)
+		}
+		return nil, rpc.NewError(rpc.CodeInternal, err.Error(), "")
+	}
+	return rpc.OKResult{OK: true}, nil
+}
+
+// handleCall forwards a method to a host's daemon. Writes are forwarded like
+// any other method: the remote daemon owns its own `.sonar.yaml` under the
+// same rules as the local one, so there is no read-only mode (remote-hosts
+// spec, decision 3).
+//
+// `remote.call` is deliberately not a recursion guard's business: the far side
+// subscribes to nothing but its own machine, so forwarding `remote.call` to a
+// host that has hosts of its own reaches exactly one level, which is what a
+// caller asked for.
+func handleCall(ctx context.Context, req *daemon.Request) (any, error) {
+	var p rpc.RemoteCallParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(p.Host) == "" || strings.TrimSpace(p.Method) == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "host and method are required",
+			`{"host": "hetzner", "method": "ports.list", "params": {}}`)
+	}
+	m, err := requireManager()
+	if err != nil {
+		return nil, err
+	}
+	if state.IsLocalhost(p.Host) {
+		return nil, rpc.NewError(rpc.CodeInvalidParams,
+			"remote.call cannot target localhost",
+			"call "+p.Method+" directly instead")
+	}
+
+	params := p.Params
+	if len(params) == 0 {
+		params = json.RawMessage("{}")
+	}
+	out, err := m.Call(ctx, p.Host, p.Method, params)
+	if err != nil {
+		if errors.Is(err, ErrUnknownHost) {
+			return nil, unknownHostError(m, p.Host)
+		}
+		return nil, err
+	}
+	return rpc.RemoteCallResult(out), nil
+}
+
+// unknownHostError names the hosts that do exist, which is what a user who
+// mistyped one wants to see.
+func unknownHostError(m *Manager, name string) error {
+	known := make([]string, 0, 4)
+	for _, h := range m.Configs() {
+		known = append(known, h.Name)
+	}
+	hint := "`sonar remote add <user@host>` registers one"
+	if len(known) > 0 {
+		hint = "registered hosts: " + strings.Join(known, ", ")
+	}
+	return rpc.NewError(rpc.CodeNotFound, "no remote host named "+name, hint)
+}
+
+// hostRowFor is the Host row for a just-registered host: whatever the bridge
+// already knows, which right after Add is "connecting".
+func hostRowFor(m *Manager, h Host) state.Host {
+	for _, row := range m.Hosts() {
+		if row.Name == h.Name {
+			return row
+		}
+	}
+	return state.Host{Name: h.Name, Address: h.Target, Status: state.HostConnecting}
+}
+
+// NormalizeHost fills in the name from the target when none was given and
+// checks what the spec fixes: names are [a-z0-9-]+, unique, and never resolved
+// as DNS by sonar — the target is what `ssh` receives.
+func NormalizeHost(h Host) (Host, error) {
+	h.Target = strings.TrimSpace(h.Target)
+	h.Name = strings.TrimSpace(h.Name)
+	if h.Target == "" {
+		return h, rpc.NewError(rpc.CodeInvalidParams, "target is required",
+			"the target is what ssh receives: `deploy@203.0.113.7`, or a ~/.ssh/config alias")
+	}
+	if h.Name == "" {
+		h.Name = config.DefaultHostName(h.Target)
+	}
+	if !config.ValidHostName(h.Name) {
+		return h, rpc.NewError(rpc.CodeInvalidParams,
+			"invalid host name "+h.Name,
+			"names are lowercase letters, digits and dashes")
+	}
+	if state.IsLocalhost(h.Name) {
+		return h, rpc.NewError(rpc.CodeInvalidParams,
+			`"localhost" names this machine and cannot be registered`,
+			"pick another --name")
+	}
+	if h.Port < 0 || h.Port > 65535 {
+		return h, rpc.NewError(rpc.CodeInvalidParams, "invalid ssh port", "")
+	}
+	return h, nil
+}

--- a/internal/remote/handlers.go
+++ b/internal/remote/handlers.go
@@ -114,7 +114,7 @@ func handleAdd(_ context.Context, req *daemon.Request) (any, error) {
 
 	h, err := NormalizeHost(Host{
 		Name:      p.Name,
-		Target:    p.Target,
+		Target:    TargetOf(p),
 		SSHArgs:   p.SSHArgs,
 		Identity:  p.Identity,
 		Port:      p.Port,
@@ -192,6 +192,16 @@ func handleCall(ctx context.Context, req *daemon.Request) (any, error) {
 		return nil, err
 	}
 	return rpc.RemoteCallResult(out), nil
+}
+
+// TargetOf is the SSH destination a remote.add call names. Some clients spell
+// the field `host` rather than `target`; both mean the string ssh receives,
+// and `target` wins when a client sends both.
+func TargetOf(p rpc.RemoteAddParams) string {
+	if t := strings.TrimSpace(p.Target); t != "" {
+		return t
+	}
+	return strings.TrimSpace(p.Host)
 }
 
 // unknownHostError names the hosts that do exist, which is what a user who

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -1,0 +1,246 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"sync"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// Options configures a Manager.
+type Options struct {
+	// Version is the local daemon's version, sent to each remote in
+	// daemon.hello.
+	Version string
+	// Logger receives the manager's log. Nil is a discard logger.
+	Logger *slog.Logger
+	// Dial opens one bridge. Nil means DialSSH.
+	Dial Dialer
+	// OnChange is called whenever any host's rows or status moved. The daemon
+	// points it at scanner.Loop.RemoteChanged, which republishes without
+	// re-scanning the local machine.
+	OnChange func()
+	// OnEvent forwards one remote event into the local stream. The daemon
+	// points it at Server.BroadcastEvent.
+	OnEvent func(state.Event)
+	// Save persists the host list. Nil means config.SaveRemoteHosts.
+	Save func([]Host) error
+}
+
+// Manager owns one bridge per registered host and merges what they report into
+// a single state.Rows the scanner folds into every published snapshot.
+type Manager struct {
+	opts Options
+	ctx  context.Context
+	stop context.CancelFunc
+
+	mu      sync.RWMutex
+	bridges map[string]*bridge
+	order   []string
+}
+
+// NewManager builds a manager. It does not connect; call Start.
+func NewManager(opts Options) *Manager {
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.DiscardHandler)
+	}
+	if opts.Dial == nil {
+		opts.Dial = DialSSH
+	}
+	if opts.OnChange == nil {
+		opts.OnChange = func() {}
+	}
+	if opts.OnEvent == nil {
+		opts.OnEvent = func(state.Event) {}
+	}
+	return &Manager{opts: opts, bridges: map[string]*bridge{}}
+}
+
+// Start brings up a bridge for every host in hosts and keeps them up until
+// Stop. Starting twice is a no-op on the second call.
+func (m *Manager) Start(ctx context.Context, hosts []Host) {
+	m.mu.Lock()
+	if m.stop != nil {
+		m.mu.Unlock()
+		return
+	}
+	m.ctx, m.stop = context.WithCancel(ctx)
+	m.mu.Unlock()
+
+	for _, h := range hosts {
+		m.add(h)
+	}
+	if len(hosts) > 0 {
+		m.opts.OnChange()
+	}
+}
+
+// Stop tears every bridge down.
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	stop := m.stop
+	m.stop = nil
+	bridges := m.bridges
+	m.bridges = map[string]*bridge{}
+	m.order = nil
+	m.mu.Unlock()
+
+	if stop != nil {
+		stop()
+	}
+	for _, b := range bridges {
+		b.stop()
+	}
+}
+
+// add registers and starts one host. The caller has checked for duplicates.
+func (m *Manager) add(h Host) {
+	b := newBridge(h, m.opts.Version, m.opts.Dial, m.opts.Logger, m.opts.OnChange, m.opts.OnEvent)
+
+	m.mu.Lock()
+	ctx := m.ctx
+	if _, dup := m.bridges[h.Name]; dup {
+		m.mu.Unlock()
+		return
+	}
+	m.bridges[h.Name] = b
+	m.order = append(m.order, h.Name)
+	sort.Strings(m.order)
+	m.mu.Unlock()
+
+	if ctx != nil {
+		b.start(ctx)
+	}
+}
+
+// Add registers a host, persists it and connects. A name already in use is an
+// error: the name is the key of everything the host contributes.
+func (m *Manager) Add(h Host) error {
+	m.mu.RLock()
+	_, dup := m.bridges[h.Name]
+	hosts := m.configsLocked()
+	m.mu.RUnlock()
+	if dup {
+		return ErrDuplicateHost
+	}
+
+	if err := m.save(append(hosts, h)); err != nil {
+		return err
+	}
+	m.add(h)
+	m.opts.OnChange()
+	return nil
+}
+
+// Remove unregisters a host: its bridge is torn down, its rows leave the
+// published state on the next publish, and it is dropped from the config.
+func (m *Manager) Remove(name string) error {
+	m.mu.Lock()
+	b, ok := m.bridges[name]
+	if !ok {
+		m.mu.Unlock()
+		return ErrUnknownHost
+	}
+	delete(m.bridges, name)
+	kept := m.order[:0]
+	for _, n := range m.order {
+		if n != name {
+			kept = append(kept, n)
+		}
+	}
+	m.order = kept
+	hosts := m.configsLocked()
+	m.mu.Unlock()
+
+	b.stop()
+	if err := m.save(hosts); err != nil {
+		return err
+	}
+	m.opts.OnChange()
+	return nil
+}
+
+// Rows is every registered host's contribution, in host-name order so the
+// published collections are stable across ticks.
+func (m *Manager) Rows() state.Rows {
+	m.mu.RLock()
+	bridges := m.bridgesLocked()
+	m.mu.RUnlock()
+
+	var out state.Rows
+	for _, b := range bridges {
+		out = out.Append(b.Rows())
+	}
+	return out
+}
+
+// Hosts is the `remote.list` result: one Host row per registered host,
+// whatever its connection state.
+func (m *Manager) Hosts() []state.Host {
+	m.mu.RLock()
+	bridges := m.bridgesLocked()
+	m.mu.RUnlock()
+
+	out := make([]state.Host, 0, len(bridges))
+	for _, b := range bridges {
+		out = append(out, b.HostRow())
+	}
+	return out
+}
+
+// Configs is the registered host list as the config spells it.
+func (m *Manager) Configs() []Host {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.configsLocked()
+}
+
+// Has reports whether name is registered.
+func (m *Manager) Has(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.bridges[name]
+	return ok
+}
+
+// Call forwards one method to a host's daemon and returns its result verbatim.
+func (m *Manager) Call(ctx context.Context, host, method string, params json.RawMessage) (json.RawMessage, error) {
+	m.mu.RLock()
+	b, ok := m.bridges[host]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, ErrUnknownHost
+	}
+	return b.Call(ctx, method, params)
+}
+
+// bridgesLocked returns the bridges in host-name order. Caller holds the lock.
+func (m *Manager) bridgesLocked() []*bridge {
+	out := make([]*bridge, 0, len(m.order))
+	for _, name := range m.order {
+		if b, ok := m.bridges[name]; ok {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// configsLocked returns the registered host configs in name order. Caller
+// holds the lock.
+func (m *Manager) configsLocked() []Host {
+	out := make([]Host, 0, len(m.order))
+	for _, b := range m.bridgesLocked() {
+		out = append(out, b.Config())
+	}
+	return out
+}
+
+func (m *Manager) save(hosts []Host) error {
+	if m.opts.Save != nil {
+		return m.opts.Save(hosts)
+	}
+	return saveHosts(hosts)
+}

--- a/internal/remote/manager_test.go
+++ b/internal/remote/manager_test.go
@@ -1,0 +1,479 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// testTimeout is a hang guard, not a latency assertion: a bridge that never
+// connects has to fail the test rather than hang the binary.
+const testTimeout = 20 * time.Second
+
+// changeSignal records the manager's OnChange callbacks so a test can wait for
+// "the multiplexer republished" instead of sleeping.
+type changeSignal struct {
+	mu sync.Mutex
+	ch chan struct{}
+	n  int
+}
+
+func newChangeSignal() *changeSignal {
+	return &changeSignal{ch: make(chan struct{}, 256)}
+}
+
+func (c *changeSignal) fire() {
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+	select {
+	case c.ch <- struct{}{}:
+	default:
+	}
+}
+
+// waitFor polls the manager's rows until cond holds, driven by OnChange.
+func waitFor(t *testing.T, sig *changeSignal, m *Manager, what string, cond func(state.Rows) bool) state.Rows {
+	t.Helper()
+	deadline := time.After(testTimeout)
+	for {
+		if rows := m.Rows(); cond(rows) {
+			return rows
+		}
+		select {
+		case <-sig.ch:
+		case <-time.After(20 * time.Millisecond):
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s; rows = %+v", what, m.Rows())
+		}
+	}
+}
+
+// newTestManager builds a manager wired to a fake remote daemon, with config
+// persistence stubbed out so no test writes to the user's home.
+func newTestManager(t *testing.T, hosts ...Host) (*Manager, *fakeDaemon, *changeSignal, []state.Event) {
+	t.Helper()
+	fake := newFakeDaemon(t)
+	sig := newChangeSignal()
+
+	var eventsMu sync.Mutex
+	var events []state.Event
+
+	m := NewManager(Options{
+		Version:  "test",
+		Dial:     fake.dialer(),
+		OnChange: sig.fire,
+		OnEvent: func(ev state.Event) {
+			eventsMu.Lock()
+			events = append(events, ev)
+			eventsMu.Unlock()
+		},
+		Save: func([]Host) error { return nil },
+	})
+	m.Start(context.Background(), hosts)
+	t.Cleanup(m.Stop)
+	return m, fake, sig, events
+}
+
+func portRow(port int, bind string) state.Port {
+	return state.Port{
+		Host: state.LocalhostName, Port: port, BindAddress: bind,
+		Process: "node", DisplayName: "node", Type: state.TypeUser,
+		ExposedURLs: []string{},
+	}
+}
+
+func snapshotWith(pp ...state.Port) state.Snapshot {
+	return state.Snapshot{
+		Ports:    pp,
+		Groups:   []state.Group{{Host: state.LocalhostName, Name: "api", Status: "running", Members: []int{pp[0].Port}}},
+		Tunnels:  []state.Tunnel{},
+		Proxies:  []state.Proxy{},
+		Sessions: []state.SessionRecord{},
+		Hosts: []state.Host{{
+			Name: state.LocalhostName, Address: state.LocalhostName,
+			Status: state.HostConnected, OS: "linux", Arch: "amd64",
+			Load: []float64{0.5, 0.4, 0.3},
+		}},
+	}
+}
+
+// TestRemoteRowsAreTaggedAndPrefixed is the multiplexer's core contract: every
+// row a remote host contributes carries that host's name, and its delta key is
+// namespaced so it cannot collide with a local row on the same port.
+func TestRemoteRowsAreTaggedAndPrefixed(t *testing.T) {
+	m, fake, sig, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+	fake.waitSubscribed(t)
+	fake.setSnapshot(snapshotWith(portRow(3000, "127.0.0.1")))
+
+	rows := waitFor(t, sig, m, "the remote port to arrive", func(r state.Rows) bool {
+		return len(r.Ports) == 1
+	})
+
+	got := rows.Ports[0]
+	if got.Host != "hetzner" {
+		t.Errorf("port host = %q, want hetzner", got.Host)
+	}
+	if want := "hetzner/3000:127.0.0.1"; got.Key() != want {
+		t.Errorf("port key = %q, want %q", got.Key(), want)
+	}
+	if len(rows.Groups) != 1 || rows.Groups[0].Host != "hetzner" {
+		t.Errorf("groups = %+v, want one tagged with hetzner", rows.Groups)
+	}
+	if want := "hetzner/api"; rows.Groups[0].Key() != want {
+		t.Errorf("group key = %q, want %q", rows.Groups[0].Key(), want)
+	}
+	if len(rows.Hosts) != 1 || rows.Hosts[0].Name != "hetzner" {
+		t.Fatalf("hosts = %+v, want the remote's row renamed to hetzner", rows.Hosts)
+	}
+	if h := rows.Hosts[0]; h.Address != "deploy@box" || h.Status != state.HostConnected {
+		t.Errorf("host row = %+v, want the ssh target and connected", h)
+	}
+	if h := rows.Hosts[0]; h.OS != "linux" || len(h.Load) != 3 {
+		t.Errorf("host row = %+v, want the remote's own load copied in", h)
+	}
+	if h := rows.Hosts[0]; h.DaemonVersion != "1.2.3" {
+		t.Errorf("daemon_version = %q, want the remote's", h.DaemonVersion)
+	}
+}
+
+// TestLocalKeysAreUnprefixed guards decision 1: only remote rows are
+// namespaced, so a client written before remote hosts existed keeps working.
+func TestLocalKeysAreUnprefixed(t *testing.T) {
+	local := portRow(3000, "127.0.0.1")
+	if want := "3000:127.0.0.1"; local.Key() != want {
+		t.Errorf("local key = %q, want %q", local.Key(), want)
+	}
+	blank := local
+	blank.Host = ""
+	if want := "3000:127.0.0.1"; blank.Key() != want {
+		t.Errorf("key of a row with no host = %q, want %q", blank.Key(), want)
+	}
+}
+
+// TestTwoHostsDoNotCollide is why the prefix exists: the same port number on
+// two machines has to be two rows.
+func TestTwoHostsDoNotCollide(t *testing.T) {
+	a := portRow(3000, "127.0.0.1")
+	a.Host = "alpha"
+	b := portRow(3000, "127.0.0.1")
+	b.Host = "beta"
+	if a.Key() == b.Key() {
+		t.Fatalf("both hosts key as %q", a.Key())
+	}
+
+	prev := state.Snapshot{Ports: []state.Port{a}}
+	next := state.Snapshot{Ports: []state.Port{a, b}}
+	d := state.Diff(prev, next)
+	if len(d.Ports.Added) != 1 || d.Ports.Added[0].Host != "beta" {
+		t.Errorf("delta added = %+v, want only beta's row", d.Ports.Added)
+	}
+	if len(d.Ports.Removed) != 0 {
+		t.Errorf("delta removed = %v, want nothing removed", d.Ports.Removed)
+	}
+}
+
+// TestRemoveDropsEveryRow: unregistering a host must take its ports, groups
+// and its own Host row out of the published state, not just stop updating them.
+func TestRemoveDropsEveryRow(t *testing.T) {
+	m, fake, sig, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+	fake.waitSubscribed(t)
+	fake.setSnapshot(snapshotWith(portRow(3000, "127.0.0.1")))
+	waitFor(t, sig, m, "the remote port to arrive", func(r state.Rows) bool { return len(r.Ports) == 1 })
+
+	if err := m.Remove("hetzner"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	rows := m.Rows()
+	if len(rows.Ports) != 0 || len(rows.Groups) != 0 || len(rows.Hosts) != 0 {
+		t.Fatalf("rows after remove = %+v, want nothing", rows)
+	}
+	if m.Has("hetzner") {
+		t.Error("the host is still registered")
+	}
+	if err := m.Remove("hetzner"); err == nil {
+		t.Error("removing an unknown host should fail")
+	}
+}
+
+// TestDisconnectDropsRowsButKeepsTheHost: a machine we cannot see contributes
+// no ports — showing the last ones would be a lie — but it keeps its row in
+// the hosts collection so a client can say why.
+func TestDisconnectDropsRowsButKeepsTheHost(t *testing.T) {
+	m, fake, sig, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+	fake.waitSubscribed(t)
+	fake.setSnapshot(snapshotWith(portRow(3000, "127.0.0.1")))
+	waitFor(t, sig, m, "the remote port to arrive", func(r state.Rows) bool { return len(r.Ports) == 1 })
+
+	fake.hangUp()
+
+	rows := waitFor(t, sig, m, "the host to go unreachable", func(r state.Rows) bool {
+		return len(r.Ports) == 0 && len(r.Hosts) == 1 && r.Hosts[0].Status != state.HostConnected
+	})
+	if rows.Hosts[0].Name != "hetzner" {
+		t.Errorf("host row = %+v, want hetzner to stay listed", rows.Hosts[0])
+	}
+}
+
+// TestReconnectRestoresRowsAndResetsBackoff: after a drop the bridge dials
+// again from the minimum delay and the host's rows come back.
+func TestReconnectRestoresRowsAndResetsBackoff(t *testing.T) {
+	m, fake, sig, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+	fake.waitSubscribed(t)
+	fake.setSnapshot(snapshotWith(portRow(3000, "127.0.0.1")))
+	waitFor(t, sig, m, "the remote port to arrive", func(r state.Rows) bool { return len(r.Ports) == 1 })
+
+	fake.hangUp()
+	waitFor(t, sig, m, "the host to go unreachable", func(r state.Rows) bool { return len(r.Ports) == 0 })
+
+	// The dialer makes a fresh session per dial, so the bridge reconnecting is
+	// a second accepted connection.
+	fake.waitSubscribed(t)
+	fake.setSnapshot(snapshotWith(portRow(4000, "127.0.0.1")))
+
+	rows := waitFor(t, sig, m, "the reconnected host's rows", func(r state.Rows) bool {
+		return len(r.Ports) == 1 && r.Ports[0].Port == 4000
+	})
+	if rows.Ports[0].Host != "hetzner" {
+		t.Errorf("reconnected port host = %q, want hetzner", rows.Ports[0].Host)
+	}
+	if rows.Hosts[0].Status != state.HostConnected {
+		t.Errorf("status = %q, want connected again", rows.Hosts[0].Status)
+	}
+}
+
+// TestBackoffProgression pins the spec's 1 s → 30 s curve.
+func TestBackoffProgression(t *testing.T) {
+	d := ReconnectMin
+	seen := []time.Duration{d}
+	for i := 0; i < 8; i++ {
+		d = nextBackoff(d)
+		seen = append(seen, d)
+	}
+	if seen[0] != time.Second {
+		t.Errorf("first delay = %s, want 1s", seen[0])
+	}
+	for i := 1; i < len(seen); i++ {
+		if seen[i] < seen[i-1] {
+			t.Fatalf("backoff went backwards: %v", seen)
+		}
+		if seen[i] > ReconnectMax {
+			t.Fatalf("backoff exceeded the cap: %v", seen)
+		}
+	}
+	if seen[len(seen)-1] != ReconnectMax {
+		t.Errorf("backoff settled at %s, want the %s cap", seen[len(seen)-1], ReconnectMax)
+	}
+}
+
+// TestProtocolMismatchIsIncompatible: a remote daemon speaking another major
+// version is a status, not a crash loop with a useless reason.
+func TestProtocolMismatchIsIncompatible(t *testing.T) {
+	fake := newFakeDaemon(t)
+	fake.protocolVersion = "99.0.0"
+	sig := newChangeSignal()
+
+	m := NewManager(Options{
+		Version: "test", Dial: fake.dialer(), OnChange: sig.fire,
+		Save: func([]Host) error { return nil },
+	})
+	m.Start(context.Background(), []Host{{Name: "hetzner", Target: "deploy@box"}})
+	t.Cleanup(m.Stop)
+
+	rows := waitFor(t, sig, m, "the incompatible status", func(r state.Rows) bool {
+		return len(r.Hosts) == 1 && r.Hosts[0].Status == state.HostIncompatible
+	})
+	if rows.Hosts[0].StatusReason == nil || *rows.Hosts[0].StatusReason == "" {
+		t.Error("an incompatible host should say why")
+	}
+}
+
+// TestCallForwardsVerbatim is decision 3 on the wire: the local daemon hands
+// the params over unchanged and returns the remote's result as it came.
+func TestCallForwardsVerbatim(t *testing.T) {
+	m, fake, _, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+
+	var gotParams json.RawMessage
+	fake.handle("ports.rename", func(params json.RawMessage) (any, *rpc.Error) {
+		gotParams = append(json.RawMessage{}, params...)
+		return map[string]any{"ok": true, "key": "3000:127.0.0.1", "affected": []string{"3000:127.0.0.1"}}, nil
+	})
+	fake.waitSubscribed(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	sent := json.RawMessage(`{"port":3000,"name":"api"}`)
+	out, err := m.Call(ctx, "hetzner", "ports.rename", sent)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if string(gotParams) != string(sent) {
+		t.Errorf("remote saw params %s, want %s", gotParams, sent)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["key"] != "3000:127.0.0.1" {
+		t.Errorf("result = %s, want the remote's own reply", out)
+	}
+}
+
+// TestCallOnAnUnknownHostFails keeps a typo from looking like an empty result.
+func TestCallOnAnUnknownHostFails(t *testing.T) {
+	m, _, _, _ := newTestManager(t)
+	_, err := m.Call(context.Background(), "nope", "ports.list", nil)
+	if err == nil {
+		t.Fatal("want an error for an unregistered host")
+	}
+}
+
+// TestAddRejectsDuplicates: the name is the key of everything the host
+// contributes, so two hosts cannot share one.
+func TestAddRejectsDuplicates(t *testing.T) {
+	m, _, _, _ := newTestManager(t)
+	h := Host{Name: "hetzner", Target: "deploy@box"}
+	if err := m.Add(h); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := m.Add(h); err == nil {
+		t.Fatal("want a duplicate error")
+	}
+	if got := m.Configs(); len(got) != 1 {
+		t.Errorf("configs = %+v, want one host", got)
+	}
+}
+
+// TestAddPersistsTheHostList proves `remote.add` writes what `sonar serve`
+// will read on its next start.
+func TestAddPersistsTheHostList(t *testing.T) {
+	fake := newFakeDaemon(t)
+	var saved [][]Host
+	m := NewManager(Options{
+		Version: "test", Dial: fake.dialer(),
+		Save: func(h []Host) error {
+			saved = append(saved, append([]Host{}, h...))
+			return nil
+		},
+	})
+	m.Start(context.Background(), nil)
+	t.Cleanup(m.Stop)
+
+	if err := m.Add(Host{Name: "a", Target: "me@a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Add(Host{Name: "b", Target: "me@b", SSHArgs: []string{"-J", "bastion"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Remove("a"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(saved) != 3 {
+		t.Fatalf("saved %d times, want 3", len(saved))
+	}
+	if len(saved[2]) != 1 || saved[2][0].Name != "b" {
+		t.Errorf("final saved list = %+v, want only b", saved[2])
+	}
+	if len(saved[1]) != 2 || len(saved[1][1].SSHArgs) != 2 {
+		t.Errorf("saved list = %+v, want b's ssh_args preserved", saved[1])
+	}
+}
+
+// TestEventsAreForwardedWithTheHost: a remote port_up has to say which machine
+// it happened on, or a client cannot place it.
+func TestEventsAreForwardedWithTheHost(t *testing.T) {
+	fake := newFakeDaemon(t)
+	sig := newChangeSignal()
+	got := make(chan state.Event, 8)
+
+	m := NewManager(Options{
+		Version: "test", Dial: fake.dialer(), OnChange: sig.fire,
+		OnEvent: func(ev state.Event) { got <- ev },
+		Save:    func([]Host) error { return nil },
+	})
+	m.Start(context.Background(), []Host{{Name: "hetzner", Target: "deploy@box"}})
+	t.Cleanup(m.Stop)
+	fake.waitSubscribed(t)
+
+	p := portRow(3000, "127.0.0.1")
+	fake.pushEvent(state.Event{Kind: "port_up", At: "2026-09-06T10:00:01Z", Port: &p})
+
+	select {
+	case ev := <-got:
+		if ev.Host != "hetzner" {
+			t.Errorf("event host = %q, want hetzner", ev.Host)
+		}
+		if ev.Port == nil || ev.Port.Host != "hetzner" {
+			t.Errorf("event port = %+v, want the port tagged too", ev.Port)
+		}
+	case <-time.After(testTimeout):
+		t.Fatal("the event never arrived")
+	}
+}
+
+// TestNormalizeHost covers the naming rules the spec fixes.
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      Host
+		want    string
+		wantErr bool
+	}{
+		{name: "derives the name from the target", in: Host{Target: "deploy@203.0.113.7"}, want: "203-0-113-7"},
+		{name: "keeps an explicit name", in: Host{Name: "hetzner", Target: "deploy@box"}, want: "hetzner"},
+		{name: "rejects localhost", in: Host{Name: "localhost", Target: "me@box"}, wantErr: true},
+		{name: "rejects an empty target", in: Host{Name: "a"}, wantErr: true},
+		{name: "rejects upper case", in: Host{Name: "Hetzner", Target: "me@box"}, wantErr: true},
+		{name: "rejects a bad port", in: Host{Name: "a", Target: "me@box", Port: 70000}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeHost(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want an error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Name != tc.want {
+				t.Errorf("name = %q, want %q", got.Name, tc.want)
+			}
+		})
+	}
+}
+
+// TestSSHArgs pins the command line the bridge asks ssh to run.
+func TestSSHArgs(t *testing.T) {
+	got := SSHArgs(Host{
+		Name: "hetzner", Target: "deploy@box", Port: 2222,
+		Identity: "/keys/id", SSHArgs: []string{"-J", "bastion"},
+		RemoteBin: "~/.local/bin/sonar",
+	})
+	want := []string{
+		"-o", "BatchMode=yes", "-p", "2222", "-i", "/keys/id",
+		"-J", "bastion", "deploy@box", "~/.local/bin/sonar daemon stdio",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("args = %v, want %v", got, want)
+		}
+	}
+
+	bare := SSHArgs(Host{Name: "a", Target: "box"})
+	if bare[len(bare)-1] != "sonar daemon stdio" {
+		t.Errorf("remote command = %q, want the PATH default", bare[len(bare)-1])
+	}
+}

--- a/internal/remote/manager_test.go
+++ b/internal/remote/manager_test.go
@@ -477,3 +477,23 @@ func TestSSHArgs(t *testing.T) {
 		t.Errorf("remote command = %q, want the PATH default", bare[len(bare)-1])
 	}
 }
+
+// TestTargetOfAcceptsHostAsAnAlias: some clients call the SSH destination
+// "host". Both spellings mean the string ssh receives.
+func TestTargetOfAcceptsHostAsAnAlias(t *testing.T) {
+	tests := []struct {
+		name string
+		in   rpc.RemoteAddParams
+		want string
+	}{
+		{"target only", rpc.RemoteAddParams{Target: "deploy@box"}, "deploy@box"},
+		{"host only", rpc.RemoteAddParams{Host: "deploy@box"}, "deploy@box"},
+		{"both, target wins", rpc.RemoteAddParams{Target: "a@x", Host: "b@y"}, "a@x"},
+		{"neither", rpc.RemoteAddParams{}, ""},
+	}
+	for _, tc := range tests {
+		if got := TargetOf(tc.in); got != tc.want {
+			t.Errorf("%s: TargetOf = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -1,0 +1,46 @@
+// Package remote is the local daemon's side of a registered SSH host: one
+// bridge per host, each speaking the ordinary daemon protocol over the
+// stdin/stdout of `ssh <target> sonar daemon stdio`, and a manager that
+// multiplexes what those bridges report into the state stream every local
+// client already reads.
+//
+// Nothing here listens on a network port and nothing here implements SSH. The
+// system `ssh` binary is spawned so the user's `~/.ssh/config`, agent, jump
+// hosts and known_hosts all apply exactly as they do from a shell — the whole
+// point of the transport choice in the remote-hosts design.
+//
+// The package registers its own RPC handlers and its own OnStart hook from
+// init(), so internal/daemon never imports it (contract §8).
+package remote
+
+import (
+	"time"
+
+	"github.com/raskrebs/sonar/internal/config"
+)
+
+// Host is one registered SSH host, as the user config spells it.
+type Host = config.RemoteHost
+
+// Reconnect timing, from the remote-hosts design: exponential backoff from one
+// second to thirty, forever, per host.
+const (
+	ReconnectMin    = 1 * time.Second
+	ReconnectMax    = 30 * time.Second
+	ReconnectFactor = 2
+
+	// HandshakeTimeout bounds `daemon.hello` over a fresh bridge. It is
+	// generous because the far side may be autostarting its own daemon, and
+	// because the first SSH connection to a cold host pays for the TCP
+	// handshake, the key exchange and a login shell.
+	HandshakeTimeout = 30 * time.Second
+
+	// PingInterval is how often a connected bridge measures round-trip
+	// latency. Latency alone never publishes a delta (state.DiffHosts ignores
+	// it), so the newest value rides out with the next real change.
+	PingInterval = 20 * time.Second
+
+	// PingTimeout bounds one latency probe. A probe that does not answer in
+	// this long is treated as a dead bridge.
+	PingTimeout = 10 * time.Second
+)

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -1,0 +1,169 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Dialer opens one bridge to a host. It returns the stream the daemon protocol
+// is spoken over: the far side's `sonar daemon stdio`. Tests replace it with a
+// pipe to an in-process daemon so the whole manager can be exercised with no
+// subprocess, no SSH and no network.
+type Dialer func(ctx context.Context, h Host) (io.ReadWriteCloser, error)
+
+// RemoteCommand is what the bridge asks the far side to run.
+const RemoteCommand = "daemon stdio"
+
+// DefaultRemoteBinary is the binary the far side runs when the host config
+// does not name one. It is resolved by the login shell's PATH, which is why
+// `sonar remote install` puts it in ~/.local/bin.
+const DefaultRemoteBinary = "sonar"
+
+// SSHArgs builds the argument list for one host, in the order `ssh` wants it:
+// options first, then the target, then the remote command. The user's own
+// ssh_args come last among the options so they can override an identity or a
+// port sonar would otherwise pass.
+func SSHArgs(h Host) []string {
+	args := make([]string, 0, 8+len(h.SSHArgs))
+	// Batch mode: a bridge runs unattended, so a password or passphrase prompt
+	// would block forever on a stdin that is carrying JSON-RPC. Failing fast
+	// turns that into a reconnect with a readable reason instead.
+	args = append(args, "-o", "BatchMode=yes")
+	if h.Port > 0 {
+		args = append(args, "-p", strconv.Itoa(h.Port))
+	}
+	if h.Identity != "" {
+		args = append(args, "-i", expandHome(h.Identity))
+	}
+	args = append(args, h.SSHArgs...)
+	args = append(args, h.Target, RemoteBinary(h)+" "+RemoteCommand)
+	return args
+}
+
+// RemoteBinary is the sonar to run on the far side.
+func RemoteBinary(h Host) string {
+	if strings.TrimSpace(h.RemoteBin) == "" {
+		return DefaultRemoteBinary
+	}
+	return strings.TrimSpace(h.RemoteBin)
+}
+
+// expandHome turns a leading ~ into the user's home directory. `ssh -i` does
+// not do it for us: the shell normally would, and there is no shell here.
+func expandHome(path string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home + path[1:]
+		}
+	}
+	return path
+}
+
+// SSHBinary is the ssh executable the bridge spawns. It is a variable so a
+// test can point it at a stand-in on PATH.
+var SSHBinary = "ssh"
+
+// DialSSH is the production Dialer: it spawns `ssh <opts> <target> sonar
+// daemon stdio` and hands back its pipes. Closing the stream kills the ssh
+// process, which is what tears the bridge down on remote.remove.
+func DialSSH(ctx context.Context, h Host) (io.ReadWriteCloser, error) {
+	if _, err := exec.LookPath(SSHBinary); err != nil {
+		return nil, fmt.Errorf("cannot find the %s binary: %w", SSHBinary, err)
+	}
+	cmd := exec.Command(SSHBinary, SSHArgs(h)...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+	// ssh writes its own diagnostics to stderr — "Permission denied", "Host
+	// key verification failed", "sonar: command not found" from the remote
+	// shell. Keeping the tail of it is what makes a host's status_reason say
+	// something a user can act on instead of "EOF".
+	var errBuf tailBuffer
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("starting %s: %w", SSHBinary, err)
+	}
+	return &process{cmd: cmd, in: stdin, out: stdout, errs: &errBuf}, nil
+}
+
+// process is a spawned `ssh ... sonar daemon stdio` seen as one stream.
+type process struct {
+	cmd  *exec.Cmd
+	in   io.WriteCloser
+	out  io.ReadCloser
+	errs *tailBuffer
+
+	once sync.Once
+}
+
+func (p *process) Read(b []byte) (int, error) {
+	n, err := p.out.Read(b)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return n, err
+	}
+	if errors.Is(err, io.EOF) {
+		// EOF on the far side's stdout is the whole story only when ssh had
+		// nothing to say. When it did, that is the diagnosis.
+		if msg := p.errs.String(); msg != "" {
+			return n, fmt.Errorf("%s: %s", io.EOF, msg)
+		}
+	}
+	return n, err
+}
+
+func (p *process) Write(b []byte) (int, error) { return p.in.Write(b) }
+
+// Close tears the bridge down: the far side sees EOF on its stdin, and the ssh
+// process is killed if it does not take the hint.
+func (p *process) Close() error {
+	p.once.Do(func() {
+		_ = p.in.Close()
+		_ = p.out.Close()
+		if p.cmd.Process != nil {
+			_ = p.cmd.Process.Kill()
+		}
+		_ = p.cmd.Wait()
+	})
+	return nil
+}
+
+// tailBuffer keeps the last few hundred bytes written to it. ssh in verbose
+// mode can write a lot; a status_reason only needs the end of it.
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+const tailBufferMax = 512
+
+func (t *tailBuffer) Write(b []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, b...)
+	if len(t.buf) > tailBufferMax {
+		t.buf = t.buf[len(t.buf)-tailBufferMax:]
+	}
+	return len(b), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return strings.TrimSpace(strings.ReplaceAll(string(t.buf), "\n", "; "))
+}

--- a/internal/remote/ssh_integration_test.go
+++ b/internal/remote/ssh_integration_test.go
@@ -1,0 +1,450 @@
+//go:build integration
+
+// The whole remote-host path with no network and no SSH: a stand-in `ssh` on
+// PATH execs the real binary's `daemon stdio` against a second daemon on this
+// machine, so `remote.add` → rows appear → `remote.remove` → rows vanish is
+// exercised end to end through the real spawn, the real bridge and the real
+// multiplexer.
+//
+// Run with `go test -tags integration ./internal/remote/...`.
+package remote_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// buildBinary compiles the sonar CLI once per test run.
+var buildBinary = sync.OnceValues(func() (string, error) {
+	dir, err := os.MkdirTemp("", "sonar-remote-itest-bin")
+	if err != nil {
+		return "", err
+	}
+	bin := filepath.Join(dir, "sonar")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = repoRoot()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("building sonar: %v: %s", err, out)
+	}
+	return bin, nil
+})
+
+// shortTempDir is a temp directory outside t.TempDir(), whose path is short
+// enough for a unix socket on macOS.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "snr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+func repoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	return "."
+}
+
+// fakeSSHScript is the stand-in for ssh. It throws away every ssh option and
+// the remote command, and runs this build's `daemon stdio` against the second
+// daemon's socket — which is precisely the shape of the real thing: ssh is a
+// pipe to a `sonar daemon stdio` somewhere else.
+const fakeSSHScript = `#!/bin/sh
+export HOME="$FAKE_SSH_HOME"
+export USERPROFILE="$FAKE_SSH_HOME"
+export SONAR_SOCKET="$FAKE_SSH_SOCKET"
+export XDG_RUNTIME_DIR=
+exec "$FAKE_SSH_BIN" daemon stdio
+`
+
+// bridgeEnv is a local daemon plus a "remote" daemon on the same machine, with
+// a fake ssh joining them.
+type bridgeEnv struct {
+	t           *testing.T
+	bin         string
+	localHome   string
+	remoteHome  string
+	localSocket string
+	remoteSock  string
+	binDir      string
+	serveCmd    *exec.Cmd
+}
+
+func newBridgeEnv(t *testing.T) *bridgeEnv {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake ssh is a POSIX shell script; the bridge itself is covered by the unit tests")
+	}
+	bin, err := buildBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// macOS caps a unix socket path at ~104 bytes, so the sockets live in
+	// short directories of their own rather than under t.TempDir(). One
+	// directory each: the single-instance lock sits beside the socket
+	// (contract §15), so two daemons sharing a directory would fight over one
+	// lock and the second would never start.
+	e := &bridgeEnv{
+		t:           t,
+		bin:         bin,
+		localHome:   t.TempDir(),
+		remoteHome:  t.TempDir(),
+		localSocket: filepath.Join(shortTempDir(t), "d.sock"),
+		remoteSock:  filepath.Join(shortTempDir(t), "d.sock"),
+		binDir:      t.TempDir(),
+	}
+
+	script := filepath.Join(e.binDir, "ssh")
+	if err := os.WriteFile(script, []byte(fakeSSHScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func (e *bridgeEnv) env() []string {
+	return append(os.Environ(),
+		"HOME="+e.localHome,
+		"USERPROFILE="+e.localHome,
+		"SONAR_SOCKET="+e.localSocket,
+		"XDG_RUNTIME_DIR=",
+		"PATH="+e.binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_SSH_BIN="+e.bin,
+		"FAKE_SSH_HOME="+e.remoteHome,
+		"FAKE_SSH_SOCKET="+e.remoteSock,
+	)
+}
+
+// serve starts the local daemon: the one that owns the bridges.
+func (e *bridgeEnv) serve() {
+	e.t.Helper()
+	cmd := exec.Command(e.bin, "serve")
+	cmd.Env = e.env()
+	cmd.WaitDelay = 5 * time.Second
+	var out strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &out
+	if err := cmd.Start(); err != nil {
+		e.t.Fatalf("starting the local daemon: %v", err)
+	}
+	e.serveCmd = cmd
+	e.t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		e.stopRemoteDaemon()
+		if e.t.Failed() && out.Len() > 0 {
+			e.t.Logf("local daemon output:\n%s", out.String())
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := client.WaitForSocket(ctx, e.localSocket, 15*time.Second); err != nil {
+		e.t.Fatalf("the local daemon never came up: %v\n%s", err, out.String())
+	}
+}
+
+// stopRemoteDaemon shuts down the daemon the bridge autostarted on the "remote"
+// side, so its lock and log are released before t.TempDir cleans up.
+func (e *bridgeEnv) stopRemoteDaemon() {
+	cmd := exec.Command(e.bin, "daemon", "stop")
+	cmd.Env = append(os.Environ(),
+		"HOME="+e.remoteHome,
+		"USERPROFILE="+e.remoteHome,
+		"SONAR_SOCKET="+e.remoteSock,
+		"XDG_RUNTIME_DIR=",
+	)
+	cmd.WaitDelay = 5 * time.Second
+	_ = cmd.Run()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if !daemon.SocketAlive(e.remoteSock) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func (e *bridgeEnv) connect(ctx context.Context) *client.Client {
+	e.t.Helper()
+	c, err := client.Dial(ctx, client.ClientInfo{
+		Name: "cli", Version: "itest", Socket: e.localSocket,
+	})
+	if err != nil {
+		e.t.Fatalf("connecting to the local daemon: %v", err)
+	}
+	e.t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// TestRemoteAddBringsRowsInAndRemoveTakesThemOut is the step's acceptance
+// demo, minus the network.
+func TestRemoteAddBringsRowsInAndRemoveTakesThemOut(t *testing.T) {
+	e := newBridgeEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	if !hasCapability(c.Hello().Capabilities, "remote") {
+		t.Errorf("capabilities = %v, want remote announced", c.Hello().Capabilities)
+	}
+
+	// Something has to be listening for the bridge to carry, and both daemons
+	// scan this same machine, so one listener shows up on both sides.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	var added rpc.RemoteAddResult
+	if err := c.Call(ctx, "remote.add", rpc.RemoteAddParams{
+		Target: "deploy@fake", Name: "fake",
+	}, &added); err != nil {
+		t.Fatalf("remote.add: %v", err)
+	}
+	if !added.OK || added.Host.Name != "fake" {
+		t.Fatalf("remote.add result = %+v", added)
+	}
+
+	// The bridge connects.
+	waitUntil(t, ctx, "the host to connect", func() bool {
+		var list rpc.RemoteListResult
+		if err := c.Call(ctx, "remote.list", rpc.Empty{}, &list); err != nil {
+			return false
+		}
+		for _, h := range list.Hosts {
+			if h.Name == "fake" && h.Status == state.HostConnected {
+				if h.DaemonVersion == "" {
+					t.Errorf("connected host has no daemon_version: %+v", h)
+				}
+				return true
+			}
+		}
+		return false
+	})
+
+	// Its rows reach the local stream, tagged and prefixed.
+	waitUntil(t, ctx, "the remote port to be multiplexed in", func() bool {
+		snap := snapshot(t, ctx, c, []string{"*"})
+		for _, p := range snap.Ports {
+			if p.Host == "fake" && p.Port == port {
+				if want := fmt.Sprintf("fake/%d:%s", port, p.BindAddress); p.Key() != want {
+					t.Errorf("remote key = %q, want %q", p.Key(), want)
+				}
+				return true
+			}
+		}
+		return false
+	})
+
+	// The same port is there once as a local row, with its unprefixed key.
+	snap := snapshot(t, ctx, c, []string{"*"})
+	local, remote := 0, 0
+	for _, p := range snap.Ports {
+		if p.Port != port {
+			continue
+		}
+		switch p.Host {
+		case state.LocalhostName:
+			local++
+			if strings.Contains(p.Key(), "/") {
+				t.Errorf("local key %q is namespaced; decision 1 says it must not be", p.Key())
+			}
+		case "fake":
+			remote++
+		}
+	}
+	if local == 0 || remote == 0 {
+		t.Errorf("port %d appeared %d times locally and %d times remotely, want both", port, local, remote)
+	}
+
+	// A default subscriber never saw any of it.
+	localOnly := snapshot(t, ctx, c, nil)
+	for _, p := range localOnly.Ports {
+		if p.Host != state.LocalhostName {
+			t.Errorf("the default view leaked a %q row", p.Host)
+		}
+	}
+
+	if err := c.Call(ctx, "remote.remove", rpc.RemoteRemoveParams{Name: "fake"}, nil); err != nil {
+		t.Fatalf("remote.remove: %v", err)
+	}
+
+	waitUntil(t, ctx, "the remote rows to vanish", func() bool {
+		snap := snapshot(t, ctx, c, []string{"*"})
+		for _, p := range snap.Ports {
+			if p.Host == "fake" {
+				return false
+			}
+		}
+		for _, h := range snap.Hosts {
+			if h.Name == "fake" {
+				return false
+			}
+		}
+		return true
+	})
+
+	var list rpc.RemoteListResult
+	if err := c.Call(ctx, "remote.list", rpc.Empty{}, &list); err != nil {
+		t.Fatalf("remote.list: %v", err)
+	}
+	if len(list.Hosts) != 0 {
+		t.Errorf("remote.list = %+v, want no hosts after remove", list.Hosts)
+	}
+}
+
+// TestRemoteCallForwardsAWrite covers decision 3: a write goes over the bridge
+// like any other method, and the remote daemon applies it.
+func TestRemoteCallForwardsAWrite(t *testing.T) {
+	e := newBridgeEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	if err := c.Call(ctx, "remote.add", rpc.RemoteAddParams{Target: "deploy@fake", Name: "fake"}, nil); err != nil {
+		t.Fatalf("remote.add: %v", err)
+	}
+	waitUntil(t, ctx, "the remote port to be multiplexed in", func() bool {
+		for _, p := range snapshot(t, ctx, c, []string{"*"}).Ports {
+			if p.Host == "fake" && p.Port == port {
+				return true
+			}
+		}
+		return false
+	})
+
+	name := "renamed-by-the-bridge"
+	var renamed rpc.PortsRenameResult
+	if err := c.Call(ctx, "remote.call", rpc.RemoteCallParams{
+		Host:   "fake",
+		Method: "ports.rename",
+		Params: mustJSON(t, rpc.PortsRenameParams{
+			Selector: rpc.Selector{Port: &port},
+			Name:     &name,
+		}),
+	}, &renamed); err != nil {
+		t.Fatalf("remote.call ports.rename: %v", err)
+	}
+	if renamed.Name == nil || *renamed.Name != name {
+		t.Fatalf("rename result = %+v, want the remote's own reply", renamed)
+	}
+
+	waitUntil(t, ctx, "the rename to reach the multiplexed rows", func() bool {
+		for _, p := range snapshot(t, ctx, c, []string{"*"}).Ports {
+			if p.Host == "fake" && p.Port == port && p.Name != nil && *p.Name == name {
+				return true
+			}
+		}
+		return false
+	})
+
+	// The local row is untouched: the write went to the other machine.
+	for _, p := range snapshot(t, ctx, c, nil).Ports {
+		if p.Port == port && p.Name != nil && *p.Name == name {
+			t.Error("the forwarded rename also renamed the local row")
+		}
+	}
+}
+
+// TestRemoteCallOnAnUnknownHost keeps a typo readable.
+func TestRemoteCallOnAnUnknownHost(t *testing.T) {
+	e := newBridgeEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	err := c.Call(ctx, "remote.call", rpc.RemoteCallParams{
+		Host: "nope", Method: "ports.list",
+	}, nil)
+	if err == nil {
+		t.Fatal("want an error for an unregistered host")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error = %v, want it to name the host", err)
+	}
+}
+
+func snapshot(t *testing.T, ctx context.Context, c *client.Client, hosts []string) state.Snapshot {
+	t.Helper()
+	var snap state.Snapshot
+	if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{Hosts: hosts}, &snap); err != nil {
+		t.Fatalf("state.snapshot: %v", err)
+	}
+	return snap
+}
+
+func waitUntil(t *testing.T, ctx context.Context, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			t.Fatalf("context ended waiting for %s", what)
+		}
+		if cond() {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func hasCapability(caps []string, want string) bool {
+	for _, c := range caps {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -86,6 +86,13 @@ type Options struct {
 	// interval and therefore needs the same collector every tick.
 	HostStats func(ctx context.Context) (state.Host, error)
 
+	// Remote returns the rows multiplexed in from the registered remote hosts,
+	// already tagged with their host name (step 3A.2). It is a function
+	// because the connection manager is installed from an OnStart hook, after
+	// the loop exists; nil means "localhost only", which is what a daemon with
+	// no registered hosts publishes.
+	Remote func() state.Rows
+
 	// Scan overrides the OS scan. Tests inject a fake; production leaves it nil
 	// and gets ports.Scan + docker.EnrichPorts + ports.Enrich.
 	Scan func(include Include) ([]ports.ListeningPort, error)
@@ -136,9 +143,13 @@ type Loop struct {
 	// order.
 	scanMu sync.Mutex
 
-	mu           sync.Mutex
-	subs         int
-	snap         state.Snapshot
+	mu   sync.Mutex
+	subs int
+	snap state.Snapshot
+	// local is the last scan's own rows, before the remote hosts were merged
+	// in. RemoteChanged republishes from it, so a remote host's delta costs
+	// nothing on the local machine: no OS scan, no attribution, no probes.
+	local        state.Rows
 	haveSnap     bool
 	lastScanAt   time.Time
 	lastHealthAt time.Time
@@ -239,25 +250,37 @@ func (l *Loop) SetPublisher(p Publisher) {
 	}
 }
 
+// SetRemote installs the remote-rows provider after construction. The remote
+// connection manager calls it from its OnStart hook.
+func (l *Loop) SetRemote(f func() state.Rows) {
+	if f != nil {
+		l.opts.Remote = f
+	}
+}
+
+// remoteRows is the current remote contribution, or nothing.
+func (l *Loop) remoteRows() state.Rows {
+	if l.opts.Remote == nil {
+		return state.Rows{}
+	}
+	return l.opts.Remote()
+}
+
 // Cached returns the last published snapshot without scanning. state.subscribe
 // uses it so the reply can be queued atomically with the subscription.
 func (l *Loop) Cached() state.Snapshot {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if !l.haveSnap {
-		return state.Snapshot{
+		// Even before the first scan `hosts` names this machine: a client
+		// that subscribes at startup must not have to special-case an empty
+		// collection to find localhost. The registered remote hosts are
+		// already there too, so a subscriber never sees them blink in.
+		base := state.Rows{Hosts: []state.Host{l.identityRow()}}
+		return base.Append(l.remoteRows()).Normalize().Into(state.Snapshot{
 			At:            l.now().Format(time.RFC3339),
 			DaemonVersion: l.opts.DaemonVersion,
-			Ports:         []state.Port{},
-			Groups:        []state.Group{},
-			Tunnels:       []state.Tunnel{},
-			Proxies:       []state.Proxy{},
-			Sessions:      []state.SessionRecord{},
-			// Even before the first scan `hosts` names this machine: a client
-			// that subscribes at startup must not have to special-case an
-			// empty collection to find localhost.
-			Hosts: []state.Host{l.identityRow()},
-		}
+		})
 	}
 	return l.snap
 }
@@ -406,19 +429,20 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	host.Ports, host.Groups = len(rows), len(groupRows)
 	host.LastSeen = l.lastScanAt.Format(time.RFC3339)
 
-	next = state.Snapshot{
+	// Tunnels and proxies belong to spec 3. Every collection is always an
+	// array, never null.
+	local := state.Rows{
+		Ports:    rows,
+		Groups:   groupRows,
+		Sessions: sessionRows,
+		Hosts:    []state.Host{host},
+	}.Tag(state.LocalhostName).Normalize()
+	l.local = local
+
+	next = local.Append(l.remoteRows()).Into(state.Snapshot{
 		At:            l.lastScanAt.Format(time.RFC3339),
 		DaemonVersion: l.opts.DaemonVersion,
-		Ports:         rows,
-		Groups:        groupRows,
-		// Tunnels and proxies belong to spec 3. Every collection is always an
-		// array, never null.
-		Tunnels:  []state.Tunnel{},
-		Proxies:  []state.Proxy{},
-		Sessions: sessionRows,
-		// One row until step 3A.2 registers remote hosts.
-		Hosts: []state.Host{host},
-	}
+	})
 
 	if l.haveSnap && !snapshotChanged(prev, next, include.Stats) {
 		if !hostChanged(prev, next) {
@@ -449,6 +473,43 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	l.haveSnap = true
 	l.interval = BaseInterval
 	return next, prev, true, nil
+}
+
+// RemoteChanged republishes the current state with the remote hosts' rows as
+// they are now. It runs no OS scan: the local half of the last tick is reused
+// verbatim, so a remote daemon publishing a delta every two seconds costs the
+// local machine a diff and a marshal rather than a full port scan.
+//
+// It takes scanMu like a scan does, so its publish cannot interleave with one
+// and delta seq order stays publish order (contract §38). Before the first
+// local scan there is nothing to merge into, so it wakes the loop instead and
+// the remote rows ride out with the first tick.
+func (l *Loop) RemoteChanged() {
+	l.scanMu.Lock()
+	defer l.scanMu.Unlock()
+
+	l.mu.Lock()
+	if !l.haveSnap {
+		l.mu.Unlock()
+		l.Wake()
+		return
+	}
+	prev := l.snap
+	next := l.local.Append(l.remoteRows()).Into(state.Snapshot{
+		At:              l.now().Format(time.RFC3339),
+		DaemonVersion:   l.opts.DaemonVersion,
+		ExposuresActive: prev.ExposuresActive,
+	})
+	if !snapshotChanged(prev, next, true) && !hostChanged(prev, next) {
+		l.mu.Unlock()
+		return
+	}
+	l.seq++
+	next.Seq = l.seq
+	l.snap = next
+	l.mu.Unlock()
+
+	l.publish(prev, next, nil)
 }
 
 // collectHost reads this machine's load for the tick. A failure is not a scan

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -266,9 +266,26 @@ func (l *Loop) remoteRows() state.Rows {
 	return l.opts.Remote()
 }
 
-// Cached returns the last published snapshot without scanning. state.subscribe
-// uses it so the reply can be queued atomically with the subscription.
-func (l *Loop) Cached() state.Snapshot {
+// Cached returns the last published snapshot without scanning, as this machine
+// alone: no remote host's rows.
+//
+// Local-only is the default on purpose. Everything inside the daemon that
+// resolves a selector — `ports.kill`, `ports.inspect`, `groups.start`, the
+// session handlers — reads a snapshot, and a port 3000 that also exists on a
+// registered host must not make those calls ambiguous for a caller that never
+// mentioned a host. A `host` on selectors is step 3A.4's job; until then, and
+// after it for every caller that omits one, a snapshot means localhost.
+//
+// The two places that publish state to clients — state.subscribe's opening
+// reply and the state.snapshot method — ask for CachedAll / SnapshotAll and
+// apply the subscriber's own `hosts` filter.
+func (l *Loop) Cached() state.Snapshot { return localOnly(l.CachedAll()) }
+
+// CachedAll is Cached including every registered remote host's rows. It is
+// what state.subscribe replies with, so a subscriber that asked for other
+// hosts sees them in its opening snapshot rather than waiting for one of them
+// to change.
+func (l *Loop) CachedAll() state.Snapshot {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if !l.haveSnap {
@@ -283,6 +300,32 @@ func (l *Loop) Cached() state.Snapshot {
 		})
 	}
 	return l.snap
+}
+
+// localOnly drops the remote hosts' rows. It is a no-op, allocation included,
+// when there are none, which is every daemon with no host registered.
+func localOnly(s state.Snapshot) state.Snapshot {
+	for i := range s.Ports {
+		if !state.IsLocalhost(s.Ports[i].Host) {
+			return state.FilterSnapshot(s, state.LocalOnly())
+		}
+	}
+	for i := range s.Hosts {
+		if !state.IsLocalhost(s.Hosts[i].Name) {
+			return state.FilterSnapshot(s, state.LocalOnly())
+		}
+	}
+	for i := range s.Groups {
+		if !state.IsLocalhost(s.Groups[i].Host) {
+			return state.FilterSnapshot(s, state.LocalOnly())
+		}
+	}
+	for i := range s.Sessions {
+		if !state.IsLocalhost(s.Sessions[i].Host) {
+			return state.FilterSnapshot(s, state.LocalOnly())
+		}
+	}
+	return s
 }
 
 // Wake nudges a stopped or backed-off loop to scan now. Called when a
@@ -671,6 +714,14 @@ func (l *Loop) nowRFC3339() string { return l.now().Format(time.RFC3339) }
 // caller asked for; otherwise it scans now. Either way it wakes the loop, so
 // reading state snaps the interval back to the base (spec, "Scanner loop").
 func (l *Loop) Snapshot(include Include) (state.Snapshot, error) {
+	snap, err := l.SnapshotAll(include)
+	return localOnly(snap), err
+}
+
+// SnapshotAll is Snapshot including every registered remote host's rows. Only
+// the state.snapshot method uses it, and it applies the caller's own `hosts`
+// filter to the result.
+func (l *Loop) SnapshotAll(include Include) (state.Snapshot, error) {
 	defer l.Wake()
 
 	if snap, ok := l.cached(include); ok {
@@ -692,7 +743,8 @@ func (l *Loop) Snapshot(include Include) (state.Snapshot, error) {
 // later. Rescan closes the window by holding scanMu across both halves.
 func (l *Loop) Rescan(include Include) (state.Snapshot, error) {
 	defer l.Wake()
-	return l.scanNow(include)
+	snap, err := l.scanNow(include)
+	return localOnly(snap), err
 }
 
 // scanNow is the uncached half of both: one scan under scanMu, published

--- a/internal/state/apply.go
+++ b/internal/state/apply.go
@@ -1,0 +1,64 @@
+package state
+
+// Apply folds a delta into a snapshot and returns the result. It is Diff's
+// inverse and the reason a client can follow a stream without ever asking for
+// a new snapshot: the remote-host bridge (step 3A.2) subscribes once to each
+// remote daemon and keeps that host's rows up to date entirely from deltas.
+func Apply(s Snapshot, d Delta) Snapshot {
+	s.Seq, s.At, s.ExposuresActive = d.Seq, d.At, d.ExposuresActive
+	s.Ports = applyChange(s.Ports, d.Ports, Port.Key)
+	s.Groups = applyChange(s.Groups, d.Groups, Group.Key)
+	s.Tunnels = applyChange(s.Tunnels, d.Tunnels, Tunnel.Key)
+	s.Proxies = applyChange(s.Proxies, d.Proxies, Proxy.Key)
+	s.Sessions = applyChange(s.Sessions, d.Sessions, SessionRecord.Key)
+	s.Hosts = applyChange(s.Hosts, d.Hosts, Host.Key)
+	return s
+}
+
+// applyChange rebuilds one collection from its previous rows and one Change.
+// The order of the surviving rows is preserved and genuinely new rows are
+// appended, so a collection the daemon publishes sorted stays sorted apart
+// from its tail.
+//
+// A key that appears in both Removed and Added is a restart: Diff emits the
+// pair for a port whose PID changed, and the new row replaces the old one
+// where it stood rather than being dropped and re-appended.
+func applyChange[T any](prev []T, ch Change[T], key func(T) string) []T {
+	removed := make(map[string]bool, len(ch.Removed))
+	for _, k := range ch.Removed {
+		removed[k] = true
+	}
+	replace := make(map[string]T, len(ch.Updated)+len(ch.Added))
+	for _, v := range ch.Updated {
+		replace[key(v)] = v
+	}
+	for _, v := range ch.Added {
+		replace[key(v)] = v
+	}
+
+	out := make([]T, 0, len(prev)+len(ch.Added))
+	kept := make(map[string]bool, len(prev))
+	for _, v := range prev {
+		k := key(v)
+		if repl, ok := replace[k]; ok {
+			out = append(out, repl)
+			kept[k] = true
+			continue
+		}
+		if removed[k] {
+			continue
+		}
+		out = append(out, v)
+		kept[k] = true
+	}
+	for _, v := range ch.Added {
+		if k := key(v); !kept[k] {
+			out = append(out, v)
+			kept[k] = true
+		}
+	}
+	if out == nil {
+		out = []T{}
+	}
+	return out
+}

--- a/internal/state/convert.go
+++ b/internal/state/convert.go
@@ -8,6 +8,9 @@ import "github.com/raskrebs/sonar/internal/ports"
 // byte-identical rows.
 func FromListening(lp ports.ListeningPort) Port {
 	p := Port{
+		// A row built straight from a scan is this machine's own. The daemon
+		// re-tags rows it multiplexes in from a remote bridge.
+		Host:        LocalhostName,
 		Port:        lp.Port,
 		BindAddress: lp.BindAddress,
 		IPVersion:   lp.IPVersion,

--- a/internal/state/delta.go
+++ b/internal/state/delta.go
@@ -25,6 +25,9 @@ type Delta struct {
 // Event is a discrete notification, sent alongside deltas when a subscriber
 // asked for events.
 type Event struct {
+	// Host is the machine the event happened on: "localhost", or the
+	// registered name of the remote host whose bridge forwarded it.
+	Host  string         `json:"host,omitempty"`
 	Kind  string         `json:"kind"` // port_up port_down port_restarted group_up group_down health_changed scan_error daemon_stopping db_reset tunnel_up tunnel_down
 	At    string         `json:"at"`
 	Port  *Port          `json:"port,omitempty"`

--- a/internal/state/diff.go
+++ b/internal/state/diff.go
@@ -20,20 +20,20 @@ func diff(prev, next Snapshot, withStats bool) Delta {
 		ExposuresActive: next.ExposuresActive,
 		Ports:           diffPorts(prev.Ports, next.Ports, withStats),
 		Groups: diffKeyed(prev.Groups, next.Groups,
-			func(g Group) string { return g.Name },
+			func(g Group) string { return g.Key() },
 			func(a, b Group) bool {
 				return a.Status == b.Status &&
 					reflect.DeepEqual(a.Members, b.Members) &&
 					reflect.DeepEqual(a.Services, b.Services)
 			}),
 		Tunnels: diffKeyed(prev.Tunnels, next.Tunnels,
-			func(t Tunnel) string { return t.ID },
+			func(t Tunnel) string { return t.Key() },
 			func(a, b Tunnel) bool { return reflect.DeepEqual(a, b) }),
 		Proxies: diffKeyed(prev.Proxies, next.Proxies,
-			func(p Proxy) string { return p.ID },
+			func(p Proxy) string { return p.Key() },
 			func(a, b Proxy) bool { return reflect.DeepEqual(a, b) }),
 		Sessions: diffKeyed(prev.Sessions, next.Sessions,
-			func(s SessionRecord) string { return s.ID },
+			func(s SessionRecord) string { return s.Key() },
 			func(a, b SessionRecord) bool { return reflect.DeepEqual(a, b) }),
 		Hosts: DiffHosts(prev.Hosts, next.Hosts),
 	}
@@ -43,7 +43,7 @@ func diff(prev, next Snapshot, withStats bool) Delta {
 // because the scanner asks the same question on its own — "did only the
 // machine's load move?" — when it decides whether a tick is worth publishing.
 func DiffHosts(prev, next []Host) Change[Host] {
-	return diffKeyed(prev, next, func(h Host) string { return h.Name }, hostsEqual)
+	return diffKeyed(prev, next, func(h Host) string { return h.Key() }, hostsEqual)
 }
 
 // hostsEqual decides whether a host row changed. Host load is state, not an

--- a/internal/state/group.go
+++ b/internal/state/group.go
@@ -23,6 +23,8 @@ type Service struct {
 // Group is a set of ports that belong to one project. Members are port
 // numbers; clients join them against the ports list.
 type Group struct {
+	// Host names the machine this group lives on (see Port.Host).
+	Host       string      `json:"host"`
 	Name       string      `json:"name"`
 	Source     GroupSource `json:"source" jsonschema:"enum=auto,enum=file,enum=manual,enum=start"`
 	RootDir    *string     `json:"root_dir" jsonschema:"nullable"`
@@ -32,10 +34,15 @@ type Group struct {
 	Services   []Service   `json:"services"`
 }
 
+// Key is the delta identity: the group name, namespaced by host for a remote
+// row.
+func (g Group) Key() string { return PrefixKey(g.Host, g.Name) }
+
 // Tunnel and Proxy are owned by spec 3; Claim and SessionRecord by spec 2.
 // Declared here so the snapshot has a stable shape from day one; fields follow
 // those specs.
 type Tunnel struct {
+	Host          string  `json:"host"`
 	ID            string  `json:"id"`
 	TargetPort    int     `json:"target_port"`
 	TargetGroup   *string `json:"target_group" jsonschema:"nullable"`
@@ -54,9 +61,13 @@ type Tunnel struct {
 	Requests      int64   `json:"requests"`
 }
 
+// Key is the delta identity: the tunnel id, namespaced by host.
+func (t Tunnel) Key() string { return PrefixKey(t.Host, t.ID) }
+
 // Proxy is a daemon-owned TCP (or HTTP) forwarder. It also appears in the
 // ports collection as a row with Type == TypeProxy.
 type Proxy struct {
+	Host        string `json:"host"`
 	ID          string `json:"id"`
 	ServicePort int    `json:"service_port"`
 	ListenPort  int    `json:"listen_port"`
@@ -68,10 +79,14 @@ type Proxy struct {
 	Requests    int64  `json:"requests"`
 }
 
+// Key is the delta identity: the proxy id, namespaced by host.
+func (p Proxy) Key() string { return PrefixKey(p.Host, p.ID) }
+
 // SessionRecord is a Session plus the aggregate counts the sessions collection
 // carries.
 type SessionRecord struct {
 	Session
+	Host      string `json:"host"`
 	FirstSeen string `json:"first_seen"`
 	LastSeen  string `json:"last_seen"`
 	Runs      int    `json:"runs"`
@@ -79,6 +94,9 @@ type SessionRecord struct {
 	Groups    int    `json:"groups"`
 	Active    bool   `json:"active"`
 }
+
+// Key is the delta identity: the session id, namespaced by host.
+func (s SessionRecord) Key() string { return PrefixKey(s.Host, s.ID) }
 
 // Claim is owned by spec 2 (slice M5); declared here so the schema has the
 // definition contract §6 requires from day one.

--- a/internal/state/host.go
+++ b/internal/state/host.go
@@ -65,3 +65,32 @@ type Host struct {
 
 // Key is the delta identity: the host name.
 func (h Host) Key() string { return h.Name }
+
+// PrefixKey is the delta-key rule for a row that may have come from a remote
+// host: local rows (host empty or "localhost") keep the key they have always
+// had, and only a remote row is namespaced with "<host>/". Keeping the local
+// form byte-identical is what lets a client built against the pre-3A.2
+// protocol keep working without a major bump (remote-hosts spec, decision 1);
+// the row's own `host` field is the disambiguator for everyone else.
+func PrefixKey(host, key string) string {
+	if IsLocalhost(host) {
+		return key
+	}
+	return host + "/" + key
+}
+
+// IsLocalhost reports whether a row's `host` names the daemon's own machine.
+// The empty string counts: a row built by a client that predates the field, or
+// by the CLI's direct scan, is a local row.
+func IsLocalhost(host string) bool {
+	return host == "" || host == LocalhostName
+}
+
+// HostOf is IsLocalhost's other half: the name a row should be filtered under,
+// with the empty string normalised to "localhost".
+func HostOf(host string) string {
+	if host == "" {
+		return LocalhostName
+	}
+	return host
+}

--- a/internal/state/port.go
+++ b/internal/state/port.go
@@ -122,6 +122,10 @@ type Session struct {
 // Port is one listening socket as published by the daemon. Clients render
 // DisplayName and never derive their own name.
 type Port struct {
+	// Host is the machine this row was observed on: "localhost" for the
+	// daemon's own machine, the registered name for a row multiplexed in from
+	// a remote host's bridge (step 3A.2). It is never empty on the wire.
+	Host        string       `json:"host"`
 	Port        int          `json:"port"`
 	BindAddress string       `json:"bind_address"`
 	IPVersion   string       `json:"ip_version"`
@@ -151,5 +155,10 @@ type Port struct {
 	StartedAt   *string      `json:"started_at" jsonschema:"nullable"`
 }
 
-// Key is the delta identity: "<port>:<bind_address>".
-func (p Port) Key() string { return fmt.Sprintf("%d:%s", p.Port, p.BindAddress) }
+// Key is the delta identity: "<port>:<bind_address>" for a local row and
+// "<host>/<port>:<bind_address>" for a row that came in over a remote bridge.
+// Local keys are deliberately unprefixed so a client written against the
+// pre-3A.2 protocol keeps working unchanged (remote-hosts spec, decision 1).
+func (p Port) Key() string {
+	return PrefixKey(p.Host, fmt.Sprintf("%d:%s", p.Port, p.BindAddress))
+}

--- a/internal/state/rows.go
+++ b/internal/state/rows.go
@@ -1,0 +1,236 @@
+package state
+
+import "sort"
+
+// Rows is one machine's contribution to the published collections: everything
+// a Snapshot carries except the sequence number and the counters, which belong
+// to the stream rather than to a host.
+//
+// The local daemon builds one Rows from its own scan and one per connected
+// remote bridge, then concatenates them into the Snapshot every subscriber
+// reads. Keeping the per-host pieces separate is what lets a remote host's
+// state change publish a delta without re-scanning the local machine, and lets
+// a host's rows be dropped wholesale when its bridge goes away.
+type Rows struct {
+	Ports    []Port
+	Groups   []Group
+	Tunnels  []Tunnel
+	Proxies  []Proxy
+	Sessions []SessionRecord
+	Hosts    []Host
+}
+
+// RowsOf takes the collections out of a snapshot.
+func RowsOf(s Snapshot) Rows {
+	return Rows{
+		Ports:    s.Ports,
+		Groups:   s.Groups,
+		Tunnels:  s.Tunnels,
+		Proxies:  s.Proxies,
+		Sessions: s.Sessions,
+		Hosts:    s.Hosts,
+	}
+}
+
+// Tag stamps every row with a host name and returns the result. It is how a
+// remote host's own state — which calls itself "localhost", because from that
+// daemon's point of view it is — becomes rows the local stream can carry
+// alongside its own without a key collision.
+//
+// The `hosts` collection is tagged too: the remote's localhost row is renamed
+// to the registered name, which is what the spec means by "the local daemon
+// copies each remote's hosts[0] into its own hosts".
+func (r Rows) Tag(host string) Rows {
+	out := Rows{
+		Ports:    make([]Port, len(r.Ports)),
+		Groups:   make([]Group, len(r.Groups)),
+		Tunnels:  make([]Tunnel, len(r.Tunnels)),
+		Proxies:  make([]Proxy, len(r.Proxies)),
+		Sessions: make([]SessionRecord, len(r.Sessions)),
+		Hosts:    make([]Host, len(r.Hosts)),
+	}
+	copy(out.Ports, r.Ports)
+	copy(out.Groups, r.Groups)
+	copy(out.Tunnels, r.Tunnels)
+	copy(out.Proxies, r.Proxies)
+	copy(out.Sessions, r.Sessions)
+	copy(out.Hosts, r.Hosts)
+
+	for i := range out.Ports {
+		out.Ports[i].Host = host
+	}
+	for i := range out.Groups {
+		out.Groups[i].Host = host
+	}
+	for i := range out.Tunnels {
+		out.Tunnels[i].Host = host
+	}
+	for i := range out.Proxies {
+		out.Proxies[i].Host = host
+	}
+	for i := range out.Sessions {
+		out.Sessions[i].Host = host
+	}
+	for i := range out.Hosts {
+		out.Hosts[i].Name = host
+	}
+	return out
+}
+
+// Append concatenates other onto r.
+func (r Rows) Append(other Rows) Rows {
+	r.Ports = append(r.Ports, other.Ports...)
+	r.Groups = append(r.Groups, other.Groups...)
+	r.Tunnels = append(r.Tunnels, other.Tunnels...)
+	r.Proxies = append(r.Proxies, other.Proxies...)
+	r.Sessions = append(r.Sessions, other.Sessions...)
+	r.Hosts = append(r.Hosts, other.Hosts...)
+	return r
+}
+
+// Normalize replaces every nil collection with an empty one, so the published
+// JSON never carries a null where the contract promises an array.
+func (r Rows) Normalize() Rows {
+	if r.Ports == nil {
+		r.Ports = []Port{}
+	}
+	if r.Groups == nil {
+		r.Groups = []Group{}
+	}
+	if r.Tunnels == nil {
+		r.Tunnels = []Tunnel{}
+	}
+	if r.Proxies == nil {
+		r.Proxies = []Proxy{}
+	}
+	if r.Sessions == nil {
+		r.Sessions = []SessionRecord{}
+	}
+	if r.Hosts == nil {
+		r.Hosts = []Host{}
+	}
+	return r
+}
+
+// Into copies the collections onto a snapshot, leaving seq, timestamp and the
+// counters alone.
+func (r Rows) Into(s Snapshot) Snapshot {
+	r = r.Normalize()
+	s.Ports, s.Groups, s.Tunnels = r.Ports, r.Groups, r.Tunnels
+	s.Proxies, s.Sessions, s.Hosts = r.Proxies, r.Sessions, r.Hosts
+	return s
+}
+
+// HostFilter decides which hosts' rows a subscriber sees. The zero value is
+// what `state.subscribe` with no `hosts` means: localhost only, which is
+// exactly the stream every pre-3A.2 client already reads.
+type HostFilter struct {
+	all  bool
+	set  map[string]bool
+	name string
+}
+
+// LocalOnly is the default filter.
+func LocalOnly() HostFilter { return HostFilter{name: LocalhostName} }
+
+// AllHosts matches every host, registered or not.
+func AllHosts() HostFilter { return HostFilter{all: true, name: "*"} }
+
+// ParseHostFilter turns the wire's `hosts` list into a filter. An absent or
+// empty list is localhost only; a list containing "*" is every host; anything
+// else is exactly the named set, so a client that wants localhost alongside a
+// remote host names both.
+func ParseHostFilter(hosts []string) HostFilter {
+	if len(hosts) == 0 {
+		return LocalOnly()
+	}
+	set := map[string]bool{}
+	for _, h := range hosts {
+		if h == "*" {
+			return AllHosts()
+		}
+		if h == "" {
+			h = LocalhostName
+		}
+		set[h] = true
+	}
+	names := make([]string, 0, len(set))
+	for h := range set {
+		names = append(names, h)
+	}
+	sort.Strings(names)
+	name := ""
+	for i, h := range names {
+		if i > 0 {
+			name += "\x00"
+		}
+		name += h
+	}
+	return HostFilter{set: set, name: name}
+}
+
+// Allows reports whether a row tagged with this host is visible.
+func (f HostFilter) Allows(host string) bool {
+	if f.all {
+		return true
+	}
+	if f.set == nil {
+		return IsLocalhost(host)
+	}
+	return f.set[HostOf(host)]
+}
+
+// All reports whether the filter is "*".
+func (f HostFilter) All() bool { return f.all }
+
+// Key is a comparable identity for the filter, so the daemon can marshal one
+// delta per distinct filter rather than one per subscriber.
+func (f HostFilter) Key() string { return f.name }
+
+// Filter keeps only the rows this filter allows.
+func (r Rows) Filter(f HostFilter) Rows {
+	if f.All() {
+		return r
+	}
+	out := Rows{}
+	for _, p := range r.Ports {
+		if f.Allows(p.Host) {
+			out.Ports = append(out.Ports, p)
+		}
+	}
+	for _, g := range r.Groups {
+		if f.Allows(g.Host) {
+			out.Groups = append(out.Groups, g)
+		}
+	}
+	for _, t := range r.Tunnels {
+		if f.Allows(t.Host) {
+			out.Tunnels = append(out.Tunnels, t)
+		}
+	}
+	for _, p := range r.Proxies {
+		if f.Allows(p.Host) {
+			out.Proxies = append(out.Proxies, p)
+		}
+	}
+	for _, s := range r.Sessions {
+		if f.Allows(s.Host) {
+			out.Sessions = append(out.Sessions, s)
+		}
+	}
+	for _, h := range r.Hosts {
+		if f.Allows(h.Name) {
+			out.Hosts = append(out.Hosts, h)
+		}
+	}
+	return out.Normalize()
+}
+
+// FilterSnapshot keeps only the rows f allows, leaving seq and the counters
+// untouched.
+func FilterSnapshot(s Snapshot, f HostFilter) Snapshot {
+	if f.All() {
+		return s
+	}
+	return RowsOf(s).Filter(f).Into(s)
+}

--- a/internal/state/rows_test.go
+++ b/internal/state/rows_test.go
@@ -1,0 +1,214 @@
+package state
+
+import (
+	"reflect"
+	"testing"
+)
+
+func port(host string, p int) Port {
+	return Port{Host: host, Port: p, BindAddress: "127.0.0.1", PID: p}
+}
+
+func TestPrefixKey(t *testing.T) {
+	tests := []struct {
+		host, key, want string
+	}{
+		{"", "3000:127.0.0.1", "3000:127.0.0.1"},
+		{"localhost", "3000:127.0.0.1", "3000:127.0.0.1"},
+		{"hetzner", "3000:127.0.0.1", "hetzner/3000:127.0.0.1"},
+	}
+	for _, tc := range tests {
+		if got := PrefixKey(tc.host, tc.key); got != tc.want {
+			t.Errorf("PrefixKey(%q, %q) = %q, want %q", tc.host, tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestTagStampsEveryCollection(t *testing.T) {
+	in := Rows{
+		Ports:    []Port{port("localhost", 3000)},
+		Groups:   []Group{{Name: "api"}},
+		Sessions: []SessionRecord{{Session: Session{ID: "s1"}}},
+		Tunnels:  []Tunnel{{ID: "t1"}},
+		Proxies:  []Proxy{{ID: "p1"}},
+		Hosts:    []Host{{Name: LocalhostName, Status: HostConnected}},
+	}
+	out := in.Tag("hetzner")
+
+	if out.Ports[0].Host != "hetzner" || out.Groups[0].Host != "hetzner" ||
+		out.Sessions[0].Host != "hetzner" || out.Tunnels[0].Host != "hetzner" ||
+		out.Proxies[0].Host != "hetzner" {
+		t.Errorf("Tag left a collection untagged: %+v", out)
+	}
+	if out.Hosts[0].Name != "hetzner" {
+		t.Errorf("host row name = %q, want the registered name", out.Hosts[0].Name)
+	}
+	if in.Ports[0].Host != "localhost" {
+		t.Error("Tag mutated the input rows")
+	}
+
+	if want := "hetzner/3000:127.0.0.1"; out.Ports[0].Key() != want {
+		t.Errorf("port key = %q, want %q", out.Ports[0].Key(), want)
+	}
+	if want := "hetzner/api"; out.Groups[0].Key() != want {
+		t.Errorf("group key = %q, want %q", out.Groups[0].Key(), want)
+	}
+	if want := "hetzner/s1"; out.Sessions[0].Key() != want {
+		t.Errorf("session key = %q, want %q", out.Sessions[0].Key(), want)
+	}
+}
+
+func TestParseHostFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		hosts  []string
+		allows map[string]bool
+	}{
+		{
+			name:   "absent means localhost only",
+			hosts:  nil,
+			allows: map[string]bool{"": true, "localhost": true, "hetzner": false},
+		},
+		{
+			name:   "star means everything",
+			hosts:  []string{"*"},
+			allows: map[string]bool{"localhost": true, "hetzner": true, "anything": true},
+		},
+		{
+			name:   "a list is exactly that set",
+			hosts:  []string{"hetzner"},
+			allows: map[string]bool{"localhost": false, "": false, "hetzner": true},
+		},
+		{
+			name:   "localhost can be named alongside a remote",
+			hosts:  []string{"localhost", "hetzner"},
+			allows: map[string]bool{"localhost": true, "": true, "hetzner": true, "other": false},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := ParseHostFilter(tc.hosts)
+			for host, want := range tc.allows {
+				if got := f.Allows(host); got != want {
+					t.Errorf("Allows(%q) = %v, want %v", host, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestHostFilterKeyIsOrderIndependent(t *testing.T) {
+	a := ParseHostFilter([]string{"b", "a"})
+	b := ParseHostFilter([]string{"a", "b"})
+	if a.Key() != b.Key() {
+		t.Errorf("keys differ by order: %q vs %q", a.Key(), b.Key())
+	}
+	if a.Key() == ParseHostFilter([]string{"a"}).Key() {
+		t.Error("different sets share a key")
+	}
+}
+
+func TestFilterSnapshotKeepsOnlyTheAskedHosts(t *testing.T) {
+	snap := Snapshot{
+		Seq:   7,
+		Ports: []Port{port("localhost", 3000), port("hetzner", 3000), port("box", 8080)},
+		Hosts: []Host{{Name: "localhost"}, {Name: "hetzner"}, {Name: "box"}},
+	}
+
+	local := FilterSnapshot(snap, LocalOnly())
+	if len(local.Ports) != 1 || local.Ports[0].Host != "localhost" {
+		t.Errorf("localhost-only ports = %+v", local.Ports)
+	}
+	if len(local.Hosts) != 1 {
+		t.Errorf("localhost-only hosts = %+v, want just localhost", local.Hosts)
+	}
+	if local.Seq != 7 {
+		t.Errorf("seq = %d, want the snapshot's own", local.Seq)
+	}
+
+	all := FilterSnapshot(snap, AllHosts())
+	if len(all.Ports) != 3 {
+		t.Errorf(`"*" ports = %+v, want all three`, all.Ports)
+	}
+
+	one := FilterSnapshot(snap, ParseHostFilter([]string{"hetzner"}))
+	if len(one.Ports) != 1 || one.Ports[0].Host != "hetzner" {
+		t.Errorf("hetzner ports = %+v", one.Ports)
+	}
+}
+
+func TestFilteredCollectionsAreNeverNull(t *testing.T) {
+	got := FilterSnapshot(Snapshot{}, LocalOnly())
+	if got.Ports == nil || got.Groups == nil || got.Tunnels == nil ||
+		got.Proxies == nil || got.Sessions == nil || got.Hosts == nil {
+		t.Errorf("filtering left a null collection: %+v", got)
+	}
+}
+
+func TestApplyIsTheInverseOfDiff(t *testing.T) {
+	prev := Snapshot{
+		Seq:      1,
+		Ports:    []Port{port("localhost", 3000), port("localhost", 8080)},
+		Groups:   []Group{{Name: "api", Status: "running"}},
+		Sessions: []SessionRecord{{Session: Session{ID: "s1"}}},
+		Hosts:    []Host{{Name: "localhost", Status: HostConnected}},
+	}
+	next := Snapshot{
+		Seq:      2,
+		At:       "2026-09-06T10:00:00Z",
+		Ports:    []Port{port("localhost", 3000), port("localhost", 9000)},
+		Groups:   []Group{{Name: "api", Status: "partial"}},
+		Sessions: []SessionRecord{},
+		Hosts:    []Host{{Name: "localhost", Status: HostConnected}},
+	}
+
+	got := Apply(prev, Diff(prev, next))
+	if got.Seq != next.Seq || got.At != next.At {
+		t.Errorf("seq/at = %d/%q, want %d/%q", got.Seq, got.At, next.Seq, next.At)
+	}
+	if !sameKeys(got.Ports, next.Ports) {
+		t.Errorf("ports = %+v, want %+v", got.Ports, next.Ports)
+	}
+	if !reflect.DeepEqual(got.Groups, next.Groups) {
+		t.Errorf("groups = %+v, want %+v", got.Groups, next.Groups)
+	}
+	if len(got.Sessions) != 0 {
+		t.Errorf("sessions = %+v, want none", got.Sessions)
+	}
+}
+
+// TestApplyHandlesARestart: Diff emits remove + add for a port whose PID
+// changed, and applying them in one delta must leave exactly one row, the new
+// one.
+func TestApplyHandlesARestart(t *testing.T) {
+	old := port("localhost", 3000)
+	fresh := old
+	fresh.PID = 999
+
+	prev := Snapshot{Seq: 1, Ports: []Port{old}}
+	next := Snapshot{Seq: 2, Ports: []Port{fresh}}
+
+	got := Apply(prev, Diff(prev, next))
+	if len(got.Ports) != 1 {
+		t.Fatalf("ports = %+v, want exactly one", got.Ports)
+	}
+	if got.Ports[0].PID != 999 {
+		t.Errorf("pid = %d, want the restarted process", got.Ports[0].PID)
+	}
+}
+
+func sameKeys(a, b []Port) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, p := range a {
+		seen[p.Key()] = true
+	}
+	for _, p := range b {
+		if !seen[p.Key()] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Adds `sonar daemon stdio`, a per-host ssh bridge with reconnect, and `remote.list/add/remove/call`. Remote rows carry `host` and are keyed `<host>/<port>:<bind>` (groups `<host>/<name>`); `state.subscribe` and `state.snapshot` take a `hosts` filter, absent meaning localhost only. Selectors keep the localhost default. `sonar remote add|remove|list` and `--host` on `sonar list` and `sonar info` route reads through the daemon.