### PR TITLE
feat: refresh per-process stats and the host load on a 1s tick of their own

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -59,10 +59,11 @@ func serveRun(cmd *cobra.Command, _ []string) error {
 	defer closeLog.Close()
 
 	srv := daemon.New(daemon.Options{
-		Socket:      socket,
-		Version:     selfupdate.Version,
-		IdleTimeout: loadedConfig.Daemon.ResolvedIdleTimeout(),
-		Logger:      logger,
+		Socket:        socket,
+		Version:       selfupdate.Version,
+		IdleTimeout:   loadedConfig.Daemon.ResolvedIdleTimeout(),
+		StatsInterval: loadedConfig.Daemon.ResolvedStatsInterval(),
+		Logger:        logger,
 	})
 
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,16 @@ type Config struct {
 // subscribers and no keepalive connection.
 const DefaultIdleTimeout = 30 * time.Minute
 
+// DefaultStatsInterval and MinStatsInterval bound `daemon.stats_interval`, the
+// cadence of the daemon's stats-only tick. They mirror scanner.StatsInterval
+// and scanner.MinStatsInterval; config does not import the scanner, which
+// would drag the whole port pipeline into every CLI command that reads a
+// config file.
+const (
+	DefaultStatsInterval = 1 * time.Second
+	MinStatsInterval     = 250 * time.Millisecond
+)
+
 // DaemonConfig holds `sonar serve` settings.
 type DaemonConfig struct {
 	// IdleTimeout is a Go duration ("30m", "2h"). "0" disables idle shutdown;
@@ -33,6 +43,12 @@ type DaemonConfig struct {
 	IdleTimeout string `yaml:"idle_timeout"`
 	// LogLevel is debug, info, warn or error. Empty means info.
 	LogLevel string `yaml:"log_level"`
+	// StatsInterval is how often the daemon refreshes per-process cpu/memory
+	// and the machine's own load row while something is subscribed, as a Go
+	// duration ("1s", "500ms"). Empty means DefaultStatsInterval; anything
+	// below MinStatsInterval is clamped to it. It does not affect how often
+	// ports are scanned — that cadence is adaptive and owned by the scanner.
+	StatsInterval string `yaml:"stats_interval"`
 }
 
 // ResolvedIdleTimeout returns the parsed idle timeout, falling back to
@@ -44,6 +60,22 @@ func (d DaemonConfig) ResolvedIdleTimeout() time.Duration {
 	v, err := time.ParseDuration(strings.TrimSpace(d.IdleTimeout))
 	if err != nil || v < 0 {
 		return DefaultIdleTimeout
+	}
+	return v
+}
+
+// ResolvedStatsInterval returns the parsed stats cadence, falling back to
+// DefaultStatsInterval and never returning less than MinStatsInterval.
+func (d DaemonConfig) ResolvedStatsInterval() time.Duration {
+	v, err := time.ParseDuration(strings.TrimSpace(d.StatsInterval))
+	if err != nil || v <= 0 {
+		// Including the unset case. There is no "off": the sampler already
+		// parks itself whenever nothing is subscribed, so a zero here would
+		// only mean a busy loop.
+		return DefaultStatsInterval
+	}
+	if v < MinStatsInterval {
+		return MinStatsInterval
 	}
 	return v
 }
@@ -117,6 +149,10 @@ const template = `# sonar configuration
 #   idle_timeout: 30m
 #   # How much the daemon writes to ~/.config/sonar/daemon.log.
 #   log_level: info     # debug | info | warn | error
+#   # How often cpu, memory and the host load strip refresh while the app (or
+#   # any other subscriber) is watching. Ports are scanned on their own
+#   # adaptive cadence and are not affected. Minimum 250ms.
+#   stats_interval: 1s
 
 # color: true       # set false to disable colored output
 
@@ -197,6 +233,16 @@ func validate(cfg *Config) []string {
 		if d, err := time.ParseDuration(v); err != nil || d < 0 {
 			warnings = append(warnings, fmt.Sprintf("config: invalid daemon.idle_timeout %q — using %s", v, DefaultIdleTimeout))
 			cfg.Daemon.IdleTimeout = ""
+		}
+	}
+
+	if v := strings.TrimSpace(cfg.Daemon.StatsInterval); v != "" {
+		if d, err := time.ParseDuration(v); err != nil || d <= 0 {
+			warnings = append(warnings, fmt.Sprintf("config: invalid daemon.stats_interval %q — using %s", v, DefaultStatsInterval))
+			cfg.Daemon.StatsInterval = ""
+		} else if d < MinStatsInterval {
+			warnings = append(warnings, fmt.Sprintf("config: daemon.stats_interval %q is below the %s minimum — using %s", v, MinStatsInterval, MinStatsInterval))
+			cfg.Daemon.StatsInterval = MinStatsInterval.String()
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPath(t *testing.T) {
@@ -199,11 +200,52 @@ func TestWriteTemplateRefusesOverwrite(t *testing.T) {
 // daemon actually honours have to be in it.
 func TestTemplateDocumentsTheDaemonAndItsEnvironment(t *testing.T) {
 	for _, want := range []string{
-		"# daemon:", "idle_timeout: 30m", "log_level: info",
+		"# daemon:", "idle_timeout: 30m", "log_level: info", "stats_interval: 1s",
 		"SONAR_DB", "SONAR_SOCKET", "SONAR_NO_HINTS",
 	} {
 		if !strings.Contains(template, want) {
 			t.Errorf("config template does not mention %q", want)
 		}
+	}
+}
+
+// daemon.stats_interval defaults to 1 s, is clamped rather than trusted, and
+// never leaves the daemon with a zero cadence.
+func TestResolvedStatsInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		set  string
+		want time.Duration
+	}{
+		{"unset", "", DefaultStatsInterval},
+		{"explicit", "2s", 2 * time.Second},
+		{"sub-second", "500ms", 500 * time.Millisecond},
+		{"below the floor", "10ms", MinStatsInterval},
+		{"zero", "0", DefaultStatsInterval},
+		{"nonsense", "soon", DefaultStatsInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DaemonConfig{StatsInterval: tt.set}.ResolvedStatsInterval()
+			if got != tt.want {
+				t.Errorf("ResolvedStatsInterval(%q) = %s, want %s", tt.set, got, tt.want)
+			}
+		})
+	}
+}
+
+// An out-of-range stats_interval is repaired with a warning, the way every
+// other bad setting is, and its neighbours survive.
+func TestValidateClampsStatsInterval(t *testing.T) {
+	cfg := &Config{Daemon: DaemonConfig{StatsInterval: "5ms", LogLevel: "debug"}}
+	warnings := validate(cfg)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "stats_interval") {
+		t.Fatalf("warnings = %v, want one about stats_interval", warnings)
+	}
+	if got := cfg.Daemon.ResolvedStatsInterval(); got != MinStatsInterval {
+		t.Errorf("stats_interval = %s, want the %s floor", got, MinStatsInterval)
+	}
+	if cfg.Daemon.LogLevel != "debug" {
+		t.Errorf("log_level = %q, a valid neighbour was dropped", cfg.Daemon.LogLevel)
 	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -43,6 +43,10 @@ type Options struct {
 	// IdleTimeout stops the daemon after this long with no clients, no
 	// subscribers and no keepalive. Zero disables it.
 	IdleTimeout time.Duration
+	// StatsInterval is the cadence of the scanner's stats-only tick
+	// (`daemon.stats_interval`). Zero means scanner.StatsInterval. Ignored
+	// when Scanner is set, since the caller built the loop itself.
+	StatsInterval time.Duration
 	// Logger receives the daemon's structured log. Required in production;
 	// tests may leave it nil for a discard logger.
 	Logger *slog.Logger
@@ -114,6 +118,7 @@ func New(opts Options) *Server {
 			DaemonVersion:   opts.Version,
 			ProtocolVersion: rpc.ProtocolVersion,
 			Logger:          opts.Logger,
+			StatsInterval:   opts.StatsInterval,
 		})
 	}
 	s.loop.SetDemand(s.demand)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,6 +60,14 @@ type testHarness struct {
 	rows  []ports.ListeningPort
 	edges []ports.Connection
 	probe scanner.Probe
+
+	// statsMove turns the two fakes the stats-only tick drives — the host
+	// collector and the per-process sampler — from constants into climbing
+	// readings. It is off by default so that a test's deltas move only when
+	// the ports it fakes do; the stats-tick tests turn it on.
+	statsMove atomic.Bool
+	hostCPU   atomic.Int64 // tenths of a percent
+	sampleN   atomic.Int64
 }
 
 // newHarness builds a server whose scan loop is already running, so a change to
@@ -94,6 +103,12 @@ func newHarness(t *testing.T, ctx context.Context) *testHarness {
 			h.mu.Unlock()
 			return probe(host, port, path, timeout)
 		},
+		// The machine's own load and the per-process sampler are faked for
+		// the same reason Scan is: both fork `ps` on Unix and a PowerShell on
+		// Windows, and the stats-only tick calls them once a second for as
+		// long as a test keeps a subscription open.
+		HostStats:   h.hostStats,
+		SampleStats: h.sampleStats,
 	})
 	h.srv = New(Options{Socket: "/test/sonar.sock", Version: "test", Scanner: h.loop})
 
@@ -123,6 +138,37 @@ func (h *testHarness) shutdown() {
 	h.stopLoop()
 	<-h.loopDone
 	h.srv.closeStore()
+}
+
+// hostStats is the harness's localhost collector: a constant row unless the
+// test asked for a moving one.
+func (h *testHarness) hostStats(context.Context) (state.Host, error) {
+	if !h.statsMove.Load() {
+		return state.Host{Kernel: "test-kernel", OS: "testos", Arch: "testarch"}, nil
+	}
+	pct := float64(h.hostCPU.Add(5)) / 10
+	return state.Host{Kernel: "test-kernel", OS: "testos", Arch: "testarch", CPUPercent: &pct}, nil
+}
+
+// sampleStats is the harness's per-process sampler. It answers for nothing
+// unless the test asked for movement, so an ordinary harness test's stats are
+// whatever its fake rows carry.
+func (h *testHarness) sampleStats(pids []int) map[int]ports.ProcSample {
+	if !h.statsMove.Load() {
+		return nil
+	}
+	n := h.sampleN.Add(1)
+	out := make(map[int]ports.ProcSample, len(pids))
+	for _, pid := range pids {
+		out[pid] = ports.ProcSample{
+			CPUPercent:  float64(n),
+			MemoryRSS:   int64(pid) << 10,
+			ThreadCount: 3,
+			State:       "running",
+			Uptime:      "1s",
+		}
+	}
+	return out
 }
 
 // setRows replaces what the fake scanner returns.

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -76,11 +76,21 @@ type testHarness struct {
 // A harness that opens a database must be built *after* the t.TempDir() that
 // holds it: cleanups run last-registered-first, and the harness has to stop
 // before the directory it writes into is removed.
-func newHarness(t *testing.T, ctx context.Context) *testHarness {
+// tune lets a test adjust the scanner options the harness builds, before the
+// loop is constructed. The stats tick is what it is for: most tests only need
+// it to exist, and paying the production 1 s cadence for each of them makes
+// the suite slower without testing anything, so they turn it down.
+type tune func(*scanner.Options)
+
+// fastStats is that knob: a cadence short enough that a test can wait for a
+// tick without waiting a second for it.
+func fastStats(o *scanner.Options) { o.StatsInterval = 50 * time.Millisecond }
+
+func newHarness(t *testing.T, ctx context.Context, tunes ...tune) *testHarness {
 	t.Helper()
 	h := &testHarness{t: t, loopDone: make(chan struct{})}
 	h.probe = refusedProbe
-	h.loop = scanner.New(scanner.Options{
+	opts := scanner.Options{
 		DaemonVersion: "test",
 		Scan: func(scanner.Include) ([]ports.ListeningPort, error) {
 			h.mu.Lock()
@@ -109,7 +119,11 @@ func newHarness(t *testing.T, ctx context.Context) *testHarness {
 		// long as a test keeps a subscription open.
 		HostStats:   h.hostStats,
 		SampleStats: h.sampleStats,
-	})
+	}
+	for _, tune := range tunes {
+		tune(&opts)
+	}
+	h.loop = scanner.New(opts)
 	h.srv = New(Options{Socket: "/test/sonar.sock", Version: "test", Scanner: h.loop})
 
 	runCtx, stop := context.WithCancel(ctx)

--- a/internal/daemon/stats_tick_test.go
+++ b/internal/daemon/stats_tick_test.go
@@ -1,0 +1,159 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// statsRows is a port set that already carries stats, the way a real scan's
+// does once a subscriber has asked for them.
+func statsRows() []ports.ListeningPort {
+	return []ports.ListeningPort{
+		{Port: 3000, BindAddress: "127.0.0.1", PID: 100, Process: "node",
+			CPUPercent: 1, MemoryRSS: 1 << 20, ThreadCount: 4, Connections: 2, State: "running"},
+		{Port: 5173, BindAddress: "127.0.0.1", PID: 200, Process: "vite",
+			CPUPercent: 2, MemoryRSS: 2 << 20, ThreadCount: 9, Connections: 1, State: "running"},
+	}
+}
+
+// The step's acceptance test: a subscriber that asked for stats is fed by the
+// 1 s stats tick, not by the adaptive port scan, so it sees several
+// stats-bearing deltas in a few seconds even though no port changed.
+func TestStatsSubscriberSeesASecondlyCadence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newHarness(t, ctx)
+	h.setRows(statsRows()...)
+	h.statsMove.Store(true)
+
+	c := h.dial(ctx)
+	c.subscribeAndSettle(rpc.StateSubscribeParams{Include: rpc.Include{"stats"}})
+
+	const want = 3
+	deadline := time.Now().Add(5 * time.Second)
+	var (
+		seen  int
+		times []time.Time
+		last  uint64
+	)
+	for seen < want && time.Now().Before(deadline) {
+		d := c.nextDelta()
+		if d.Seq <= last {
+			t.Fatalf("delta seq %d after %d: seq order is not publish order", d.Seq, last)
+		}
+		last = d.Seq
+		if !carriesStats(d) {
+			continue
+		}
+		// Contract §21: an updated row is the full Port object, not a patch.
+		for _, p := range d.Ports.Updated {
+			if p.Port == 0 || p.Process == "" {
+				t.Fatalf("a stats delta carried a partial port: %+v", p)
+			}
+		}
+		if len(d.Ports.Added)+len(d.Ports.Removed) != 0 {
+			t.Fatalf("a stats tick added or removed a port: %+v", d.Ports)
+		}
+		seen++
+		times = append(times, time.Now())
+	}
+	if seen < want {
+		t.Fatalf("saw %d stats-bearing deltas in 5s, want at least %d", seen, want)
+	}
+	t.Logf("stats deltas at %v", times)
+}
+
+// A subscriber that asked for neither stats nor health still sees the machine
+// load the same tick collects — host load is state, not an opt-in statistic
+// (contract §37) — and never sees a `stats` object.
+func TestNonStatsSubscriberGetsHostRowsButNoStats(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newHarness(t, ctx)
+	h.setRows(statsRows()...)
+	h.statsMove.Store(true)
+
+	// One subscriber asks for stats, so the scanner really is collecting
+	// them: the filter has to be what keeps them off the other's wire.
+	statsClient := h.dial(ctx)
+	statsClient.subscribeAndSettle(rpc.StateSubscribeParams{Include: rpc.Include{"stats"}})
+	go drain(ctx, statsClient)
+
+	plain := h.dial(ctx)
+	plain.subscribeAndSettle(rpc.StateSubscribeParams{})
+
+	hostDeltas := 0
+	deadline := time.Now().Add(5 * time.Second)
+	for hostDeltas < 3 && time.Now().Before(deadline) {
+		d := plain.nextDelta()
+		for _, p := range append(append([]state.Port{}, d.Ports.Added...), d.Ports.Updated...) {
+			if p.Stats != nil {
+				t.Fatalf("a subscriber without include:[stats] received stats: %+v", p.Stats)
+			}
+		}
+		if len(d.Hosts.Updated)+len(d.Hosts.Added) > 0 {
+			hostDeltas++
+		}
+	}
+	if hostDeltas < 3 {
+		t.Fatalf("saw %d host deltas in 5s, want at least 3", hostDeltas)
+	}
+}
+
+// With nobody subscribed the stats tick is parked, so an RPC read — which
+// wakes the loop — must not start it and `daemon.status` must report exactly
+// what a scan left behind.
+func TestStatsTickStaysParkedForRPCReads(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newHarness(t, ctx)
+	h.setRows(statsRows()...)
+	h.statsMove.Store(true)
+
+	c := h.dial(ctx)
+	if e := c.call("state.snapshot", rpc.StateSnapshotParams{Include: rpc.Include{"stats"}}, nil); e != nil {
+		t.Fatalf("state.snapshot: %v", e)
+	}
+	time.Sleep(1500 * time.Millisecond)
+	if got := h.sampleN.Load(); got != 0 {
+		t.Errorf("the stats sampler ran %d times for an unsubscribed daemon", got)
+	}
+
+	var status rpc.DaemonStatusResult
+	if e := c.call("daemon.status", rpc.Empty{}, &status); e != nil {
+		t.Fatalf("daemon.status: %v", e)
+	}
+	if status.ScanIntervalMs < int(scanner.BaseInterval/time.Millisecond) {
+		t.Errorf("scan_interval_ms = %d, want at least the %s base", status.ScanIntervalMs, scanner.BaseInterval)
+	}
+}
+
+// carriesStats reports whether a delta moved any port's stats.
+func carriesStats(d state.Delta) bool {
+	for _, p := range d.Ports.Updated {
+		if p.Stats != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// drain keeps a client's pipe empty. net.Pipe is unbuffered, so a subscriber
+// nobody reads blocks the daemon's writer and starves every other one.
+func drain(ctx context.Context, c *testClient) {
+	for ctx.Err() == nil {
+		c.conn.SetReadDeadline(time.Now().Add(pipeRead))
+		if _, err := c.r.ReadBytes('\n'); err != nil {
+			return
+		}
+	}
+}

--- a/internal/daemon/stats_tick_test.go
+++ b/internal/daemon/stats_tick_test.go
@@ -157,3 +157,70 @@ func drain(ctx context.Context, c *testClient) {
 		}
 	}
 }
+
+// The stats tick runs on its own clock, so it lands in the window between a
+// bridge swapping its rows in and RemoteChanged announcing them. The remote
+// host must be published exactly once, with a seq of its own, and the daemon's
+// cached snapshot must agree with what went out.
+func TestStatsTickBetweenARemoteChangeAndItsPublish(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newHarness(t, ctx)
+	h.setRows(statsRows()...)
+	h.statsMove.Store(true)
+
+	src := &remoteSource{}
+	h.loop.SetRemote(src.get)
+
+	c := h.dial(ctx)
+	c.subscribeAndSettle(rpc.StateSubscribeParams{
+		Include: rpc.Include{"stats"}, Hosts: []string{"*"},
+	})
+
+	// The bridge writes, then at least one stats tick runs before the call
+	// that is supposed to announce it.
+	before := h.sampleN.Load()
+	src.set(remoteRows("hetzner", 3000))
+	deadline := time.Now().Add(5 * time.Second)
+	for h.sampleN.Load() < before+2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if h.sampleN.Load() < before+2 {
+		t.Fatal("no stats tick ran in the window; the test proved nothing")
+	}
+	h.loop.RemoteChanged()
+
+	// Read a few seconds of deltas and count the ones announcing the host.
+	announced, last := 0, uint64(0)
+	for i := 0; i < 5; i++ {
+		d := c.nextDelta()
+		if d.Seq <= last {
+			t.Fatalf("delta seq %d after %d: publish order is not seq order", d.Seq, last)
+		}
+		last = d.Seq
+		for _, p := range d.Ports.Added {
+			if p.Host == "hetzner" && p.Port == 3000 {
+				announced++
+			}
+		}
+	}
+	if announced != 1 {
+		t.Fatalf("the remote host was announced %d times, want exactly 1", announced)
+	}
+
+	// And a reader that arrives now sees what the stream said.
+	var snap state.Snapshot
+	if e := c.call("state.snapshot", map[string]any{"hosts": []string{"*"}}, &snap); e != nil {
+		t.Fatalf("state.snapshot: %v", e)
+	}
+	found := false
+	for _, p := range snap.Ports {
+		if p.Host == "hetzner" && p.Port == 3000 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the snapshot lost the remote row the stream announced")
+	}
+}

--- a/internal/daemon/stats_tick_test.go
+++ b/internal/daemon/stats_tick_test.go
@@ -77,7 +77,7 @@ func TestNonStatsSubscriberGetsHostRowsButNoStats(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h := newHarness(t, ctx)
+	h := newHarness(t, ctx, fastStats)
 	h.setRows(statsRows()...)
 	h.statsMove.Store(true)
 
@@ -115,7 +115,7 @@ func TestStatsTickStaysParkedForRPCReads(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h := newHarness(t, ctx)
+	h := newHarness(t, ctx, fastStats)
 	h.setRows(statsRows()...)
 	h.statsMove.Store(true)
 
@@ -123,7 +123,8 @@ func TestStatsTickStaysParkedForRPCReads(t *testing.T) {
 	if e := c.call("state.snapshot", rpc.StateSnapshotParams{Include: rpc.Include{"stats"}}, nil); e != nil {
 		t.Fatalf("state.snapshot: %v", e)
 	}
-	time.Sleep(1500 * time.Millisecond)
+	// Many cadences' worth of chances to fire.
+	time.Sleep(500 * time.Millisecond)
 	if got := h.sampleN.Load(); got != 0 {
 		t.Errorf("the stats sampler ran %d times for an unsubscribed daemon", got)
 	}
@@ -166,7 +167,7 @@ func TestStatsTickBetweenARemoteChangeAndItsPublish(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	h := newHarness(t, ctx)
+	h := newHarness(t, ctx, fastStats)
 	h.setRows(statsRows()...)
 	h.statsMove.Store(true)
 

--- a/internal/ports/connections.go
+++ b/internal/ports/connections.go
@@ -1,0 +1,158 @@
+package ports
+
+import (
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// applyConnectionCounts fills in every row's established-connection count from
+// a single listing of the machine's TCP connections.
+//
+// It used to be one `lsof -iTCP:<port>` (or one `ss`) per listening port. On a
+// developer machine with three dozen listeners that is three dozen forks per
+// scan and, measured on macOS, 2.4 s of the 4.5 s a stats-enabled scan took —
+// all of it inside the lock that keeps scans and the stats tick from
+// interleaving, which starved the 1 s tick down to a delta every five or six
+// seconds. One listing costs 75 ms and answers for every port at once.
+func applyConnectionCounts(pp []ListeningPort) {
+	if len(pp) == 0 {
+		return
+	}
+	counts := connectionCounts()
+	for i := range pp {
+		pp[i].Connections = counts[pp[i].Port]
+	}
+}
+
+// connectionCounts lists established TCP connections once and counts them per
+// local port.
+func connectionCounts() map[int]int {
+	switch runtime.GOOS {
+	case "windows":
+		out, err := exec.Command("netstat", "-ano").Output()
+		if err != nil {
+			return nil
+		}
+		return countNetstatByPort(string(out))
+	case "darwin":
+		out, err := exec.Command("lsof", "-iTCP", "-sTCP:ESTABLISHED", "-n", "-P").Output()
+		if err != nil {
+			return nil
+		}
+		return countLsofByPort(string(out))
+	default:
+		out, err := exec.Command("ss", "-tn", "state", "established").Output()
+		if err != nil {
+			return nil
+		}
+		return countSSByPort(string(out))
+	}
+}
+
+// countLsofByPort counts `lsof -iTCP -sTCP:ESTABLISHED -n -P` by port.
+//
+// It reproduces exactly what the per-port `lsof -iTCP:<port>` calls reported,
+// halving included: `-i:<port>` matches a connection at *either* end, so a
+// loopback connection between two local processes showed up twice — once as
+// the server's fd and once as the client's — and the old code divided by two
+// to undo that. Both endpoints are counted here for the same reason, so the
+// published `connections` figure does not move for anyone.
+func countLsofByPort(out string) map[int]int {
+	hits := map[int]int{}
+	for _, line := range strings.Split(out, "\n") {
+		local, remote, ok := lsofEndpoints(line)
+		if !ok {
+			continue
+		}
+		hits[local]++
+		hits[remote]++
+	}
+	counts := make(map[int]int, len(hits))
+	for port, n := range hits {
+		counts[port] = n / 2
+	}
+	return counts
+}
+
+// lsofEndpoints pulls the two port numbers out of an lsof NAME field of the
+// form "127.0.0.1:3000->127.0.0.1:52344 (ESTABLISHED)", IPv6 brackets and all.
+func lsofEndpoints(line string) (local, remote int, ok bool) {
+	for _, field := range strings.Fields(line) {
+		arrow := strings.Index(field, "->")
+		if arrow < 0 {
+			continue
+		}
+		l, lok := portAfterColon(field[:arrow])
+		r, rok := portAfterColon(field[arrow+2:])
+		if lok && rok {
+			return l, r, true
+		}
+	}
+	return 0, 0, false
+}
+
+// countSSByPort counts `ss -tn state established` by local port. `ss` reports
+// only the local end as the source, which is what the per-port
+// `sport = :<port>` filter selected, so no halving applies.
+//
+// The columns are read from the right, not by index: `ss` prints a State
+// column when it is not filtering by state and drops it when it is, so a
+// fixed index reads Send-Q on one machine and the local address on another.
+// The last two address-shaped fields are always local and peer.
+func countSSByPort(out string) map[int]int {
+	counts := map[int]int{}
+	for _, line := range strings.Split(out, "\n") {
+		local, ok := ssLocalPort(strings.Fields(line))
+		if !ok {
+			continue
+		}
+		counts[local]++
+	}
+	return counts
+}
+
+// ssLocalPort returns the local port of one `ss` row: the second-to-last field
+// that looks like an address with a port.
+func ssLocalPort(fields []string) (int, bool) {
+	var ports []int
+	for _, f := range fields {
+		if p, ok := portAfterColon(f); ok {
+			ports = append(ports, p)
+		}
+	}
+	if len(ports) < 2 {
+		return 0, false
+	}
+	return ports[len(ports)-2], true
+}
+
+// countNetstatByPort counts `netstat -ano` ESTABLISHED rows by local port.
+func countNetstatByPort(out string) map[int]int {
+	counts := map[int]int{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 4 || strings.ToUpper(fields[3]) != "ESTABLISHED" {
+			continue
+		}
+		if port, ok := portAfterColon(fields[1]); ok {
+			counts[port]++
+		}
+	}
+	return counts
+}
+
+// portAfterColon reads the port off an address, ignoring the IPv6 brackets and
+// the colons inside them.
+func portAfterColon(addr string) (int, bool) {
+	i := strings.LastIndex(addr, ":")
+	if i < 0 {
+		return 0, false
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(addr[i+1:]))
+	if err != nil || port <= 0 {
+		return 0, false
+	}
+	return port, true
+}

--- a/internal/ports/connections_test.go
+++ b/internal/ports/connections_test.go
@@ -1,0 +1,111 @@
+package ports
+
+import (
+	"reflect"
+	"testing"
+)
+
+// One `lsof -iTCP -sTCP:ESTABLISHED` must answer for every port at once, and
+// answer with the numbers the old per-port calls did: `-i:<port>` matched a
+// connection at either end, so a loopback pair counted twice and was halved.
+func TestCountLsofByPort(t *testing.T) {
+	out := `COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+node     1000 rkrebs   24u  IPv4 0x1111      0t0  TCP 127.0.0.1:3000->127.0.0.1:52344 (ESTABLISHED)
+curl     1001 rkrebs    5u  IPv4 0x1111      0t0  TCP 127.0.0.1:52344->127.0.0.1:3000 (ESTABLISHED)
+node     1000 rkrebs   25u  IPv4 0x2222      0t0  TCP 127.0.0.1:3000->127.0.0.1:52345 (ESTABLISHED)
+curl     1002 rkrebs    5u  IPv4 0x2222      0t0  TCP 127.0.0.1:52345->127.0.0.1:3000 (ESTABLISHED)
+vite     1003 rkrebs   30u  IPv6 0x3333      0t0  TCP [::1]:5173->[::1]:60001 (ESTABLISHED)
+chrome   1004 rkrebs   88u  IPv6 0x3333      0t0  TCP [::1]:60001->[::1]:5173 (ESTABLISHED)
+sshd      900 root      3u  IPv4 0x4444      0t0  TCP 10.0.0.2:22->10.0.0.9:51000 (ESTABLISHED)
+`
+	got := countLsofByPort(out)
+	for _, tt := range []struct {
+		port, want int
+	}{
+		{3000, 2}, // two loopback clients
+		{5173, 1}, // one, over IPv6
+		{22, 0},   // remote peer: only one end is local, as before
+	} {
+		if got[tt.port] != tt.want {
+			t.Errorf("port %d = %d connections, want %d (all: %v)", tt.port, got[tt.port], tt.want, got)
+		}
+	}
+}
+
+func TestCountSSByPort(t *testing.T) {
+	// With a state filter ss drops the State column; without one it keeps it.
+	// Both shapes have to read the same.
+	filtered := `Recv-Q Send-Q Local Address:Port  Peer Address:Port
+0      0      127.0.0.1:3000      127.0.0.1:52344
+0      0      127.0.0.1:3000      127.0.0.1:52345
+0      0      127.0.0.1:52344     127.0.0.1:3000
+0      0      [::1]:5173          [::1]:60001
+`
+	unfiltered := `State  Recv-Q Send-Q Local Address:Port  Peer Address:Port
+ESTAB  0      0      127.0.0.1:3000      127.0.0.1:52344
+ESTAB  0      0      127.0.0.1:3000      127.0.0.1:52345
+ESTAB  0      0      127.0.0.1:52344     127.0.0.1:3000
+ESTAB  0      0      [::1]:5173          [::1]:60001
+`
+	if !reflect.DeepEqual(countSSByPort(filtered), countSSByPort(unfiltered)) {
+		t.Errorf("ss with and without its State column read differently:\n %v\n %v",
+			countSSByPort(filtered), countSSByPort(unfiltered))
+	}
+	got := countSSByPort(filtered)
+	// ss reports the local end as the source, which is what the per-port
+	// `sport = :<port>` filter selected: no halving.
+	if got[3000] != 2 || got[5173] != 1 || got[52344] != 1 {
+		t.Errorf("counts = %v, want 3000:2 5173:1 52344:1", got)
+	}
+}
+
+func TestCountNetstatByPort(t *testing.T) {
+	out := `
+Active Connections
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    127.0.0.1:3000         127.0.0.1:52344        ESTABLISHED     1000
+  TCP    127.0.0.1:3000         127.0.0.1:52345        ESTABLISHED     1000
+  TCP    0.0.0.0:5173           0.0.0.0:0              LISTENING       1003
+`
+	got := countNetstatByPort(out)
+	if got[3000] != 2 {
+		t.Errorf("port 3000 = %d, want 2 (all: %v)", got[3000], got)
+	}
+	if got[5173] != 0 {
+		t.Errorf("a LISTENING row was counted as a connection: %v", got)
+	}
+}
+
+// `ps -M` with a pid list: a process line then one line per thread, and the
+// pid sits in a different column on each. The count is every line but the
+// header, per pid, which is what the one-fork-per-pid version reported.
+func TestCountPSThreads(t *testing.T) {
+	out := `USER     PID   TT   %CPU STAT PRI     STIME     UTIME COMMAND
+root       1   ??    0.0 S    31T   0:00.40   0:00.09 /sbin/launchd
+           1         0.0 S    37T   0:00.02   0:00.02 
+           1         0.1 S    37T   0:00.01   0:00.01 
+rkrebs  1000   ??    3.1 S    31T   0:00.01   0:00.01 node server.js
+        1000         0.0 S    37T   0:00.00   0:00.00 
+`
+	got := countPSThreads(out, map[int]bool{1: true, 1000: true})
+	want := map[int]int{1: 3, 1000: 2}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("thread counts = %v, want %v", got, want)
+	}
+}
+
+// A pid ps had nothing to say about is absent rather than reported as zero
+// threads by a line that belongs to someone else.
+func TestCountPSThreadsIgnoresUnrequestedPIDs(t *testing.T) {
+	out := `USER     PID   TT   %CPU STAT PRI     STIME     UTIME COMMAND
+rkrebs  1000   ??    3.1 S    31T   0:00.01   0:00.01 node server.js
+        1000         0.0 S    37T   0:00.00   0:00.00 
+`
+	got := countPSThreads(out, map[int]bool{1000: true, 2000: true})
+	if _, ok := got[2000]; ok {
+		t.Errorf("counts = %v, want no entry for the pid ps did not report", got)
+	}
+	if got[1000] != 2 {
+		t.Errorf("pid 1000 = %d threads, want 2", got[1000])
+	}
+}

--- a/internal/ports/enrich.go
+++ b/internal/ports/enrich.go
@@ -378,105 +378,43 @@ func field(rec []string, cols map[string]int, name string) string {
 	return rec[i]
 }
 
-// batchEnrichProcessStats fetches CPU, memory, state, uptime for all non-Docker
-// ports in a single ps call (or PowerShell on Windows).
+// batchEnrichProcessStats fetches CPU, memory, state and uptime for every
+// non-Docker port. It goes through the same one-call sampler the daemon's
+// stats-only tick uses, so a row enriched by a scan and a row refreshed
+// between scans are filled from identical parsing.
+//
+// The sample is keyed by pid and applied to every row that pid owns. Keying
+// the other way round — one *ListeningPort per pid — silently dropped the
+// stats of every socket but the last when one process listened on several.
 func batchEnrichProcessStats(pp []ListeningPort) {
-	var nativePorts []*ListeningPort
+	pids := make([]int, 0, len(pp))
 	for i := range pp {
 		if pp[i].Type != PortTypeDocker && pp[i].PID > 0 {
-			nativePorts = append(nativePorts, &pp[i])
+			pids = append(pids, pp[i].PID)
 		}
 	}
-	if len(nativePorts) == 0 {
+	if len(pids) == 0 {
 		return
 	}
 
-	pidStrs := make([]string, len(nativePorts))
-	for i, p := range nativePorts {
-		pidStrs[i] = strconv.Itoa(p.PID)
-	}
+	samples := SampleProcStats(pids)
 
-	// Build PID -> port lookup
-	pidMap := make(map[int]*ListeningPort)
-	for _, p := range nativePorts {
-		pidMap[p.PID] = p
-	}
-
-	if runtime.GOOS == "windows" {
-		batchEnrichProcessStatsWindows(pidStrs, pidMap)
-		return
-	}
-
-	var out []byte
-	var err error
+	// macOS has no batched thread count: `ps -M` is one fork per pid. It runs
+	// here, on the scan tick, and never on the 1 s stats tick.
 	if runtime.GOOS == "darwin" {
-		out, err = exec.Command("ps", "-o", "pid=,%cpu=,rss=,state=,lstart=", "-p", strings.Join(pidStrs, ",")).Output()
-	} else {
-		out, err = exec.Command("ps", "-o", "pid=,%cpu=,rss=,nlwp=,state=,lstart=", "-p", strings.Join(pidStrs, ",")).Output()
-	}
-	if err != nil {
-		return
-	}
-
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(strings.TrimSpace(line))
-		if len(fields) < 2 {
-			continue
-		}
-		pid, err := strconv.Atoi(fields[0])
-		if err != nil {
-			continue
-		}
-		p, ok := pidMap[pid]
-		if !ok {
-			continue
-		}
-		// Parse remaining fields (skip pid)
-		rest := fields[1:]
-		if runtime.GOOS == "darwin" {
-			parseDarwinStats(p, rest)
-			p.ThreadCount = countThreadsDarwin(p.PID)
-		} else {
-			parseLinuxStats(p, rest)
+		for pid, s := range samples {
+			s.ThreadCount = countThreadsDarwin(pid)
+			samples[pid] = s
 		}
 	}
-}
 
-// batchEnrichProcessStatsWindows uses PowerShell Get-Process to fetch stats.
-func batchEnrichProcessStatsWindows(pidStrs []string, pidMap map[int]*ListeningPort) {
-	psCmd := fmt.Sprintf(
-		"Get-Process -Id %s -ErrorAction SilentlyContinue | Select-Object Id,CPU,WorkingSet64,@{N='ThreadCount';E={$_.Threads.Count}},@{N='StartTime';E={$_.StartTime.ToString('o')}} | ConvertTo-Csv -NoTypeInformation",
-		strings.Join(pidStrs, ","),
-	)
-
-	out, err := exec.Command("powershell", "-NoProfile", "-Command", psCmd).Output()
-	if err != nil {
-		return
-	}
-
-	r := csv.NewReader(strings.NewReader(strings.TrimSpace(string(out))))
-	records, err := r.ReadAll()
-	if err != nil {
-		return
-	}
-
-	// CSV columns: "Id","CPU","WorkingSet64","ThreadCount","StartTime"
-	for i, record := range records {
-		if i == 0 {
-			continue // skip header
-		}
-		if len(record) < 5 {
+	for i := range pp {
+		if pp[i].Type == PortTypeDocker || pp[i].PID <= 0 {
 			continue
 		}
-		pid, err := strconv.Atoi(strings.TrimSpace(record[0]))
-		if err != nil {
-			continue
+		if s, ok := samples[pp[i].PID]; ok {
+			s.Apply(&pp[i])
 		}
-		p, ok := pidMap[pid]
-		if !ok {
-			continue
-		}
-		parseWindowsStats(p, record[1:])
 	}
 }
 

--- a/internal/ports/enrich.go
+++ b/internal/ports/enrich.go
@@ -77,20 +77,9 @@ func EnrichStats(pp []ListeningPort, dockerStats map[string]*DockerStatsEntry) {
 	// Batch native process stats into a single ps call
 	batchEnrichProcessStats(pp)
 
-	// Connection counts — on Windows, fetch netstat once and reuse the output
-	if runtime.GOOS == "windows" {
-		out, err := exec.Command("netstat", "-ano").Output()
-		if err == nil {
-			output := string(out)
-			for i := range pp {
-				pp[i].Connections = countConnectionsNetstat(output, strconv.Itoa(pp[i].Port))
-			}
-		}
-	} else {
-		for i := range pp {
-			pp[i].Connections = countConnections(pp[i].Port)
-		}
-	}
+	// Connection counts, from one listing of the machine's TCP connections
+	// rather than one call per port.
+	applyConnectionCounts(pp)
 }
 
 // DockerStatsEntry holds pre-fetched per-container stats.
@@ -399,11 +388,13 @@ func batchEnrichProcessStats(pp []ListeningPort) {
 
 	samples := SampleProcStats(pids)
 
-	// macOS has no batched thread count: `ps -M` is one fork per pid. It runs
-	// here, on the scan tick, and never on the 1 s stats tick.
+	// macOS reports no thread count in the sampler's `ps`, so it takes a
+	// second (batched) call. It runs here, on the scan tick, and never on the
+	// 1 s stats tick.
 	if runtime.GOOS == "darwin" {
+		threads := countThreadsDarwin(pids)
 		for pid, s := range samples {
-			s.ThreadCount = countThreadsDarwin(pid)
+			s.ThreadCount = threads[pid]
 			samples[pid] = s
 		}
 	}

--- a/internal/ports/sample.go
+++ b/internal/ports/sample.go
@@ -1,0 +1,157 @@
+package ports
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// ProcSample is one process's live resource usage, keyed by pid rather than by
+// socket. It is what the daemon's stats-only tick reads for the pids a
+// snapshot already names: no port scan behind it, no attribution, no health.
+//
+// ThreadCount is 0 when the platform could not report it in the same call.
+// macOS is the case that matters: counting threads there is one `ps -M` fork
+// per pid, so it stays on the scan tick and a sample carries 0, which callers
+// read as "unchanged" rather than as "no threads".
+type ProcSample struct {
+	CPUPercent  float64
+	MemoryRSS   int64
+	ThreadCount int
+	StartTime   string // raw, as ps printed it
+	Uptime      string
+	State       string
+	StartedAt   string // RFC3339, "" when the start time did not parse
+}
+
+// SampleProcStats reads cpu, memory, state and uptime for the given pids in a
+// single `ps` call (one PowerShell call on Windows). A pid the OS no longer
+// knows about is simply absent from the result: a process that exited between
+// the scan that listed it and this sample must not report zeroes that read
+// like facts.
+func SampleProcStats(pids []int) map[int]ProcSample {
+	out := make(map[int]ProcSample, len(pids))
+	if len(pids) == 0 {
+		return out
+	}
+	pidStrs := make([]string, 0, len(pids))
+	seen := make(map[int]bool, len(pids))
+	for _, pid := range pids {
+		if pid <= 0 || seen[pid] {
+			continue
+		}
+		seen[pid] = true
+		pidStrs = append(pidStrs, strconv.Itoa(pid))
+	}
+	if len(pidStrs) == 0 {
+		return out
+	}
+	if runtime.GOOS == "windows" {
+		return sampleProcStatsWindows(pidStrs)
+	}
+	return sampleProcStatsPS(pidStrs)
+}
+
+// sampleProcStatsPS is the macOS/Linux sample: one `ps` for every pid at once.
+func sampleProcStatsPS(pidStrs []string) map[int]ProcSample {
+	out := map[int]ProcSample{}
+
+	format := "pid=,%cpu=,rss=,nlwp=,state=,lstart="
+	if runtime.GOOS == "darwin" {
+		// No nlwp on BSD ps; threads cost a fork per pid and stay on the scan.
+		format = "pid=,%cpu=,rss=,state=,lstart="
+	}
+	raw, err := exec.Command("ps", "-o", format, "-p", strings.Join(pidStrs, ",")).Output()
+	if err != nil {
+		return out
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		var scratch ListeningPort
+		scratch.PID = pid
+		if runtime.GOOS == "darwin" {
+			parseDarwinStats(&scratch, fields[1:])
+		} else {
+			parseLinuxStats(&scratch, fields[1:])
+		}
+		out[pid] = sampleOf(scratch)
+	}
+	return out
+}
+
+// sampleProcStatsWindows is the same sample from one Get-Process call.
+func sampleProcStatsWindows(pidStrs []string) map[int]ProcSample {
+	out := map[int]ProcSample{}
+
+	psCmd := fmt.Sprintf(
+		"Get-Process -Id %s -ErrorAction SilentlyContinue | Select-Object Id,CPU,WorkingSet64,@{N='ThreadCount';E={$_.Threads.Count}},@{N='StartTime';E={$_.StartTime.ToString('o')}} | ConvertTo-Csv -NoTypeInformation",
+		strings.Join(pidStrs, ","),
+	)
+	raw, err := exec.Command("powershell", "-NoProfile", "-Command", psCmd).Output()
+	if err != nil {
+		return out
+	}
+
+	r := csv.NewReader(strings.NewReader(strings.TrimSpace(string(raw))))
+	r.FieldsPerRecord = -1
+	records, err := r.ReadAll()
+	if err != nil {
+		return out
+	}
+	for i, record := range records {
+		if i == 0 || len(record) < 5 {
+			continue // header, or a row Get-Process could not fill in
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(record[0]))
+		if err != nil {
+			continue
+		}
+		var scratch ListeningPort
+		scratch.PID = pid
+		parseWindowsStats(&scratch, record[1:])
+		out[pid] = sampleOf(scratch)
+	}
+	return out
+}
+
+// sampleOf lifts the fields the per-OS parsers wrote onto a scratch row.
+func sampleOf(p ListeningPort) ProcSample {
+	return ProcSample{
+		CPUPercent:  p.CPUPercent,
+		MemoryRSS:   p.MemoryRSS,
+		ThreadCount: p.ThreadCount,
+		StartTime:   p.StartTime,
+		Uptime:      p.Uptime,
+		State:       p.State,
+		StartedAt:   p.StartedAt,
+	}
+}
+
+// Apply writes a sample onto a listening row. A zero thread count means the
+// platform did not report one in this call and the row keeps what it had;
+// `started_at` is never overwritten, because the runs registry's answer is
+// better than a parsed `ps` time.
+func (s ProcSample) Apply(p *ListeningPort) {
+	p.CPUPercent = s.CPUPercent
+	p.MemoryRSS = s.MemoryRSS
+	p.State = s.State
+	p.Uptime = s.Uptime
+	p.StartTime = s.StartTime
+	if s.ThreadCount > 0 {
+		p.ThreadCount = s.ThreadCount
+	}
+	if p.StartedAt == "" {
+		p.StartedAt = s.StartedAt
+	}
+}

--- a/internal/ports/stats.go
+++ b/internal/ports/stats.go
@@ -31,9 +31,9 @@ func parseDarwinStats(p *ListeningPort, fields []string) {
 	if p.StartedAt == "" {
 		p.StartedAt = parseStartTime(lstart)
 	}
-
-	// macOS: get thread count via proc_info or ps -M
-	p.ThreadCount = countThreadsDarwin(p.PID)
+	// Thread count is not in this call: macOS needs one `ps -M` per pid, so
+	// the caller decides whether that fork is worth paying for (the scan tick
+	// pays it, the 1 s stats tick does not).
 }
 
 // parseLinuxStats parses: %cpu rss nlwp state lstart...

--- a/internal/ports/stats.go
+++ b/internal/ports/stats.go
@@ -3,7 +3,6 @@ package ports
 import (
 	"fmt"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -90,74 +89,68 @@ func parseWindowsStats(p *ListeningPort, fields []string) {
 	}
 }
 
-// countThreadsDarwin gets thread count on macOS via ps -M.
-func countThreadsDarwin(pid int) int {
-	out, err := exec.Command("ps", "-M", "-p", strconv.Itoa(pid)).Output()
-	if err != nil {
-		return 0
+// countThreadsDarwin counts each pid's threads from a single `ps -M`.
+//
+// macOS has no batched thread-count column (`nlwp` is a Linux ps extension),
+// so this used to be one fork per pid — eighteen of them on the machine this
+// was measured on, inside the lock that serializes a scan against the stats
+// tick. `ps -M` accepts a pid list and prints one line per process followed by
+// one per thread, which is all the counting needs.
+func countThreadsDarwin(pids []int) map[int]int {
+	counts := map[int]int{}
+	if len(pids) == 0 {
+		return counts
 	}
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	// First line is the header, remaining lines are threads
-	if len(lines) <= 1 {
-		return 1
-	}
-	return len(lines) - 1
-}
-
-// countConnections counts established TCP connections to a specific port.
-func countConnections(port int) int {
-	portStr := strconv.Itoa(port)
-
-	var out []byte
-	var err error
-
-	switch runtime.GOOS {
-	case "darwin":
-		out, err = exec.Command("lsof", "-iTCP:"+portStr, "-sTCP:ESTABLISHED", "-n", "-P").Output()
-	case "windows":
-		out, err = exec.Command("netstat", "-ano").Output()
-		if err != nil {
-			return 0
+	want := make(map[int]bool, len(pids))
+	pidStrs := make([]string, 0, len(pids))
+	for _, pid := range pids {
+		if pid <= 0 || want[pid] {
+			continue
 		}
-		return countConnectionsNetstat(string(out), portStr)
-	default:
-		out, err = exec.Command("ss", "-tn", "state", "established", fmt.Sprintf("sport = :%s", portStr)).Output()
+		want[pid] = true
+		pidStrs = append(pidStrs, strconv.Itoa(pid))
 	}
+	out, err := exec.Command("ps", "-M", "-p", strings.Join(pidStrs, ",")).Output()
 	if err != nil {
-		return 0
+		return counts
 	}
-
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if len(lines) <= 1 {
-		return 0
-	}
-	// Subtract header line; divide by 2 for lsof (each connection shows local + remote)
-	count := len(lines) - 1
-	if runtime.GOOS == "darwin" {
-		count = count / 2
-	}
-	return count
+	return countPSThreads(string(out), want)
 }
 
-// countConnectionsNetstat counts ESTABLISHED connections to a port from netstat -ano output.
-func countConnectionsNetstat(output, portStr string) int {
-	count := 0
-	suffix := ":" + portStr
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
+// countPSThreads counts the `ps -M` lines belonging to each requested pid.
+//
+// A process line is "USER PID TT %CPU ..." and a thread line is "PID %CPU ..."
+// with the user and tty columns blank, so the pid is in the first or the
+// second field depending on which it is. Both count, which is what the
+// single-pid version reported (every line but the header).
+func countPSThreads(out string, want map[int]bool) map[int]int {
+	counts := map[int]int{}
+	current := 0
+	for i, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 4 {
+		if len(fields) == 0 {
 			continue
 		}
-		if strings.ToUpper(fields[3]) != "ESTABLISHED" {
+		if i == 0 && strings.EqualFold(fields[0], "USER") {
+			continue // header
+		}
+		switch {
+		case len(fields) > 1 && inSet(want, fields[1]):
+			current, _ = strconv.Atoi(fields[1])
+		case inSet(want, fields[0]):
+			current, _ = strconv.Atoi(fields[0])
+		case current == 0:
 			continue
 		}
-		// Check if local address matches the port
-		if strings.HasSuffix(fields[1], suffix) {
-			count++
-		}
+		counts[current]++
 	}
-	return count
+	return counts
+}
+
+// inSet reports whether a field is one of the pids that were asked for.
+func inSet(want map[int]bool, field string) bool {
+	v, err := strconv.Atoi(field)
+	return err == nil && want[v]
 }
 
 // decodeState converts the single-char process state to a human-readable string.

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -607,9 +607,14 @@ func (l *Loop) commitScan(
 // local machine a diff and a marshal rather than a full port scan.
 //
 // It takes scanMu like a scan does, so its publish cannot interleave with one
-// and delta seq order stays publish order (contract §38). Before the first
-// local scan there is nothing to merge into, so it wakes the loop instead and
-// the remote rows ride out with the first tick.
+// and delta seq order stays publish order (contract §38).
+//
+// Before the first local scan it publishes against the identity-only snapshot
+// CachedAll synthesises rather than declining to publish. Waking the loop and
+// leaving the rows for the first tick looked equivalent and was not: a bridge
+// that connects in that window reaches no subscriber until a scan lands, and
+// nothing tells the subscriber a host appeared. It still wakes the loop, so
+// the local half follows.
 func (l *Loop) RemoteChanged() {
 	l.scanMu.Lock()
 	defer l.scanMu.Unlock()
@@ -618,9 +623,15 @@ func (l *Loop) RemoteChanged() {
 
 	l.mu.Lock()
 	if !l.haveSnap {
-		l.mu.Unlock()
-		l.Wake()
-		return
+		// The same base CachedAll serves before the first scan, so what a
+		// subscriber is told and what a new subscriber reads agree.
+		l.local = state.Rows{Hosts: []state.Host{l.identityRow()}}.Normalize()
+		l.snap = l.local.Into(state.Snapshot{
+			At:            l.now().Format(time.RFC3339),
+			DaemonVersion: l.opts.DaemonVersion,
+		})
+		l.haveSnap = true
+		defer l.Wake()
 	}
 	prev := l.snap
 	next := l.local.Append(l.remoteRows()).Into(state.Snapshot{

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -166,6 +166,25 @@ type Loop struct {
 	// order.
 	scanMu sync.Mutex
 
+	// commitMu is the narrower half of that promise: it is held across the
+	// commit into the cache *and* the publish that follows, by everything
+	// that publishes — a scan, a remote host's rows changing, and the
+	// stats-only tick. That is what makes delta seq order equal publish
+	// order (contract §38), and it is all the stats tick needs.
+	//
+	// The tick deliberately does not take scanMu. A scan holds that from its
+	// first OS call to its last, and with a container running `docker stats`
+	// alone is two seconds of it — measured, on the machine this was built
+	// for. A 1 s sampler queued behind that is not a 1 s sampler; it emitted
+	// a burst of deltas every five or six seconds. Since the tick reads no
+	// store and runs no scan, the write-ordering rule scanMu exists for
+	// (1A.15) does not apply to it, and it holds commitMu across its own
+	// read-sample-commit so it can still never publish a snapshot a scan has
+	// already replaced.
+	//
+	// Lock order is scanMu then commitMu, never the reverse.
+	commitMu sync.Mutex
+
 	mu   sync.Mutex
 	subs int
 	snap state.Snapshot
@@ -427,25 +446,23 @@ func (l *Loop) Run(ctx context.Context) {
 }
 
 // scanAndPublish runs one scan, updates the cache, adapts the interval and
-// publishes when something changed. One scan at a time (see scanMu).
+// publishes when something changed. One scan at a time (see scanMu); the
+// publish itself happens inside scanLocked, under commitMu.
 func (l *Loop) scanAndPublish(include Include) {
 	l.scanMu.Lock()
 	defer l.scanMu.Unlock()
 
-	next, prev, changed, err := l.scanLocked(include)
+	_, prev, _, err := l.scanLocked(include)
 	if err != nil {
 		l.opts.Logger.Warn("scan failed, keeping last good state", "error", err)
+		// A scan_error carries no snapshot and takes no seq, so it needs no
+		// place in the commit order.
 		l.opts.Publish(prev, prev, []state.Event{{
 			Kind: "scan_error",
 			At:   l.nowRFC3339(),
 			Data: map[string]any{"error": err.Error()},
 		}})
-		return
 	}
-	if !changed {
-		return
-	}
-	l.publish(prev, next, deriveEvents(prev, next, l.nowRFC3339()))
 }
 
 // publish hands the transition to the daemon and then writes its port
@@ -496,6 +513,27 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	// is, not an opt-in statistic (step 1A.7).
 	probeConfigured(rows, groupRows, l.opts.Probe)
 
+	// Everything from here on is the commit: the point at which this scan
+	// becomes the published state. It is serialized against every other
+	// publisher, and the publish rides inside it so a later seq can never
+	// reach a client first (contract §38).
+	l.commitMu.Lock()
+	defer l.commitMu.Unlock()
+
+	next, prev, changed = l.commitScan(subs, include, wantHealth, rows, groupRows, sessionRows, host)
+	if changed {
+		l.publish(prev, next, deriveEvents(prev, next, l.nowRFC3339()))
+	}
+	return next, prev, changed, nil
+}
+
+// commitScan swaps a finished scan into the cache and adapts the interval.
+// Caller holds scanMu and commitMu; this takes l.mu for the swap itself.
+func (l *Loop) commitScan(
+	subs int, include Include, wantHealth bool,
+	rows []state.Port, groupRows []state.Group, sessionRows []state.SessionRecord,
+	host state.Host,
+) (next, prev state.Snapshot, changed bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -539,7 +577,7 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 			next.Seq = prev.Seq
 			l.snap = next
 			l.interval = backoff(l.interval, l.maxIntervalLocked())
-			return next, prev, false, nil
+			return next, prev, false
 		}
 		// Only the machine's own load moved. It is published — host load is
 		// state, not an opt-in statistic, so it reaches every subscriber
@@ -552,7 +590,7 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 		next.Seq = l.seq
 		l.snap = next
 		l.interval = backoff(l.interval, l.maxIntervalLocked())
-		return next, prev, true, nil
+		return next, prev, true
 	}
 
 	l.seq++
@@ -560,7 +598,7 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	l.snap = next
 	l.haveSnap = true
 	l.interval = BaseInterval
-	return next, prev, true, nil
+	return next, prev, true
 }
 
 // RemoteChanged republishes the current state with the remote hosts' rows as
@@ -575,6 +613,8 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 func (l *Loop) RemoteChanged() {
 	l.scanMu.Lock()
 	defer l.scanMu.Unlock()
+	l.commitMu.Lock()
+	defer l.commitMu.Unlock()
 
 	l.mu.Lock()
 	if !l.haveSnap {
@@ -798,16 +838,13 @@ func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
 	l.scanMu.Lock()
 	defer l.scanMu.Unlock()
 
-	next, prev, changed, err := l.scanLocked(l.withDemand(include))
+	next, prev, _, err := l.scanLocked(l.withDemand(include))
 	if err != nil {
 		if prev.Seq > 0 {
 			// A failed rescan still serves the last good state.
 			return prev, nil
 		}
 		return state.Snapshot{}, err
-	}
-	if changed {
-		l.publish(prev, next, deriveEvents(prev, next, l.nowRFC3339()))
 	}
 	return next, nil
 }

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -39,6 +39,16 @@ const (
 	HealthTimeout = 2 * time.Second
 	// HostStatsTimeout bounds one collection of the machine's own load.
 	HostStatsTimeout = 3 * time.Second
+	// StatsInterval is the fixed cadence of the stats-only tick: per-process
+	// cpu and memory plus this machine's load row, sampled without a port
+	// scan behind it. Unlike the scan interval it never backs off, and it
+	// only runs while someone is subscribed.
+	StatsInterval = 1 * time.Second
+	// MinStatsInterval is the floor `daemon.stats_interval` may be set to.
+	// Below it the sampler costs more than the numbers it publishes are
+	// worth: every tick is a `ps` per machine on Unix and a PowerShell on
+	// Windows.
+	MinStatsInterval = 250 * time.Millisecond
 )
 
 // Include is the per-subscriber opt-in from `state.subscribe {include}`.
@@ -117,6 +127,16 @@ type Options struct {
 	// never opens a real socket.
 	Probe Probe
 
+	// SampleStats reads cpu, memory, state and uptime for pids the last
+	// snapshot already named — the stats-only tick's one OS call. Tests
+	// inject a fake; production leaves it nil and gets ports.SampleProcStats.
+	SampleStats func(pids []int) map[int]ports.ProcSample
+
+	// StatsInterval overrides the stats-only tick's cadence
+	// (`daemon.stats_interval`). Zero means StatsInterval; anything below
+	// MinStatsInterval is clamped to it.
+	StatsInterval time.Duration
+
 	// Now overrides the clock, for tests.
 	Now func() time.Time
 }
@@ -127,6 +147,9 @@ type Loop struct {
 	now  func() time.Time
 
 	wake chan struct{}
+	// statsWake unparks the stats-only tick when a subscriber connects. It is
+	// separate from wake so the two ticks can park and resume independently.
+	statsWake chan struct{}
 
 	attr attribution
 
@@ -182,15 +205,19 @@ func New(opts Options) *Loop {
 	if opts.HostStats == nil {
 		opts.HostStats = hoststats.New().Collect
 	}
+	if opts.SampleStats == nil {
+		opts.SampleStats = ports.SampleProcStats
+	}
 	now := opts.Now
 	if now == nil {
 		now = time.Now
 	}
 	return &Loop{
-		opts:     opts,
-		now:      now,
-		wake:     make(chan struct{}, 1),
-		interval: BaseInterval,
+		opts:      opts,
+		now:       now,
+		wake:      make(chan struct{}, 1),
+		statsWake: make(chan struct{}, 1),
+		interval:  BaseInterval,
 	}
 }
 
@@ -335,11 +362,29 @@ func (l *Loop) Wake() {
 	case l.wake <- struct{}{}:
 	default:
 	}
+	select {
+	case l.statsWake <- struct{}{}:
+	default:
+	}
 }
 
 // Run drives the loop until ctx is cancelled. With zero subscribers it parks on
 // Wake and does no work at all; the next RPC or subscription starts it again.
+//
+// It also runs the stats-only tick (see runStats) in a second goroutine, and
+// returns only once both have stopped. The two are serialized against each
+// other by scanMu, never by being the same goroutine: the whole point is that
+// a 1 s load sample does not have to wait for — or reset — an adaptive port
+// scan that may be 5 s apart.
 func (l *Loop) Run(ctx context.Context) {
+	var stats sync.WaitGroup
+	stats.Add(1)
+	go func() {
+		defer stats.Done()
+		l.runStats(ctx)
+	}()
+	defer stats.Wait()
+
 	timer := time.NewTimer(time.Hour)
 	defer timer.Stop()
 

--- a/internal/scanner/stats.go
+++ b/internal/scanner/stats.go
@@ -73,19 +73,18 @@ func (l *Loop) statsInterval() time.Duration {
 
 // sampleStats runs one stats-only tick and publishes what moved.
 //
-// It holds scanMu for exactly the reason a scan does (contract §38): a sample
-// must never interleave with a scan's commit, or the two would race to replace
-// the cached snapshot and `seq` order would stop matching publish order. It
-// never touches the scan interval, the scan counters or `lastScanAt`: the port
-// scan's adaptive cadence, the RPC cache TTL and `daemon status` all read
+// It never touches the scan interval, the scan counters or `lastScanAt`: the
+// port scan's adaptive cadence, the RPC cache TTL and `daemon status` all read
 // exactly what they read before this tick existed.
 func (l *Loop) sampleStats(include Include) {
-	// The publish happens under scanMu too, exactly as a scan's does. A tick
-	// that took its seq inside the lock and then published outside it can be
-	// overtaken by the next scan, and a subscriber sees seq 35 before seq 34
-	// — the one thing §38 promises will not happen.
-	l.scanMu.Lock()
-	defer l.scanMu.Unlock()
+	// commitMu, not scanMu: see the comment on the fields. It is held across
+	// the whole read-sample-commit-publish, not just the commit — a tick that
+	// read the snapshot, sampled, and only then took the lock could republish
+	// a port set a scan had already replaced in between, which is exactly the
+	// revert 1A.15 fixed for scans. Sampling is ~40 ms, so a scan waiting
+	// behind it waits ~40 ms.
+	l.commitMu.Lock()
+	defer l.commitMu.Unlock()
 
 	prev, next, changed := l.sampleStatsLocked(include)
 	if !changed {
@@ -97,7 +96,7 @@ func (l *Loop) sampleStats(include Include) {
 }
 
 // sampleStatsLocked builds the refreshed snapshot and commits it. Caller holds
-// scanMu.
+// commitMu.
 //
 // It rebuilds from l.local — this machine's own rows, before the remote hosts
 // were merged in — for the same reason RemoteChanged does: only localhost's

--- a/internal/scanner/stats.go
+++ b/internal/scanner/stats.go
@@ -98,10 +98,15 @@ func (l *Loop) sampleStats(include Include) {
 // sampleStatsLocked builds the refreshed snapshot and commits it. Caller holds
 // commitMu.
 //
-// It rebuilds from l.local — this machine's own rows, before the remote hosts
-// were merged in — for the same reason RemoteChanged does: only localhost's
-// processes are sampled here, and re-merging the remote contribution keeps a
-// remote host's rows and its `hosts` entry intact across a local stats tick.
+// It patches the published snapshot in place — this machine's `stats` objects
+// and the localhost `hosts` row — rather than rebuilding it by re-merging
+// l.remoteRows(). Re-merging would let a tick pick up a remote bridge's newest
+// rows as a side effect and commit them; RemoteChanged would then diff against
+// a snapshot that already carries them, find nothing to do, and the remote
+// change would reach no subscriber at all while a later state.snapshot showed
+// rows no delta ever announced. Keeping the tick strictly localhost means it
+// can only ever move what it actually sampled, and RemoteChanged stays the one
+// thing that publishes a remote host's state.
 func (l *Loop) sampleStatsLocked(include Include) (prev, next state.Snapshot, changed bool) {
 	l.mu.Lock()
 	prev, local, have := l.snap, l.local, l.haveSnap
@@ -120,39 +125,74 @@ func (l *Loop) sampleStatsLocked(include Include) (prev, next state.Snapshot, ch
 	host := l.collectHost()
 
 	at := l.now()
-	local.Ports = refreshStats(local.Ports, samples)
 	host.Ports, host.Groups = len(local.Ports), len(local.Groups)
 	host.LastSeen = at.Format(time.RFC3339)
+
+	next = prev
+	next.At = host.LastSeen
+	next.Ports = refreshStats(prev.Ports, samples)
+	next.Hosts = replaceLocalhost(prev.Hosts, host)
+
+	// next differs from prev in the stats objects and the localhost row and
+	// in nothing else, by construction, so this narrow comparison is exact.
+	changed = statsChanged(prev.Ports, next.Ports) || hostChanged(prev, next)
+	if !changed {
+		// Commit nothing. A snapshot that differs from the published one and
+		// is never published is how a change goes missing; when the readings
+		// are identical there is nothing to carry forward anyway.
+		return prev, next, false
+	}
+
+	// This machine's own half, kept in step so RemoteChanged — which rebuilds
+	// from it — cannot republish the stats this tick has just replaced.
+	local.Ports = refreshStats(local.Ports, samples)
 	local.Hosts = []state.Host{host}
-	local = local.Tag(state.LocalhostName).Normalize()
-
-	next = local.Append(l.remoteRows()).Into(state.Snapshot{
-		At:              at.Format(time.RFC3339),
-		DaemonVersion:   l.opts.DaemonVersion,
-		ExposuresActive: prev.ExposuresActive,
-	})
-
-	// The full comparison, not just the stats one: a remote bridge may have
-	// replaced its rows since the last publish without RemoteChanged having
-	// run yet, and committing those silently would lose them — the next
-	// RemoteChanged would diff against a snapshot that already carries them.
-	changed = snapshotChanged(prev, next, true) || hostChanged(prev, next)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.local = local
-	if !changed {
-		// Commit anyway, so the next tick diffs against the newest reading,
-		// but keep the seq: a snapshot nobody was told about must not consume
-		// a sequence number (contract §15's resync rule).
-		next.Seq = prev.Seq
-		l.snap = next
-		return prev, next, false
-	}
 	l.seq++
 	next.Seq = l.seq
 	l.snap = next
 	return prev, next, true
+}
+
+// replaceLocalhost swaps the localhost row of a `hosts` collection, leaving
+// every registered remote host's row exactly as it was.
+func replaceLocalhost(prev []state.Host, host state.Host) []state.Host {
+	out := make([]state.Host, 0, len(prev)+1)
+	replaced := false
+	for _, h := range prev {
+		if state.IsLocalhost(h.Name) {
+			out, replaced = append(out, host), true
+			continue
+		}
+		out = append(out, h)
+	}
+	if !replaced {
+		out = append(out, host)
+	}
+	return out
+}
+
+// statsChanged reports whether any row's stats object moved. The two slices
+// are index-aligned — next is prev with stats replaced — so this compares
+// position by position rather than going through a keyed diff.
+func statsChanged(prev, next []state.Port) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range next {
+		a, b := prev[i].Stats, next[i].Stats
+		switch {
+		case a == nil && b == nil:
+		case a == nil || b == nil:
+			return true
+		case *a != *b:
+			return true
+		}
+	}
+	return false
 }
 
 // statsPIDs are the processes a stats tick samples: the ones this machine's
@@ -175,24 +215,25 @@ func statsPIDs(pp []state.Port) []int {
 	return pids
 }
 
-// refreshStats returns the previous rows with only their `stats` object
-// replaced. Every other field — display name, group, health, started_at, the
-// host tag — is carried through untouched, which is what makes a stats delta
-// invisible to a subscriber that did not ask for stats.
+// refreshStats returns the given rows with only their `stats` object replaced.
+// Every other field — display name, group, health, started_at, the host tag —
+// is carried through untouched, which is what makes a stats delta invisible to
+// a subscriber that did not ask for stats, and a remote host's row is never
+// touched at all: pid 4242 on a build server is not pid 4242 here.
 //
 // A row the sample has nothing to say about keeps the stats it had: a pid that
 // vanished between the scan and this tick is dropped from the sample, not
 // zeroed on the wire, and the next port scan is what removes the row.
 // `connections` is carried forward too — counting them is an `lsof` (or `ss`,
 // or `netstat`) per port and stays on the scan tick.
-func refreshStats(prev []state.Port, samples map[int]ports.ProcSample) []state.Port {
+func refreshStats(rows []state.Port, samples map[int]ports.ProcSample) []state.Port {
 	if len(samples) == 0 {
-		return prev
+		return rows
 	}
-	out := make([]state.Port, len(prev))
-	copy(out, prev)
+	out := make([]state.Port, len(rows))
+	copy(out, rows)
 	for i := range out {
-		if out[i].Stats == nil || out[i].Type == state.TypeDocker {
+		if out[i].Stats == nil || out[i].Type == state.TypeDocker || !state.IsLocalhost(out[i].Host) {
 			continue
 		}
 		s, ok := samples[out[i].PID]

--- a/internal/scanner/stats.go
+++ b/internal/scanner/stats.go
@@ -1,0 +1,215 @@
+package scanner
+
+import (
+	"context"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// runStats is the stats-only tick: a fixed sampler, decoupled from the port
+// scan, that refreshes what moves every second — each listening process's cpu
+// and memory, and this machine's own load row — and publishes the difference
+// through the ordinary per-subscriber `include` filter.
+//
+// It exists because those two things are the only parts of a snapshot that
+// change continuously, and the port scan they used to ride on is deliberately
+// adaptive: it backs off to 5 s while a subscriber watches an unchanging
+// machine (contract §37), which is right for ports and useless for a load
+// meter. Sampling them apart lets the meter run at 1 s without pinning the
+// daemon to a full `lsof`/`netstat` scan at the same rate.
+//
+// It parks whenever nothing is subscribed, so an unsubscribed daemon —
+// answering `sonar list` and `daemon status` over RPC — samples nothing at
+// all.
+func (l *Loop) runStats(ctx context.Context) {
+	interval := l.statsInterval()
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	for {
+		subs, include := l.opts.Demand()
+		if subs == 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-l.statsWake:
+				continue
+			}
+		}
+
+		l.sampleStats(include)
+
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(interval)
+		// Deliberately not woken by l.statsWake here: a read or a new
+		// subscriber must not make the sampler fire faster than its own
+		// cadence. Only a parked sampler listens for the nudge.
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// statsInterval is the cadence, clamped to something a machine can sustain.
+func (l *Loop) statsInterval() time.Duration {
+	d := l.opts.StatsInterval
+	if d <= 0 {
+		return StatsInterval
+	}
+	if d < MinStatsInterval {
+		return MinStatsInterval
+	}
+	return d
+}
+
+// sampleStats runs one stats-only tick and publishes what moved.
+//
+// It holds scanMu for exactly the reason a scan does (contract §38): a sample
+// must never interleave with a scan's commit, or the two would race to replace
+// the cached snapshot and `seq` order would stop matching publish order. It
+// never touches the scan interval, the scan counters or `lastScanAt`: the port
+// scan's adaptive cadence, the RPC cache TTL and `daemon status` all read
+// exactly what they read before this tick existed.
+func (l *Loop) sampleStats(include Include) {
+	// The publish happens under scanMu too, exactly as a scan's does. A tick
+	// that took its seq inside the lock and then published outside it can be
+	// overtaken by the next scan, and a subscriber sees seq 35 before seq 34
+	// — the one thing §38 promises will not happen.
+	l.scanMu.Lock()
+	defer l.scanMu.Unlock()
+
+	prev, next, changed := l.sampleStatsLocked(include)
+	if !changed {
+		return
+	}
+	// No events: a stats tick cannot bring a port up or down, and nothing it
+	// moves belongs in the history ring.
+	l.opts.Publish(prev, next, nil)
+}
+
+// sampleStatsLocked builds the refreshed snapshot and commits it. Caller holds
+// scanMu.
+func (l *Loop) sampleStatsLocked(include Include) (prev, next state.Snapshot, changed bool) {
+	l.mu.Lock()
+	prev, have := l.snap, l.haveSnap
+	l.mu.Unlock()
+	if !have {
+		// Nothing has been scanned yet, so there is no port set to refresh
+		// and no identity row to attach a load to. The first scan owns that.
+		return prev, prev, false
+	}
+
+	// Both of these may fork `ps`; neither may hold l.mu while it does.
+	var samples map[int]ports.ProcSample
+	if include.Stats {
+		samples = l.opts.SampleStats(statsPIDs(prev.Ports))
+	}
+	host := l.collectHost()
+
+	at := l.now()
+	next = prev
+	next.At = at.Format(time.RFC3339)
+	next.Ports = refreshStats(prev.Ports, samples)
+	host.Ports, host.Groups = len(next.Ports), len(next.Groups)
+	host.LastSeen = next.At
+	next.Hosts = []state.Host{host}
+
+	changed = statsChanged(prev.Ports, next.Ports) || hostChanged(prev, next)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !changed {
+		// Commit anyway, so the next tick diffs against the newest reading,
+		// but keep the seq: a snapshot nobody was told about must not consume
+		// a sequence number (contract §15's resync rule).
+		next.Seq = prev.Seq
+		l.snap = next
+		return prev, next, false
+	}
+	l.seq++
+	next.Seq = l.seq
+	l.snap = next
+	return prev, next, true
+}
+
+// statsPIDs are the processes a stats tick samples: the ones the last snapshot
+// already named, minus containers, whose stats come from Docker rather than
+// from the process table. A pid that has since exited is simply missing from
+// the sample.
+func statsPIDs(pp []state.Port) []int {
+	pids := make([]int, 0, len(pp))
+	for i := range pp {
+		if pp[i].Type == state.TypeDocker || pp[i].PID <= 0 || pp[i].Stats == nil {
+			continue
+		}
+		pids = append(pids, pp[i].PID)
+	}
+	return pids
+}
+
+// refreshStats returns the previous rows with only their `stats` object
+// replaced. Every other field — display name, group, health, started_at — is
+// carried through untouched, which is what makes a stats delta invisible to a
+// subscriber that did not ask for stats.
+//
+// A row the sample has nothing to say about keeps the stats it had: a pid that
+// vanished between the scan and this tick is dropped from the sample, not
+// zeroed on the wire, and the next port scan is what removes the row.
+// `connections` is carried forward too — counting them is an `lsof` (or `ss`,
+// or `netstat`) per port and stays on the scan tick.
+func refreshStats(prev []state.Port, samples map[int]ports.ProcSample) []state.Port {
+	if len(samples) == 0 {
+		return prev
+	}
+	out := make([]state.Port, len(prev))
+	copy(out, prev)
+	for i := range out {
+		if out[i].Stats == nil || out[i].Type == state.TypeDocker {
+			continue
+		}
+		s, ok := samples[out[i].PID]
+		if !ok {
+			continue
+		}
+		st := *out[i].Stats // copy: the previous snapshot's object is shared
+		st.CPUPercent = s.CPUPercent
+		st.MemoryRSS = s.MemoryRSS
+		st.Uptime = s.Uptime
+		st.State = s.State
+		if s.ThreadCount > 0 {
+			st.ThreadCount = s.ThreadCount
+		}
+		out[i].Stats = &st
+	}
+	return out
+}
+
+// statsChanged reports whether any row's stats object moved. It compares the
+// slices directly rather than going through state.DiffWithStats because a
+// stats tick changes nothing else by construction, and the answer decides
+// whether a delta is published at all.
+func statsChanged(prev, next []state.Port) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	for i := range next {
+		a, b := prev[i].Stats, next[i].Stats
+		switch {
+		case a == nil && b == nil:
+		case a == nil || b == nil:
+			return true
+		case *a != *b:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scanner/stats.go
+++ b/internal/scanner/stats.go
@@ -98,9 +98,14 @@ func (l *Loop) sampleStats(include Include) {
 
 // sampleStatsLocked builds the refreshed snapshot and commits it. Caller holds
 // scanMu.
+//
+// It rebuilds from l.local — this machine's own rows, before the remote hosts
+// were merged in — for the same reason RemoteChanged does: only localhost's
+// processes are sampled here, and re-merging the remote contribution keeps a
+// remote host's rows and its `hosts` entry intact across a local stats tick.
 func (l *Loop) sampleStatsLocked(include Include) (prev, next state.Snapshot, changed bool) {
 	l.mu.Lock()
-	prev, have := l.snap, l.haveSnap
+	prev, local, have := l.snap, l.local, l.haveSnap
 	l.mu.Unlock()
 	if !have {
 		// Nothing has been scanned yet, so there is no port set to refresh
@@ -111,22 +116,32 @@ func (l *Loop) sampleStatsLocked(include Include) (prev, next state.Snapshot, ch
 	// Both of these may fork `ps`; neither may hold l.mu while it does.
 	var samples map[int]ports.ProcSample
 	if include.Stats {
-		samples = l.opts.SampleStats(statsPIDs(prev.Ports))
+		samples = l.opts.SampleStats(statsPIDs(local.Ports))
 	}
 	host := l.collectHost()
 
 	at := l.now()
-	next = prev
-	next.At = at.Format(time.RFC3339)
-	next.Ports = refreshStats(prev.Ports, samples)
-	host.Ports, host.Groups = len(next.Ports), len(next.Groups)
-	host.LastSeen = next.At
-	next.Hosts = []state.Host{host}
+	local.Ports = refreshStats(local.Ports, samples)
+	host.Ports, host.Groups = len(local.Ports), len(local.Groups)
+	host.LastSeen = at.Format(time.RFC3339)
+	local.Hosts = []state.Host{host}
+	local = local.Tag(state.LocalhostName).Normalize()
 
-	changed = statsChanged(prev.Ports, next.Ports) || hostChanged(prev, next)
+	next = local.Append(l.remoteRows()).Into(state.Snapshot{
+		At:              at.Format(time.RFC3339),
+		DaemonVersion:   l.opts.DaemonVersion,
+		ExposuresActive: prev.ExposuresActive,
+	})
+
+	// The full comparison, not just the stats one: a remote bridge may have
+	// replaced its rows since the last publish without RemoteChanged having
+	// run yet, and committing those silently would lose them — the next
+	// RemoteChanged would diff against a snapshot that already carries them.
+	changed = snapshotChanged(prev, next, true) || hostChanged(prev, next)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	l.local = local
 	if !changed {
 		// Commit anyway, so the next tick diffs against the newest reading,
 		// but keep the seq: a snapshot nobody was told about must not consume
@@ -141,14 +156,19 @@ func (l *Loop) sampleStatsLocked(include Include) (prev, next state.Snapshot, ch
 	return prev, next, true
 }
 
-// statsPIDs are the processes a stats tick samples: the ones the last snapshot
-// already named, minus containers, whose stats come from Docker rather than
-// from the process table. A pid that has since exited is simply missing from
-// the sample.
+// statsPIDs are the processes a stats tick samples: the ones this machine's
+// half of the last snapshot already named, minus containers, whose stats come
+// from Docker rather than from the process table. A pid that has since exited
+// is simply missing from the sample. Remote hosts are never sampled here —
+// their pids belong to another machine's process table, and their own daemon
+// runs this same tick for them.
 func statsPIDs(pp []state.Port) []int {
 	pids := make([]int, 0, len(pp))
 	for i := range pp {
 		if pp[i].Type == state.TypeDocker || pp[i].PID <= 0 || pp[i].Stats == nil {
+			continue
+		}
+		if !state.IsLocalhost(pp[i].Host) {
 			continue
 		}
 		pids = append(pids, pp[i].PID)
@@ -157,9 +177,9 @@ func statsPIDs(pp []state.Port) []int {
 }
 
 // refreshStats returns the previous rows with only their `stats` object
-// replaced. Every other field — display name, group, health, started_at — is
-// carried through untouched, which is what makes a stats delta invisible to a
-// subscriber that did not ask for stats.
+// replaced. Every other field — display name, group, health, started_at, the
+// host tag — is carried through untouched, which is what makes a stats delta
+// invisible to a subscriber that did not ask for stats.
 //
 // A row the sample has nothing to say about keeps the stats it had: a pid that
 // vanished between the scan and this tick is dropped from the sample, not
@@ -191,25 +211,4 @@ func refreshStats(prev []state.Port, samples map[int]ports.ProcSample) []state.P
 		out[i].Stats = &st
 	}
 	return out
-}
-
-// statsChanged reports whether any row's stats object moved. It compares the
-// slices directly rather than going through state.DiffWithStats because a
-// stats tick changes nothing else by construction, and the answer decides
-// whether a delta is published at all.
-func statsChanged(prev, next []state.Port) bool {
-	if len(prev) != len(next) {
-		return true
-	}
-	for i := range next {
-		a, b := prev[i].Stats, next[i].Stats
-		switch {
-		case a == nil && b == nil:
-		case a == nil || b == nil:
-			return true
-		case *a != *b:
-			return true
-		}
-	}
-	return false
 }

--- a/internal/scanner/stats_test.go
+++ b/internal/scanner/stats_test.go
@@ -393,3 +393,62 @@ func TestStatsTickIsSerializedWithScans(t *testing.T) {
 		last = p.next.Seq
 	}
 }
+
+// A stats tick refreshes this machine only. A registered remote host's rows —
+// its ports and its `hosts` entry — are merged back in untouched, and its pids
+// are never handed to the local process table: pid 100 on a build server is
+// not pid 100 here.
+func TestStatsTickLeavesRemoteRowsAlone(t *testing.T) {
+	r := newStatsRig(t)
+
+	var sampled []int
+	inner := r.loop.opts.SampleStats
+	r.loop.opts.SampleStats = func(pids []int) map[int]ports.ProcSample {
+		sampled = append([]int{}, pids...)
+		return inner(pids)
+	}
+
+	remotePort := state.Port{
+		Port: 3000, BindAddress: "0.0.0.0", PID: 100, Process: "node", Host: "build",
+		Stats: &state.Stats{CPUPercent: 42, MemoryRSS: 99, ThreadCount: 2},
+	}
+	r.loop.opts.Remote = func() state.Rows {
+		return state.Rows{
+			Ports: []state.Port{remotePort},
+			Hosts: []state.Host{{Name: "build", Address: "build", Status: state.HostConnected}},
+		}
+	}
+
+	r.loop.scanAndPublish(Include{Stats: true})
+	r.loop.sampleStats(Include{Stats: true})
+
+	for _, pid := range sampled {
+		if pid != 100 && pid != 200 {
+			t.Fatalf("the sampler was handed pid %d, which is not one of this machine's", pid)
+		}
+	}
+	if len(sampled) != 2 {
+		t.Fatalf("sampled pids = %v, want this machine's two (a remote pid 100 must not be added)", sampled)
+	}
+
+	snap := r.loop.CachedAll()
+	var found *state.Port
+	for i := range snap.Ports {
+		if !state.IsLocalhost(snap.Ports[i].Host) {
+			found = &snap.Ports[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("the stats tick dropped the remote host's port row")
+	}
+	if found.Stats == nil || *found.Stats != *remotePort.Stats {
+		t.Errorf("remote stats = %+v, want the bridge's own %+v", found.Stats, remotePort.Stats)
+	}
+	names := map[string]bool{}
+	for _, h := range snap.Hosts {
+		names[h.Name] = true
+	}
+	if !names["build"] || !names[state.LocalhostName] {
+		t.Errorf("hosts after a stats tick = %v, want both localhost and the remote", names)
+	}
+}

--- a/internal/scanner/stats_test.go
+++ b/internal/scanner/stats_test.go
@@ -500,3 +500,148 @@ func TestStatsTickRunsWhileAScanIsInFlight(t *testing.T) {
 	close(release)
 	<-scanDone
 }
+
+// A stats tick that runs after a bridge has swapped its rows in, but before
+// RemoteChanged has been called, must not swallow them.
+//
+// The tick used to rebuild the snapshot as l.local.Append(l.remoteRows()), so
+// it picked the new remote rows up as a side effect and committed them.
+// RemoteChanged then diffed against a snapshot that already carried them,
+// found nothing to do, and the remote host reached no subscriber at all —
+// while a later state.snapshot showed rows no delta had ever announced.
+func TestStatsTickDoesNotSwallowARemoteChange(t *testing.T) {
+	r := newStatsRig(t)
+	r.loop.opts.HostStats = fixedHost
+
+	var mu sync.Mutex
+	var remote state.Rows
+	r.loop.opts.Remote = func() state.Rows {
+		mu.Lock()
+		defer mu.Unlock()
+		return remote
+	}
+
+	r.loop.scanAndPublish(Include{Stats: true})
+	before := r.loop.Status().Seq
+
+	mu.Lock()
+	remote = state.Rows{
+		Ports: []state.Port{{
+			Port: 3000, BindAddress: "127.0.0.1", PID: 4242, Process: "node",
+			ExposedURLs: []string{}, Stats: &state.Stats{CPUPercent: 42},
+		}},
+		Hosts: []state.Host{{Name: state.LocalhostName, Status: state.HostConnected}},
+	}.Tag("hetzner").Normalize()
+	mu.Unlock()
+
+	// The tick lands in the window between the bridge's write and the call
+	// that is supposed to announce it.
+	r.loop.sampleStats(Include{Stats: true})
+	r.loop.RemoteChanged()
+
+	carried := 0
+	for _, p := range r.published() {
+		for _, row := range p.next.Ports {
+			if row.Host == "hetzner" {
+				carried++
+				break
+			}
+		}
+	}
+	if carried != 1 {
+		t.Fatalf("%d publishes carried the remote host's rows, want exactly 1", carried)
+	}
+	if after := r.loop.Status().Seq; after <= before {
+		t.Fatalf("seq = %d, want more than %d: the remote change took no sequence number", after, before)
+	}
+
+	// And what a new reader sees agrees with what was published.
+	snap := r.loop.CachedAll()
+	found := false
+	for _, row := range snap.Ports {
+		if row.Host == "hetzner" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the cached snapshot lost the remote rows a delta announced")
+	}
+}
+
+// A bridge that connects before the daemon's first scan still reaches every
+// subscriber. RemoteChanged used to wake the loop and return, publishing
+// nothing, so the host appeared only when a scan happened to land.
+func TestRemoteChangedPublishesBeforeTheFirstScan(t *testing.T) {
+	r := newStatsRig(t)
+	r.loop.opts.HostStats = fixedHost
+	r.loop.opts.Remote = func() state.Rows {
+		return state.Rows{
+			Hosts: []state.Host{{Name: state.LocalhostName, Status: state.HostConnected}},
+		}.Tag("hetzner").Normalize()
+	}
+
+	r.loop.RemoteChanged()
+
+	if got := r.loop.Status().Seq; got == 0 {
+		t.Fatal("a remote host that connected before the first scan published nothing")
+	}
+	seen := r.published()
+	if len(seen) != 1 {
+		t.Fatalf("%d publishes, want 1", len(seen))
+	}
+	names := map[string]bool{}
+	for _, h := range seen[0].next.Hosts {
+		names[h.Name] = true
+	}
+	if !names["hetzner"] || !names[state.LocalhostName] {
+		t.Errorf("published hosts = %v, want localhost and the remote", names)
+	}
+	// The scan that follows must still publish this machine's ports.
+	r.loop.scanAndPublish(Include{})
+	if got := len(r.published()); got != 2 {
+		t.Errorf("%d publishes after the first scan, want 2", got)
+	}
+	if got := len(r.loop.Cached().Ports); got == 0 {
+		t.Error("the first scan after a pre-scan RemoteChanged published no local ports")
+	}
+}
+
+// The invariant behind the two tests above, asserted directly: the loop never
+// commits a snapshot it did not publish. A cached snapshot that differs from
+// the last delta is how a change goes missing — the next comparison is made
+// against state nobody was told about, so whatever produced it decides there
+// is nothing to announce.
+func TestStatsTickCommitsNothingItDidNotPublish(t *testing.T) {
+	r := newStatsRig(t)
+	r.loop.opts.HostStats = fixedHost
+	// A clock that moves a second per read, so a snapshot committed without
+	// being published is visible as a timestamp no delta carried. With a real
+	// clock three ticks land inside one RFC3339 second and the difference
+	// hides.
+	var clockMu sync.Mutex
+	tick := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	r.loop.now = func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		tick = tick.Add(time.Second)
+		return tick
+	}
+	fixed := map[int]ports.ProcSample{
+		100: {CPUPercent: 1, MemoryRSS: 1 << 20, ThreadCount: 4, State: "running", Uptime: "1s"},
+		200: {CPUPercent: 2, MemoryRSS: 2 << 20, ThreadCount: 9, State: "running", Uptime: "1s"},
+	}
+	r.loop.opts.SampleStats = func([]int) map[int]ports.ProcSample { return fixed }
+
+	r.loop.scanAndPublish(Include{Stats: true})
+	r.loop.sampleStats(Include{Stats: true}) // settles the scan's stats onto the sampler's
+
+	for i := 0; i < 3; i++ {
+		r.loop.sampleStats(Include{Stats: true})
+		seen := r.published()
+		last := seen[len(seen)-1].next
+		if got := r.loop.CachedAll(); !reflect.DeepEqual(got, last) {
+			t.Fatalf("tick %d cached a snapshot no delta carried:\n cached    at=%s seq=%d\n published at=%s seq=%d",
+				i+1, got.At, got.Seq, last.At, last.Seq)
+		}
+	}
+}

--- a/internal/scanner/stats_test.go
+++ b/internal/scanner/stats_test.go
@@ -1,0 +1,395 @@
+package scanner
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// statsRig is a loop whose scan, host collector and per-process sampler are all
+// fakes, wired for the stats-only tick: the scan reports a fixed port set so
+// nothing but stats can move, and the sampler's cpu figure climbs on every
+// call the way a real one does.
+type statsRig struct {
+	loop *Loop
+
+	mu       sync.Mutex
+	rows     []ports.ListeningPort
+	gonePIDs map[int]bool
+	deltas   []published
+
+	scans    atomic.Int64
+	samples  atomic.Int64
+	hostCPU  atomic.Int64 // tenths of a percent, so the host row moves too
+	sampleAt atomic.Int64
+	subs     atomic.Int64
+	include  atomic.Bool
+}
+
+// published is one (prev, next) transition the loop handed to its publisher.
+type published struct {
+	prev, next state.Snapshot
+	at         time.Time
+}
+
+func newStatsRig(t *testing.T) *statsRig {
+	t.Helper()
+	r := &statsRig{
+		gonePIDs: map[int]bool{},
+		rows: []ports.ListeningPort{
+			{Port: 3000, BindAddress: "127.0.0.1", PID: 100, Process: "node", CPUPercent: 1, MemoryRSS: 1 << 20, Connections: 7, ThreadCount: 4},
+			{Port: 5173, BindAddress: "127.0.0.1", PID: 200, Process: "vite", CPUPercent: 2, MemoryRSS: 2 << 20, Connections: 3, ThreadCount: 9},
+		},
+	}
+	r.loop = New(Options{
+		DaemonVersion: "test",
+		StatsInterval: 30 * time.Millisecond,
+		Demand: func() (int, Include) {
+			return int(r.subs.Load()), Include{Stats: r.include.Load()}
+		},
+		Publish: func(prev, next state.Snapshot, _ []state.Event) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.deltas = append(r.deltas, published{prev: prev, next: next, at: time.Now()})
+		},
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			r.scans.Add(1)
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			return append([]ports.ListeningPort{}, r.rows...), nil
+		},
+		SampleStats: func(pids []int) map[int]ports.ProcSample {
+			n := r.samples.Add(1)
+			r.sampleAt.Store(time.Now().UnixNano())
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			out := map[int]ports.ProcSample{}
+			for _, pid := range pids {
+				if r.gonePIDs[pid] {
+					continue
+				}
+				out[pid] = ports.ProcSample{
+					CPUPercent:  float64(n),
+					MemoryRSS:   int64(pid) << 10,
+					ThreadCount: 11,
+					State:       "running",
+					Uptime:      "1s",
+				}
+			}
+			return out
+		},
+		HostStats: func(context.Context) (state.Host, error) {
+			pct := float64(r.hostCPU.Add(5)) / 10
+			return state.Host{Kernel: "test-kernel", CPUPercent: &pct}, nil
+		},
+	})
+	return r
+}
+
+// run starts the loop and stops it when the test ends.
+func (r *statsRig) run(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.loop.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+// subscribe fakes a client connecting with the given include set.
+func (r *statsRig) subscribe(stats bool) {
+	r.include.Store(stats)
+	r.subs.Store(1)
+	r.loop.Wake()
+}
+
+func (r *statsRig) unsubscribe() {
+	r.subs.Store(0)
+	r.include.Store(false)
+	r.loop.Wake()
+}
+
+func (r *statsRig) published() []published {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]published{}, r.deltas...)
+}
+
+// waitFor polls until cond holds or the deadline passes.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// The sampler is dead weight on a daemon nobody is watching: `sonar list` and
+// `daemon status` go through Snapshot, which wakes the loop, and that must not
+// start a 1 s `ps` on a machine with no subscriber.
+func TestStatsTickParksUntilSomeoneSubscribes(t *testing.T) {
+	r := newStatsRig(t)
+	r.run(t)
+
+	// An RPC read: it scans and wakes, but nobody is subscribed.
+	if _, err := r.loop.Snapshot(Include{}); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if got := r.samples.Load(); got != 0 {
+		t.Fatalf("the stats sampler ran %d times with no subscribers, want 0", got)
+	}
+
+	r.subscribe(true)
+	waitFor(t, "the sampler to start on the first subscribe", func() bool {
+		return r.samples.Load() > 0
+	})
+
+	r.unsubscribe()
+	// Let the tick in flight finish, then check it stops for good.
+	time.Sleep(100 * time.Millisecond)
+	before := r.samples.Load()
+	time.Sleep(250 * time.Millisecond)
+	if after := r.samples.Load(); after != before {
+		t.Errorf("the sampler ran %d more times after the last unsubscribe", after-before)
+	}
+}
+
+// The tick keeps its own cadence: several samples land inside one base scan
+// interval, and the scan is not what produced them.
+func TestStatsTickRunsOnItsOwnCadence(t *testing.T) {
+	r := newStatsRig(t)
+	r.run(t)
+	r.subscribe(true)
+
+	waitFor(t, "four stats samples", func() bool { return r.samples.Load() >= 4 })
+	if scans := r.scans.Load(); scans > 3 {
+		t.Errorf("%d port scans while four stats samples were taken; the scan cadence was dragged along", scans)
+	}
+}
+
+// A stats tick publishes a delta whose only moving parts are `stats` and the
+// host row. Everything that identifies a port — display name, group, health,
+// started_at, connections — is carried through untouched, which is what makes
+// the delta invisible to a subscriber that did not ask for stats.
+func TestStatsTickMovesOnlyStatsAndHost(t *testing.T) {
+	r := newStatsRig(t)
+	r.loop.scanAndPublish(Include{Stats: true})
+
+	before := r.loop.Cached()
+	r.include.Store(true)
+	r.loop.sampleStats(Include{Stats: true})
+	after := r.loop.Cached()
+
+	if after.Seq != before.Seq+1 {
+		t.Fatalf("seq = %d, want %d: a published stats tick takes the next seq", after.Seq, before.Seq+1)
+	}
+	if len(after.Ports) != len(before.Ports) {
+		t.Fatalf("port count changed: %d -> %d", len(before.Ports), len(after.Ports))
+	}
+	for i := range after.Ports {
+		a, b := before.Ports[i], after.Ports[i]
+		if a.Stats == nil || b.Stats == nil {
+			t.Fatalf("port %s lost its stats object", b.Key())
+		}
+		if *a.Stats == *b.Stats {
+			t.Errorf("port %s stats did not move: %+v", b.Key(), *b.Stats)
+		}
+		if b.Stats.Connections != a.Stats.Connections {
+			t.Errorf("connections moved on a stats tick (%d -> %d); counting them is a per-port lsof and belongs on the scan",
+				a.Stats.Connections, b.Stats.Connections)
+		}
+		a.Stats, b.Stats = nil, nil
+		if !reflect.DeepEqual(a, b) {
+			t.Errorf("a stats tick changed a non-stats field:\n before %+v\n after  %+v", a, b)
+		}
+	}
+
+	if len(after.Hosts) != 1 || after.Hosts[0].CPUPercent == nil {
+		t.Fatalf("hosts = %+v, want the localhost row with a load", after.Hosts)
+	}
+	if *after.Hosts[0].CPUPercent == *before.Hosts[0].CPUPercent {
+		t.Error("the host load did not move on a stats tick")
+	}
+	if after.Hosts[0].Ports != len(after.Ports) {
+		t.Errorf("host.ports = %d, want the %d rows in the snapshot", after.Hosts[0].Ports, len(after.Ports))
+	}
+}
+
+// The whole point of the split: a stats tick must never reset the scan
+// backoff, or a subscribed daemon is pinned to a full port scan every second
+// (contract §37's rule for host-only changes, now enforced for stats too).
+func TestStatsTickNeverResetsTheScanInterval(t *testing.T) {
+	r := newStatsRig(t)
+
+	// Back the scan interval off with unchanged scans.
+	for i := 0; i < 4; i++ {
+		r.loop.scanAndPublish(Include{Stats: true})
+	}
+	backedOff := r.loop.Status().IntervalMs
+	if backedOff <= int(BaseInterval/time.Millisecond) {
+		t.Fatalf("interval = %dms, expected the backoff to have grown past %s", backedOff, BaseInterval)
+	}
+	scans := r.scans.Load()
+
+	for i := 0; i < 5; i++ {
+		r.loop.sampleStats(Include{Stats: true})
+	}
+
+	st := r.loop.Status()
+	if st.IntervalMs != backedOff {
+		t.Errorf("the stats tick moved the scan interval: %dms -> %dms", backedOff, st.IntervalMs)
+	}
+	if st.Scans != scans {
+		t.Errorf("scan count = %d, want %d: a stats tick is not a scan", st.Scans, scans)
+	}
+	if r.scans.Load() != scans {
+		t.Errorf("the stats tick called the OS scan %d times", r.scans.Load()-scans)
+	}
+}
+
+// Nothing moved, nothing published: an empty delta is never sent (contract
+// §15), and a snapshot nobody was told about does not consume a seq.
+func TestStatsTickSuppressesAnEmptyDelta(t *testing.T) {
+	r := newStatsRig(t)
+	// A sampler and a host collector that both answer the same thing forever.
+	fixed := map[int]ports.ProcSample{
+		100: {CPUPercent: 1, MemoryRSS: 1 << 20, ThreadCount: 4, State: "running", Uptime: "1s"},
+		200: {CPUPercent: 2, MemoryRSS: 2 << 20, ThreadCount: 9, State: "running", Uptime: "1s"},
+	}
+	r.loop.opts.SampleStats = func([]int) map[int]ports.ProcSample { return fixed }
+	r.loop.opts.HostStats = fixedHost
+
+	r.loop.scanAndPublish(Include{Stats: true})
+	// One tick to settle: the scan's own stats and the sampler's disagree
+	// about uptime and state, so the first sample after a scan really does
+	// move something.
+	r.loop.sampleStats(Include{Stats: true})
+	seq := r.loop.Cached().Seq
+	published := len(r.published())
+
+	for i := 0; i < 3; i++ {
+		r.loop.sampleStats(Include{Stats: true})
+	}
+
+	if got := len(r.published()); got != published {
+		t.Errorf("%d deltas published by stats ticks where nothing moved", got-published)
+	}
+	if got := r.loop.Cached().Seq; got != seq {
+		t.Errorf("seq = %d, want %d: an unpublished tick must not burn a sequence number", got, seq)
+	}
+}
+
+// A process that exits between the scan that listed it and the sample that
+// refreshes it is absent from the sample. Its row keeps the stats it had —
+// zeroes would read like facts — and the next port scan is what removes it.
+func TestStatsTickHandlesAPIDDisappearing(t *testing.T) {
+	r := newStatsRig(t)
+	r.loop.scanAndPublish(Include{Stats: true})
+	r.loop.sampleStats(Include{Stats: true})
+	before := r.loop.Cached()
+
+	r.mu.Lock()
+	r.gonePIDs[100] = true
+	r.mu.Unlock()
+
+	r.loop.sampleStats(Include{Stats: true})
+	after := r.loop.Cached()
+
+	if len(after.Ports) != len(before.Ports) {
+		t.Fatalf("the stats tick removed a row: %d -> %d ports", len(before.Ports), len(after.Ports))
+	}
+	gone, alive := after.Ports[0], after.Ports[1]
+	if gone.PID != 100 || alive.PID != 200 {
+		t.Fatalf("unexpected row order: %+v", after.Ports)
+	}
+	if *gone.Stats != *before.Ports[0].Stats {
+		t.Errorf("a vanished pid's stats were rewritten: %+v -> %+v", *before.Ports[0].Stats, *gone.Stats)
+	}
+	if *alive.Stats == *before.Ports[1].Stats {
+		t.Error("the surviving pid's stats were not refreshed")
+	}
+}
+
+// A subscriber that asked for neither stats nor health still gets the host
+// load, and the sampler does not fork a `ps` for per-process stats nobody
+// wants.
+func TestStatsTickWithoutStatsIncludeOnlyMovesTheHost(t *testing.T) {
+	r := newStatsRig(t)
+	r.loop.scanAndPublish(Include{})
+	before := r.loop.Cached()
+
+	r.loop.sampleStats(Include{})
+	after := r.loop.Cached()
+
+	if got := r.samples.Load(); got != 0 {
+		t.Errorf("the per-process sampler ran %d times for a subscriber that did not ask for stats", got)
+	}
+	if after.Seq != before.Seq+1 {
+		t.Errorf("seq = %d, want %d: the host load still moved", after.Seq, before.Seq+1)
+	}
+	if *after.Hosts[0].CPUPercent == *before.Hosts[0].CPUPercent {
+		t.Error("the host load did not move")
+	}
+}
+
+// Stats ticks and scans are serialized end to end, so `seq` order is publish
+// order (contract §38). Run under -race: this is the test that catches a
+// sampler committing a snapshot in the middle of a scan's commit.
+func TestStatsTickIsSerializedWithScans(t *testing.T) {
+	r := newStatsRig(t)
+	r.run(t)
+	r.subscribe(true)
+
+	// Writers hammering Rescan the way ports.rename does, while the stats
+	// tick runs at 30 ms.
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := r.loop.Rescan(Include{Stats: true}); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	waitFor(t, "a few stats samples under load", func() bool { return r.samples.Load() >= 5 })
+	close(stop)
+	wg.Wait()
+
+	seen := r.published()
+	if len(seen) < 2 {
+		t.Fatalf("only %d publishes; the test did not exercise anything", len(seen))
+	}
+	var last uint64
+	for i, p := range seen {
+		if p.next.Seq <= last {
+			t.Fatalf("publish %d has seq %d after seq %d: publish order is not seq order", i, p.next.Seq, last)
+		}
+		last = p.next.Seq
+	}
+}

--- a/internal/scanner/stats_test.go
+++ b/internal/scanner/stats_test.go
@@ -452,3 +452,51 @@ func TestStatsTickLeavesRemoteRowsAlone(t *testing.T) {
 		t.Errorf("hosts after a stats tick = %v, want both localhost and the remote", names)
 	}
 }
+
+// A slow scan must not starve the tick. This is the whole reason the tick
+// takes commitMu rather than scanMu: a scan holds scanMu from its first OS
+// call to its last, and `docker stats` alone is two seconds of that, which
+// turned a 1 s sampler into a burst of deltas every five or six seconds.
+func TestStatsTickRunsWhileAScanIsInFlight(t *testing.T) {
+	r := newStatsRig(t)
+	r.loop.scanAndPublish(Include{Stats: true}) // a snapshot to refresh
+
+	scanning := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	rows := r.rows
+	r.loop.opts.Scan = func(Include) ([]ports.ListeningPort, error) {
+		once.Do(func() {
+			close(scanning)
+			<-release
+		})
+		return append([]ports.ListeningPort{}, rows...), nil
+	}
+
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		r.loop.scanAndPublish(Include{Stats: true})
+	}()
+	<-scanning
+
+	before := r.loop.Cached().Seq
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.loop.sampleStats(Include{Stats: true})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		close(release)
+		<-scanDone
+		t.Fatal("the stats tick blocked behind a scan that was still doing OS work")
+	}
+	if got := r.loop.Cached().Seq; got <= before {
+		t.Errorf("seq = %d, want more than %d: the tick published nothing", got, before)
+	}
+
+	close(release)
+	<-scanDone
+}


### PR DESCRIPTION
A stats-only sampler runs every second while a subscriber is connected, republishing `Port.stats` and the localhost `Host` row without a port scan. The adaptive scan cadence and its backoff are untouched, and the sampler parks when nobody is subscribed. Publishes are ordered by a commit lock so a slow scan cannot starve the tick. Connection and thread counts are now gathered with one call each instead of one per port, taking a stats-enabled scan from 4.5 s to about 130 ms. Adds `daemon.stats_interval`.