### PR TITLE
feat: route actions to a remote host with a host selector and --host on the write commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ sonar remote list                              # status, latency, version, load
 sonar remote remove hetzner
 
 sonar list --host hetzner                      # that host's ports
+sonar list --host "*"                          # every host, with a HOST column
 sonar info 3000 --host hetzner
 ```
 
@@ -492,6 +493,43 @@ thirty for as long as it stays registered.
 `--host` also still takes a bare `user@host` that sonar knows nothing about: it
 falls back to the agentless `ssh` + `ss`/`lsof` scan and prints a hint to
 `sonar remote install`.
+
+#### Acting on another machine
+
+Every write takes `--host` too, and does there exactly what it does here:
+
+```sh
+sonar kill 3000 --host hetzner                 # stop a port on that machine
+sonar kill -g api --host hetzner               # a whole group of its services
+sonar kill-all --filter docker --host hetzner  # its containers
+sonar up api --host hetzner                    # start a group from its .sonar.yaml
+sonar logs 3000 --host hetzner                 # tail its output here
+sonar rename 3000 storefront --host hetzner    # its name, in its database
+sonar assign 3000 storefront --host hetzner
+```
+
+The local daemon forwards the call over that host's bridge and hands back what
+the remote daemon answered, in the same envelope a local call returns — every
+result row says which host it happened on, and a kill's `affected` carries the
+`<host>/<port>:<bind>` keys the stream uses for those rows. A streaming command
+streams: `sonar up --host` prints each service as the far side starts it, and
+Ctrl-C stops the remote work rather than just this terminal.
+
+Because a row's key already names its host, a client can hand one straight back
+as a selector — `{"key": "hetzner/3000:127.0.0.1"}` is the whole of a selector,
+host included. One call acts on one machine; naming two is an error rather than
+half a kill on each.
+
+Two things stay local. `sonar attach` puts *this* terminal in front of a
+process, so it refuses `--host` and says to ssh over and attach there. And an
+agent session is state this daemon holds, so `sonar kill --session` has no
+remote form. Everything else needs the daemon running here — it is where the
+connection to the other machine lives — and says so instead of quietly scanning
+this machine instead.
+
+`sonar up --host` needs the group named: the `.sonar.yaml` at your working
+directory is a path on this machine, and it is the remote daemon that reads the
+file and starts the services.
 
 ### The daemon
 

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -963,6 +963,9 @@
     },
     "GroupsAssignParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "port": {
           "type": "integer"
         },
@@ -976,6 +979,9 @@
           "type": "string"
         },
         "proxy_id": {
+          "type": "string"
+        },
+        "key": {
           "type": "string"
         },
         "group": {
@@ -1029,6 +1035,9 @@
     },
     "GroupsConfigGetParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -1055,6 +1064,9 @@
     },
     "GroupsConfigSetParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "path": {
           "type": "string"
         },
@@ -1146,6 +1158,9 @@
     },
     "GroupsInspectParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         }
@@ -1229,6 +1244,9 @@
     },
     "GroupsKillParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -1335,6 +1353,9 @@
     },
     "GroupsStartParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -1590,6 +1611,14 @@
         "last_seen"
       ]
     },
+    "HostParams": {
+      "properties": {
+        "host": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "Include": {
       "items": {
         "type": "string"
@@ -1623,6 +1652,9 @@
     },
     "KillResult": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "port": {
           "type": "integer"
         },
@@ -1654,6 +1686,7 @@
       },
       "type": "object",
       "required": [
+        "host",
         "port",
         "bind_address",
         "pid",
@@ -2123,6 +2156,9 @@
     },
     "PortsHealthParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "ports": {
           "items": {
             "type": "integer"
@@ -2148,6 +2184,9 @@
     },
     "PortsHistoryParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "port": {
           "type": "integer"
         },
@@ -2201,6 +2240,9 @@
     },
     "PortsKillParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "targets": {
           "items": {
             "$ref": "#/definitions/Selector"
@@ -2230,6 +2272,9 @@
     },
     "PortsListParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "group": {
           "type": "string"
         },
@@ -2282,6 +2327,9 @@
     },
     "PortsLogsParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "port": {
           "type": "integer"
         },
@@ -2295,6 +2343,9 @@
           "type": "string"
         },
         "proxy_id": {
+          "type": "string"
+        },
+        "key": {
           "type": "string"
         },
         "lines": {
@@ -2364,6 +2415,9 @@
     },
     "PortsRenameParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "port": {
           "type": "integer"
         },
@@ -2377,6 +2431,9 @@
           "type": "string"
         },
         "proxy_id": {
+          "type": "string"
+        },
+        "key": {
           "type": "string"
         },
         "name": {
@@ -2466,6 +2523,9 @@
     },
     "PortsWaitParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "ports": {
           "items": {
             "type": "integer"
@@ -3017,6 +3077,9 @@
     },
     "Selector": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "port": {
           "type": "integer"
         },
@@ -3030,6 +3093,9 @@
           "type": "string"
         },
         "proxy_id": {
+          "type": "string"
+        },
+        "key": {
           "type": "string"
         }
       },
@@ -3293,6 +3359,9 @@
     },
     "SessionsInspectParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "id": {
           "type": "string"
         }
@@ -3329,6 +3398,9 @@
     },
     "SessionsKillParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "id": {
           "type": "string"
         },
@@ -3349,6 +3421,9 @@
     },
     "SessionsListParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "active_only": {
           "type": "boolean"
         }
@@ -3654,7 +3729,7 @@
     },
     "claims.list": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/ClaimsListResult"
@@ -3670,7 +3745,7 @@
     },
     "config.get": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/ConfigGetResult"
@@ -3678,7 +3753,7 @@
     },
     "config.path": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/ConfigPathResult"
@@ -3718,7 +3793,7 @@
     },
     "daemon.status": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/DaemonStatusResult"
@@ -3828,7 +3903,7 @@
     },
     "groups.list": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/GroupsListResult"
@@ -3836,7 +3911,7 @@
     },
     "groups.reload": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/GroupsReloadResult"
@@ -3896,7 +3971,7 @@
     },
     "ports.graph": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/PortsGraphResult"
@@ -4042,7 +4117,7 @@
     },
     "runs.list": {
       "params": {
-        "$ref": "#/definitions/Empty"
+        "$ref": "#/definitions/HostParams"
       },
       "result": {
         "$ref": "#/definitions/RunsListResult"

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -209,6 +209,9 @@
     },
     "ClaimsAcquireParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "project": {
           "type": "string"
         },
@@ -279,6 +282,9 @@
     },
     "ClaimsReleaseParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "key": {
           "type": "string"
         }
@@ -342,6 +348,9 @@
     },
     "ConfigSetParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "patch": {
           "type": "object"
         }
@@ -1111,6 +1120,9 @@
     },
     "GroupsInitParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "root_dir": {
           "type": "string"
         },
@@ -2384,6 +2396,9 @@
     },
     "PortsNextParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "start": {
           "type": "integer"
         },
@@ -2939,6 +2954,9 @@
     },
     "RunsRegisterParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "pid": {
           "type": "integer"
         },
@@ -2997,6 +3015,9 @@
     },
     "RunsSpawnParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "argv": {
           "items": {
             "type": "string"
@@ -3066,6 +3087,9 @@
     },
     "RunsUnregisterParams": {
       "properties": {
+        "host": {
+          "type": "string"
+        },
         "pid": {
           "type": "integer"
         }

--- a/internal/cmd/assign.go
+++ b/internal/cmd/assign.go
@@ -30,6 +30,7 @@ func init() {
 	assignCmd.Flags().BoolVar(&assignPID, "pid", false, "Read the argument as a pid instead of a port")
 	assignCmd.Flags().String("ip", "", "Specify bind address when a port is bound to multiple IPs")
 	assignCmd.Flags().BoolVar(&assignJSON, "json", false, "Output as JSON")
+	addHostFlag(assignCmd, "Pin a port on a registered remote `host` instead of this machine")
 	rootCmd.AddCommand(assignCmd)
 }
 
@@ -43,7 +44,7 @@ func assignRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := connectForWrite(cmd.Context())
+	c, err := connectForHostWrite(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -29,6 +29,15 @@ For other services, opens a raw TCP connection to the port.`,
 
 		bindIP, _ := cmd.Flags().GetString("ip")
 
+		// Attaching is a terminal on this machine talking to a process on this
+		// machine: a docker exec, or a raw TCP connection to the port. Neither
+		// travels over the bridge, and pretending otherwise would open a shell
+		// into the wrong container.
+		if onRemoteHost() {
+			return fmt.Errorf("attach cannot run on a remote host: it puts this terminal in front of a local process\nhint: ssh to the host and run `sonar attach %d` there",
+				port)
+		}
+
 		lp, err := ports.FindByPort(port, bindIP)
 		if err != nil {
 			return err
@@ -53,6 +62,7 @@ For other services, opens a raw TCP connection to the port.`,
 func init() {
 	attachCmd.Flags().StringVar(&attachShell, "shell", "", "Shell to use for Docker exec (default: auto-detect sh/bash)")
 	attachCmd.Flags().String("ip", "", "Specify bind address when a port is bound to multiple IPs")
+	addHostFlag(attachCmd, "Refused: attach is a terminal on this machine, so ssh there and attach locally")
 	rootCmd.AddCommand(attachCmd)
 }
 

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -62,7 +62,7 @@ For other services, opens a raw TCP connection to the port.`,
 func init() {
 	attachCmd.Flags().StringVar(&attachShell, "shell", "", "Shell to use for Docker exec (default: auto-detect sh/bash)")
 	attachCmd.Flags().String("ip", "", "Specify bind address when a port is bound to multiple IPs")
-	addHostFlag(attachCmd, "Refused: attach is a terminal on this machine, so ssh there and attach locally")
+	addHostFlag(attachCmd, "Refused for a remote `host`: attach is a terminal on this machine, so ssh there and attach locally")
 	rootCmd.AddCommand(attachCmd)
 }
 

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/display"
 	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/profile"
 	"github.com/spf13/cobra"
 )
@@ -28,15 +29,26 @@ var downCmd = &cobra.Command{
 			return err
 		}
 
-		snapshot := scanForKill()
-		var targets []killer.Target
-		for _, entry := range prof.Ports {
-			for _, p := range snapshot {
-				if p.Port == entry.Port {
-					targets = append(targets, killer.Target{Port: p.Port, BindAddress: p.BindAddress})
+		selectTargets := func(snapshot []ports.ListeningPort) ([]killer.Target, error) {
+			var targets []killer.Target
+			for _, entry := range prof.Ports {
+				for _, p := range snapshot {
+					if p.Port == entry.Port {
+						targets = append(targets, killer.Target{Port: p.Port, BindAddress: p.BindAddress})
+					}
 				}
 			}
+			return targets, nil
 		}
+
+		if onRemoteHost() {
+			fmt.Printf("Profile %s on %s:\n", display.Bold(prof.Name), display.Bold(remoteHostFlag))
+			return killSweepThroughDaemon(cmd.Context(), selectTargets,
+				killer.Options{Force: downForceFlag}, !downYesFlag, false)
+		}
+
+		snapshot := scanForKill()
+		targets, _ := selectTargets(snapshot)
 		if len(targets) == 0 {
 			fmt.Println("No profile ports are currently running.")
 			return nil
@@ -51,5 +63,6 @@ var downCmd = &cobra.Command{
 func init() {
 	downCmd.Flags().BoolVarP(&downYesFlag, "yes", "y", false, "Skip confirmation prompt")
 	downCmd.Flags().BoolVarP(&downForceFlag, "force", "f", false, "Send SIGKILL instead of SIGTERM")
+	addHostFlag(downCmd, "Stop the profile's ports on a registered remote `host`")
 	rootCmd.AddCommand(downCmd)
 }

--- a/internal/cmd/hostflag.go
+++ b/internal/cmd/hostflag.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+	"github.com/spf13/cobra"
+)
+
+// `--host <name>` on the write commands (remote-hosts spec, "CLI").
+//
+// The read commands (`list`, `info`, `watch`) have had a `--host` for as long
+// as the agentless SSH scan has existed, and it still means what it meant: a
+// registered host is read through the daemon, anything else is scanned over
+// ssh. A write has no such fallback. `sonar kill --host box` is a kill on
+// another machine's daemon, so the host has to be registered and a daemon has
+// to be running here to reach it — and the command says so rather than quietly
+// doing something else.
+//
+// One flag variable is enough: a process runs one command.
+var remoteHostFlag string
+
+// addHostFlag registers `--host` on a command that writes, with completion
+// from the registered hosts.
+func addHostFlag(cmd *cobra.Command, usage string) {
+	cmd.Flags().StringVar(&remoteHostFlag, "host", "", usage)
+	_ = cmd.RegisterFlagCompletionFunc("host",
+		func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return remoteHostNames(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+		})
+}
+
+// targetHost is the host the current command acts on, normalised: the empty
+// string for this machine, so a params struct can carry it unconditionally.
+func targetHost() string {
+	if state.IsLocalhost(remoteHostFlag) {
+		return ""
+	}
+	return remoteHostFlag
+}
+
+// hostParams is the wire form of the flag.
+func hostParams() rpc.HostParams { return rpc.HostParams{Host: targetHost()} }
+
+// onRemoteHost reports whether this command was pointed at another machine.
+func onRemoteHost() bool { return targetHost() != "" }
+
+// connectForHostWrite dials the daemon for a write that may be aimed at a
+// remote host. Writing needs the daemon either way (contract §20); a remote
+// write needs it because the bridge lives there, which is worth saying rather
+// than falling back to a direct scan of the wrong machine.
+func connectForHostWrite(ctx context.Context) (*client.Client, error) {
+	if onRemoteHost() && noDaemonFlag {
+		return nil, fmt.Errorf("--host %s needs the daemon: the connection to that host lives there\nhint: drop --no-daemon",
+			remoteHostFlag)
+	}
+	return connectForWrite(ctx)
+}
+
+// hostSnapshot reads the port table a command selects its targets from, from
+// whichever machine `--host` named.
+func hostSnapshot(ctx context.Context, c *client.Client) ([]ports.ListeningPort, error) {
+	return daemonList(ctx, c, rpc.PortsListParams{HostParams: hostParams(), All: true})
+}

--- a/internal/cmd/hostflag_test.go
+++ b/internal/cmd/hostflag_test.go
@@ -1,0 +1,268 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// `--host` at the CLI level: a real daemon over a real socket, with a stand-in
+// for the SSH bridge behind it. The point is the routing decision and what the
+// user sees, not the transport — internal/remote's integration tests drive the
+// real bridge.
+
+// fakeHostRouter is one registered host whose daemon is a map of canned
+// answers. It records what was forwarded, which is how these tests check that
+// `--host` reached the wire rather than being silently dropped.
+type fakeHostRouter struct {
+	name    string
+	replies map[string]any
+	calls   []forwarded
+}
+
+type forwarded struct {
+	host   string
+	method string
+	params string
+}
+
+func (f *fakeHostRouter) Known(name string) bool { return name == f.name }
+
+func (f *fakeHostRouter) Forward(_ context.Context, host, method string, params json.RawMessage) (json.RawMessage, daemon.RemoteStream, error) {
+	f.calls = append(f.calls, forwarded{host: host, method: method, params: string(params)})
+	reply, ok := f.replies[method]
+	if !ok {
+		return nil, nil, rpc.NewError(rpc.CodeNotFound, "the fake host does not serve "+method, "")
+	}
+	raw, err := json.Marshal(reply)
+	if err != nil {
+		return nil, nil, err
+	}
+	return raw, nil, nil
+}
+
+func (f *fakeHostRouter) sawMethod(method string) *forwarded {
+	for i := range f.calls {
+		if f.calls[i].method == method {
+			return &f.calls[i]
+		}
+	}
+	return nil
+}
+
+// startDaemonForHostTests runs a daemon whose remote rows and router are the
+// test's own, and points the CLI at it.
+func startDaemonForHostTests(t *testing.T, router daemon.Router, remote func() state.Rows) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the unix-socket harness does not apply to named pipes")
+	}
+	dir, err := os.MkdirTemp("", "sn")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socket := filepath.Join(dir, "d.sock")
+
+	loop := scanner.New(scanner.Options{DaemonVersion: "test"})
+	srv := daemon.New(daemon.Options{Socket: socket, Version: "test", Scanner: loop})
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = srv.Serve(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		<-srv.Done()
+	})
+	if err := client.WaitForSocket(ctx, socket, 5*time.Second); err != nil {
+		t.Fatalf("daemon did not come up: %v", err)
+	}
+
+	// After the daemon is up, not before: internal/remote's OnStart hook
+	// installs the real manager as both the remote rows and the router, and
+	// this test's stand-ins have to be what is in place when the CLI calls.
+	if remote != nil {
+		loop.SetRemote(remote)
+	}
+	daemon.SetRouter(router)
+	t.Cleanup(func() { daemon.SetRouter(nil) })
+
+	dial := func(ctx context.Context) (*client.Client, error) {
+		return client.Dial(ctx, client.ClientInfo{Name: "cli", Version: "test", Socket: socket})
+	}
+	prevDial, prevWrite := dialDaemon, connectForWrite
+	dialDaemon, connectForWrite = dial, dial
+	t.Cleanup(func() { dialDaemon, connectForWrite = prevDial, prevWrite })
+}
+
+// onHost points the current command at a host for one test.
+func onHost(t *testing.T, name string) {
+	t.Helper()
+	prev := remoteHostFlag
+	remoteHostFlag = name
+	t.Cleanup(func() { remoteHostFlag = prev })
+}
+
+// TestKillHostGoesToTheRemoteDaemon: `sonar kill 3000 --host fake` selects its
+// target from the remote's port table and kills it there. Nothing on this
+// machine is touched — the local daemon never even scans for it.
+func TestKillHostGoesToTheRemoteDaemon(t *testing.T) {
+	resetRouting(t)
+	setKillFlags(t, false, true)
+	onHost(t, "fake")
+
+	router := &fakeHostRouter{
+		name: "fake",
+		replies: map[string]any{
+			"ports.list": rpc.PortsListResult{Ports: []state.Port{{
+				Host: state.LocalhostName, Port: 3000, BindAddress: "127.0.0.1",
+				PID: 4242, Process: "node", DisplayName: "api",
+			}}},
+			"ports.kill": rpc.KillEnvelope{
+				MutationResult: rpc.MutationResult{OK: true, Affected: []string{"3000:127.0.0.1"}},
+				Results: []state.KillResult{{
+					Host: state.LocalhostName, Port: 3000, BindAddress: "127.0.0.1",
+					PID: 4242, Name: "api", Method: state.MethodSIGTERM, OK: true,
+				}},
+			},
+		},
+	}
+	startDaemonForHostTests(t, router, nil)
+
+	out, err := runKillCmd(t, "3000")
+	if err != nil {
+		t.Fatalf("kill --host: %v\n%s", err, out)
+	}
+
+	list := router.sawMethod("ports.list")
+	if list == nil {
+		t.Fatal("the target was not selected from the remote's port table")
+	}
+	if list.host != "fake" {
+		t.Errorf("ports.list went to %q, want fake", list.host)
+	}
+	kill := router.sawMethod("ports.kill")
+	if kill == nil {
+		t.Fatal("ports.kill never reached the remote host")
+	}
+	if kill.host != "fake" {
+		t.Errorf("ports.kill went to %q, want fake", kill.host)
+	}
+	// The host named the machine; it must not also travel as a param the far
+	// side would have to ignore.
+	if strings.Contains(kill.params, `"host"`) {
+		t.Errorf("forwarded params still carry a host: %s", kill.params)
+	}
+	if !strings.Contains(kill.params, `"port":3000`) {
+		t.Errorf("forwarded params = %s, want the selector", kill.params)
+	}
+
+	// The row the user sees is attributed to the host it happened on, and the
+	// key is the one the state stream uses for that row.
+	var rows []state.KillResult
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not the result list: %v\n%s", err, out)
+	}
+	if len(rows) != 1 || rows[0].Host != "fake" {
+		t.Fatalf("result = %+v, want one row tagged fake", rows)
+	}
+}
+
+// A write to another machine has nowhere to fall back to, and says so.
+func TestKillHostRefusesWithoutTheDaemon(t *testing.T) {
+	resetRouting(t)
+	setKillFlags(t, false, false)
+	onHost(t, "fake")
+
+	prev := noDaemonFlag
+	noDaemonFlag = true
+	t.Cleanup(func() { noDaemonFlag = prev })
+
+	_, err := runKillCmd(t, "3000")
+	if err == nil {
+		t.Fatal("want an error: --host needs the daemon that holds the bridge")
+	}
+	if !strings.Contains(err.Error(), "--host") {
+		t.Errorf("err = %v, want it to name the flag", err)
+	}
+}
+
+// TestListEveryHostShowsAHostColumn is `sonar list --host "*"`: every machine
+// in one table, with a HOST column that appears because there is more than one.
+func TestListEveryHostShowsAHostColumn(t *testing.T) {
+	resetRouting(t)
+	display.NoColor = true
+
+	remote := func() state.Rows {
+		return state.Rows{
+			Ports: []state.Port{{
+				Host: "fake", Port: 4321, BindAddress: "0.0.0.0",
+				PID: 77, Process: "postgres", DisplayName: "postgres",
+				Type: state.TypeUser, IPVersion: "IPv4",
+			}},
+			Hosts: []state.Host{{Name: "fake", Address: "deploy@box", Status: state.HostConnected}},
+		}
+	}
+	startDaemonForHostTests(t, &fakeHostRouter{name: "fake"}, remote)
+
+	prevHost, prevCols := hostFlag, columnsFlag
+	hostFlag, columnsFlag = allHosts, "port,process"
+	t.Cleanup(func() { hostFlag, columnsFlag = prevHost, prevCols })
+
+	rows, _, err := listPorts(context.Background(), listQuery{showApps: true})
+	if err != nil {
+		t.Fatalf(`list --host "*": %v`, err)
+	}
+
+	var sawRemote, sawLocal bool
+	for _, r := range rows {
+		switch r.Host {
+		case "fake":
+			sawRemote = true
+		case state.LocalhostName:
+			sawLocal = true
+		}
+	}
+	if !sawRemote {
+		t.Fatalf(`--host "*" did not include the remote host's rows (%d rows, none tagged fake)`, len(rows))
+	}
+	if !sawLocal && len(rows) > 1 {
+		t.Error(`--host "*" must include this machine too`)
+	}
+
+	out := captureStdout(t, func() {
+		display.RenderTable(os.Stdout, rows, display.TableOptions{Columns: []string{"port", "process"}})
+	})
+	if !strings.Contains(out, "HOST") {
+		t.Errorf("the table has no HOST column even though the rows span hosts:\n%s", out)
+	}
+	if !strings.Contains(out, "fake") {
+		t.Errorf("the table does not name the remote host:\n%s", out)
+	}
+}
+
+// One host, no column: a HOST that says the same thing on every row is noise.
+func TestOneHostGetsNoHostColumn(t *testing.T) {
+	display.NoColor = true
+	rows := []ports.ListeningPort{
+		{Host: state.LocalhostName, Port: 3000, Process: "node"},
+		{Host: state.LocalhostName, Port: 5432, Process: "postgres"},
+	}
+	out := captureStdout(t, func() {
+		display.RenderTable(os.Stdout, rows, display.TableOptions{Columns: []string{"port", "process"}})
+	})
+	if strings.Contains(out, "HOST") {
+		t.Errorf("a single-host table must not carry a HOST column:\n%s", out)
+	}
+}

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -51,6 +51,7 @@ Examples:
   sonar kill --all --project my-app    # one Docker Compose project
   sonar kill 3000 --ip 127.0.0.1       # disambiguate a multi-bind port
   sonar kill 3000 --tree --dry-run     # show the tree, change nothing
+  sonar kill 3000 --host hetzner       # on a registered remote host
 
 A positional argument is read as a port; a number no one is listening on that
 matches a running process is read as a pid.`,
@@ -75,6 +76,7 @@ func init() {
 	killCmd.Flags().BoolVar(&killDryRunFlag, "dry-run", false, "Show what would be killed and do nothing")
 	killCmd.Flags().String("ip", "", "Bind address, when a port is bound to several")
 	killCmd.Flags().BoolVar(&killJSONFlag, "json", false, "Print the result list as JSON")
+	addHostFlag(killCmd, "Kill on a registered remote `host` instead of this machine")
 	killCmd.MarkFlagsMutuallyExclusive("group", "all")
 	killCmd.MarkFlagsMutuallyExclusive("session", "all")
 	killCmd.MarkFlagsMutuallyExclusive("session", "group")
@@ -89,7 +91,23 @@ func runKill(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 || len(killPIDFlag) > 0 {
 			return fmt.Errorf("--session cannot be combined with ports or pids")
 		}
+		if onRemoteHost() {
+			// A session is local daemon state: the agent that started the run
+			// is on this machine, and the remote daemon has never heard of it.
+			return fmt.Errorf("--session and --host cannot be combined: a session is local daemon state")
+		}
 		return killSession(cmd.Context())
+	}
+
+	// A kill on another machine has no direct path: the bridge to that host is
+	// in the daemon, so the daemon does the killing there as well as here.
+	if onRemoteHost() {
+		c, err := connectForHostWrite(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+		return killThroughDaemon(cmd.Context(), c, args, bindIP)
 	}
 
 	// A reachable daemon does the killing, so it rescans straight afterwards

--- a/internal/cmd/kill_test.go
+++ b/internal/cmd/kill_test.go
@@ -16,11 +16,12 @@ import (
 )
 
 func sampleResults() []killer.Result {
+	const here = state.LocalhostName
 	return []killer.Result{
-		{Port: 3000, BindAddress: "127.0.0.1", PID: 400, Name: "esbuild", Method: state.MethodSIGTERM, OK: true},
-		{Port: 3000, BindAddress: "127.0.0.1", PID: 300, Name: "vite", Method: state.MethodSIGKILL, OK: true},
-		{Port: 5432, BindAddress: "0.0.0.0", PID: 0, Name: "db", Method: state.MethodDockerStop, OK: true},
-		{Port: 8080, BindAddress: "127.0.0.1", PID: 900, Name: "nginx", Method: state.MethodNone, OK: false,
+		{Host: here, Port: 3000, BindAddress: "127.0.0.1", PID: 400, Name: "esbuild", Method: state.MethodSIGTERM, OK: true},
+		{Host: here, Port: 3000, BindAddress: "127.0.0.1", PID: 300, Name: "vite", Method: state.MethodSIGKILL, OK: true},
+		{Host: here, Port: 5432, BindAddress: "0.0.0.0", PID: 0, Name: "db", Method: state.MethodDockerStop, OK: true},
+		{Host: here, Port: 8080, BindAddress: "127.0.0.1", PID: 900, Name: "nginx", Method: state.MethodNone, OK: false,
 			Error: "not permitted to signal PID 900"},
 	}
 }
@@ -34,6 +35,7 @@ func TestKillJSONGolden(t *testing.T) {
 	}
 	const want = `[
   {
+    "host": "localhost",
     "port": 3000,
     "bind_address": "127.0.0.1",
     "pid": 400,
@@ -42,6 +44,7 @@ func TestKillJSONGolden(t *testing.T) {
     "ok": true
   },
   {
+    "host": "localhost",
     "port": 3000,
     "bind_address": "127.0.0.1",
     "pid": 300,
@@ -50,6 +53,7 @@ func TestKillJSONGolden(t *testing.T) {
     "ok": true
   },
   {
+    "host": "localhost",
     "port": 5432,
     "bind_address": "0.0.0.0",
     "pid": 0,
@@ -58,6 +62,7 @@ func TestKillJSONGolden(t *testing.T) {
     "ok": true
   },
   {
+    "host": "localhost",
     "port": 8080,
     "bind_address": "127.0.0.1",
     "pid": 900,

--- a/internal/cmd/killall.go
+++ b/internal/cmd/killall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,14 @@ Examples:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		Hint(cmd, HintKillAllToKill(killAllFilterFlag, killAllProjectFlag, killAllYesFlag, killAllForceFlag))
+		opts := killer.Options{Force: killAllForceFlag}
+		if onRemoteHost() {
+			return killSweepThroughDaemon(cmd.Context(),
+				func(snapshot []ports.ListeningPort) ([]killer.Target, error) {
+					return sweepTargets(snapshot, killAllFilterFlag, killAllProjectFlag)
+				}, opts, !killAllYesFlag, false)
+		}
+
 		snapshot := scanForKill()
 		targets, err := sweepTargets(snapshot, killAllFilterFlag, killAllProjectFlag)
 		if err != nil {
@@ -41,7 +50,7 @@ Examples:
 			fmt.Println("No matching ports found.")
 			return nil
 		}
-		opts := killer.Options{Force: killAllForceFlag, Ports: snapshot}
+		opts.Ports = snapshot
 		return killRun(cmd.Context(), targets, snapshot, opts, !killAllYesFlag, false)
 	},
 }
@@ -51,5 +60,6 @@ func init() {
 	killAllCmd.Flags().StringVar(&killAllProjectFlag, "project", "", "Filter by Docker Compose project name")
 	killAllCmd.Flags().BoolVarP(&killAllYesFlag, "yes", "y", false, "Skip confirmation prompt")
 	killAllCmd.Flags().BoolVarP(&killAllForceFlag, "force", "f", false, "Send SIGKILL instead of SIGTERM")
+	addHostFlag(killAllCmd, "Kill on a registered remote `host` instead of this machine")
 	rootCmd.AddCommand(killAllCmd)
 }

--- a/internal/cmd/killroute.go
+++ b/internal/cmd/killroute.go
@@ -8,6 +8,7 @@ import (
 	"github.com/raskrebs/sonar/internal/daemon/client"
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/ports"
 )
 
 // killThroughDaemon runs `sonar kill` as `ports.kill` / `groups.kill`.
@@ -19,7 +20,7 @@ import (
 // signalling moves: the daemon kills, then rescans and records the port going
 // down, which is what the CLI's own killer could never do (contract §22).
 func killThroughDaemon(ctx context.Context, c *client.Client, args []string, bindIP string) error {
-	snapshot, err := daemonList(ctx, c, rpc.PortsListParams{All: true})
+	snapshot, err := hostSnapshot(ctx, c)
 	if err != nil {
 		return cliError(err)
 	}
@@ -67,10 +68,11 @@ func killCallFor(targets []killer.Target, opts killer.Options) killCall {
 		return func(ctx context.Context, c *client.Client, dryRun bool) ([]killer.Result, error) {
 			var env rpc.KillEnvelope
 			err := c.Call(ctx, "groups.kill", rpc.GroupsKillParams{
-				Name:    name,
-				Force:   opts.Force,
-				GraceMs: graceMs(opts),
-				DryRun:  dryRun,
+				HostParams: hostParams(),
+				Name:       name,
+				Force:      opts.Force,
+				GraceMs:    graceMs(opts),
+				DryRun:     dryRun,
 			}, &env)
 			return env.Results, err
 		}
@@ -80,12 +82,13 @@ func killCallFor(targets []killer.Target, opts killer.Options) killCall {
 	return func(ctx context.Context, c *client.Client, dryRun bool) ([]killer.Result, error) {
 		var env rpc.KillEnvelope
 		err := c.Call(ctx, "ports.kill", rpc.PortsKillParams{
-			Targets:  selectors,
-			Tree:     opts.Tree,
-			Force:    opts.Force,
-			GraceMs:  graceMs(opts),
-			Escalate: opts.Escalate,
-			DryRun:   dryRun,
+			HostParams: hostParams(),
+			Targets:    selectors,
+			Tree:       opts.Tree,
+			Force:      opts.Force,
+			GraceMs:    graceMs(opts),
+			Escalate:   opts.Escalate,
+			DryRun:     dryRun,
 		}, &env)
 		return env.Results, err
 	}
@@ -181,4 +184,60 @@ func killSession(ctx context.Context) error {
 		return cliError(err)
 	}
 	return reportKill(os.Stdout, results, snapshot, killJSONFlag, killDryRunFlag)
+}
+
+// killSweepThroughDaemon is what `kill-all` and `down` do when they are pointed
+// at another machine: the same target selection they always do, against that
+// host's port table, killed by that host's daemon. Locally they still kill
+// directly — they are aliases of `sonar kill`, and a machine with no daemon
+// running must keep working (contract §20).
+func killSweepThroughDaemon(ctx context.Context, selectTargets func([]ports.ListeningPort) ([]killer.Target, error),
+	opts killer.Options, confirm, asJSON bool) error {
+	c, err := connectForHostWrite(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	snapshot, err := hostSnapshot(ctx, c)
+	if err != nil {
+		return cliError(err)
+	}
+	targets, err := selectTargets(snapshot)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		fmt.Println("No matching ports found.")
+		return nil
+	}
+
+	selectors := killSelectors(targets)
+	call := func(dryRun bool) ([]killer.Result, error) {
+		var env rpc.KillEnvelope
+		err := c.Call(ctx, "ports.kill", rpc.PortsKillParams{
+			HostParams: hostParams(),
+			Targets:    selectors,
+			Force:      opts.Force,
+			GraceMs:    graceMs(opts),
+			DryRun:     dryRun,
+		}, &env)
+		return env.Results, err
+	}
+
+	if confirm {
+		plan, err := call(true)
+		if err != nil {
+			return cliError(err)
+		}
+		if !confirmPlan(plan, snapshot) {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+	results, err := call(false)
+	if err != nil {
+		return cliError(err)
+	}
+	return reportKill(os.Stdout, results, snapshot, asJSON, false)
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -55,7 +55,9 @@ func init() {
 		"Read a registered `host` through the daemon, \"*\" for every host, or scan any user@hostname over SSH")
 	_ = listCmd.RegisterFlagCompletionFunc("host",
 		func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-			return remoteHostNames(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
+			// Only `list` reads every host at once, so only `list` offers it.
+			return append([]string{allHosts}, remoteHostNames(cmd.Context())...),
+				cobra.ShellCompDirectiveNoFileComp
 		})
 	listCmd.Flags().BoolVarP(&ipv4Flag, "ipv4", "4", false, "Show only IPv4 ports")
 	listCmd.Flags().BoolVarP(&ipv6Flag, "ipv6", "6", false, "Show only IPv6 ports")

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -52,7 +52,7 @@ func init() {
 	listCmd.Flags().BoolVar(&healthFlag, "health", false, "Run HTTP health checks on each port")
 	listCmd.Flags().BoolVar(&statsFlag, "stats", false, "Include resource stats (CPU, memory, threads, uptime, state)")
 	listCmd.Flags().StringVar(&hostFlag, "host", "",
-		"Read a registered `host` through the daemon, or scan any user@hostname over SSH")
+		"Read a registered `host` through the daemon, \"*\" for every host, or scan any user@hostname over SSH")
 	_ = listCmd.RegisterFlagCompletionFunc("host",
 		func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return remoteHostNames(cmd.Context()), cobra.ShellCompDirectiveNoFileComp
@@ -264,24 +264,34 @@ func listPorts(ctx context.Context, q listQuery) ([]ports.ListeningPort, *groups
 	if hostFlag != "" && q.session != "" {
 		return nil, nil, errors.New("--session and --host cannot be combined: a session is local daemon state")
 	}
+	if hostFlag == allHosts {
+		rows, err := listEveryHost(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		return applyListFilters(rows, q), nil, nil
+	}
 	if hostFlag != "" {
 		// A registered host has a daemon and a bridge, so its ports come back
 		// through the local daemon already attributed, named and grouped. The
 		// SSH scan below is the fallback for a host that has neither.
 		if c := routeRemote(ctx, hostFlag); c != nil {
 			defer c.Close()
-			var res rpc.PortsListResult
-			err := remoteCall(ctx, c, hostFlag, "ports.list", rpc.PortsListParams{
-				Group:     strPtrOrNil(q.group),
-				Filter:    strPtrOrNil(q.filter),
-				All:       q.showApps,
-				IPVersion: strPtrOrNil(q.ipVersion),
-				Include:   listInclude(statsFlag, healthFlag),
-			}, &res)
+			// `host` on the method itself: the local daemon forwards the read
+			// over that host's bridge and hands the rows back tagged with it
+			// (contract §43).
+			rows, err := daemonList(ctx, c, rpc.PortsListParams{
+				HostParams: rpc.HostParams{Host: hostFlag},
+				Group:      strPtrOrNil(q.group),
+				Filter:     strPtrOrNil(q.filter),
+				All:        q.showApps,
+				IPVersion:  strPtrOrNil(q.ipVersion),
+				Include:    listInclude(statsFlag, healthFlag),
+			})
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, cliError(err)
 			}
-			return state.ToListeningAll(res.Ports), nil, nil
+			return rows, nil, nil
 		}
 
 		// A remote host with no daemon is scanned over SSH; the local daemon
@@ -337,6 +347,35 @@ func listPorts(ctx context.Context, q listQuery) ([]ports.ListeningPort, *groups
 	// This is the no-daemon path, so it happens per command.
 	_, index := groups.Attribute(results)
 	return applyListFilters(results, q), index, nil
+}
+
+// allHosts is what `--host "*"` spells: every machine sonar knows about, this
+// one included.
+const allHosts = "*"
+
+// listEveryHost reads the whole multiplexed table. It goes through
+// `state.snapshot {hosts: ["*"]}` rather than a read per host because that is
+// the one call that already means "every machine": the daemon has the rows
+// from every bridge in hand, tagged and keyed, and does not have to go back
+// over the network for them.
+func listEveryHost(ctx context.Context) ([]ports.ListeningPort, error) {
+	if noDaemonFlag {
+		return nil, errors.New(`--host "*" needs the daemon: the other hosts are connected from there`)
+	}
+	c, err := dialDaemon(ctx)
+	if err != nil {
+		return nil, fmt.Errorf(`--host "*" needs the daemon: %w`, err)
+	}
+	defer c.Close()
+
+	var snap state.Snapshot
+	if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{
+		Hosts:   []string{allHosts},
+		Include: listInclude(statsFlag, healthFlag),
+	}, &snap); err != nil {
+		return nil, cliError(err)
+	}
+	return state.ToListeningAll(snap.Ports), nil
 }
 
 // applyListFilters is the direct path's copy of what the daemon does to

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -34,6 +34,18 @@ var logsCmd = &cobra.Command{
 
 		bindIP, _ := cmd.Flags().GetString("ip")
 
+		if onRemoteHost() {
+			// Another machine's output only reaches this terminal through the
+			// daemon that holds the bridge; there is no direct path to fall
+			// back to.
+			c, err := connectForHostWrite(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+			return logsThroughDaemon(cmd.Context(), c, port, bindIP)
+		}
+
 		if c := daemonClient(cmd.Context()); c != nil {
 			defer c.Close()
 			return logsThroughDaemon(cmd.Context(), c, port, bindIP)
@@ -97,9 +109,13 @@ func logsThroughDaemon(ctx context.Context, c *client.Client, port int, bindIP s
 		display.Cyan(fmt.Sprintf("%d", row.PID)))
 
 	params := rpc.PortsLogsParams{
-		Selector: rpc.Selector{Port: &row.Port, BindAddress: strPtrOrNil(row.BindAddress)},
-		Lines:    logsLinesFlag,
-		Follow:   logsFollow,
+		Selector: rpc.Selector{
+			HostParams:  hostParams(),
+			Port:        &row.Port,
+			BindAddress: strPtrOrNil(row.BindAddress),
+		},
+		Lines:  logsLinesFlag,
+		Follow: logsFollow,
 	}
 
 	if !logsFollow {
@@ -156,7 +172,7 @@ func printLogHeader(source string) {
 // daemonFindPort resolves one port through ports.list, so the header a command
 // prints names the same process the daemon is about to act on.
 func daemonFindPort(ctx context.Context, c *client.Client, port int, bindIP string) (*ports.ListeningPort, error) {
-	rows, err := daemonList(ctx, c, rpc.PortsListParams{All: true})
+	rows, err := hostSnapshot(ctx, c)
 	if err != nil {
 		return nil, cliError(err)
 	}
@@ -190,5 +206,6 @@ func init() {
 	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", true, "Follow log output (stream continuously)")
 	logsCmd.Flags().IntVarP(&logsLinesFlag, "lines", "n", 10, "Number of trailing lines to show before following")
 	logsCmd.Flags().String("ip", "", "Specify bind address when a port is bound to multiple IPs")
+	addHostFlag(logsCmd, "Tail a port's output on a registered remote `host` instead of this machine")
 	rootCmd.AddCommand(logsCmd)
 }

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -42,6 +42,7 @@ func init() {
 	renameCmd.Flags().BoolVar(&renamePID, "pid", false, "Read the argument as a pid instead of a port")
 	renameCmd.Flags().String("ip", "", "Specify bind address when a port is bound to multiple IPs")
 	renameCmd.Flags().BoolVar(&renameJSON, "json", false, "Output as JSON")
+	addHostFlag(renameCmd, "Rename a port on a registered remote `host` instead of this machine")
 	rootCmd.AddCommand(renameCmd)
 }
 
@@ -55,7 +56,7 @@ func renameRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := connectForWrite(cmd.Context())
+	c, err := connectForHostWrite(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -84,9 +85,9 @@ func selectorFrom(arg string, asPID bool, cmd *cobra.Command) (rpc.Selector, err
 		return rpc.Selector{}, fmt.Errorf("%q is not a port or a pid", arg)
 	}
 	if asPID {
-		return rpc.Selector{PID: &n}, nil
+		return rpc.Selector{HostParams: hostParams(), PID: &n}, nil
 	}
-	sel := rpc.Selector{Port: &n}
+	sel := rpc.Selector{HostParams: hostParams(), Port: &n}
 	if cmd != nil {
 		if ip, _ := cmd.Flags().GetString("ip"); ip != "" {
 			sel.BindAddress = &ip
@@ -115,7 +116,10 @@ func writeValue(args []string, clear bool, what, example string) (*string, error
 
 // connectForWrite dials the daemon, starting it if it is not running. A daemon
 // that will not start is fatal here: there is nowhere else to write to.
-func connectForWrite(ctx context.Context) (*client.Client, error) {
+//
+// It is a variable for the same reason dialDaemon is: the tests point the CLI
+// at a daemon of their own rather than at the user's.
+var connectForWrite = func(ctx context.Context) (*client.Client, error) {
 	c, err := client.Connect(ctx, client.ClientInfo{Name: "cli", Version: selfupdate.Version})
 	if err != nil {
 		return nil, fmt.Errorf("%w\nhint: the daemon log is at %s", err, daemon.LogPath())

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -44,6 +44,7 @@ var upCmd = &cobra.Command{
 func init() {
 	upCmd.Flags().StringSliceVar(&upOnly, "only", nil, "Start only these services (comma separated)")
 	upCmd.Flags().BoolVar(&upJSON, "json", false, "Output as JSON")
+	addHostFlag(upCmd, "Start the group on a registered remote `host` instead of this machine")
 	rootCmd.AddCommand(upCmd)
 }
 
@@ -53,7 +54,7 @@ func upRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := connectForWrite(cmd.Context())
+	c, err := connectForHostWrite(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -72,11 +73,18 @@ func upRun(cmd *cobra.Command, args []string) error {
 // upParams turns the command line into groups.start params: a name when one was
 // given, the config at or above the working directory otherwise.
 func upParams(args []string) (rpc.GroupsStartParams, error) {
-	params := rpc.GroupsStartParams{Only: upOnly}
+	params := rpc.GroupsStartParams{HostParams: hostParams(), Only: upOnly}
 	if len(args) == 1 {
 		name := strings.TrimSpace(args[0])
 		params.Name = &name
 		return params, nil
+	}
+	if onRemoteHost() {
+		// The config path below is a path on this machine, and the remote
+		// daemon resolves groups against its own .sonar.yaml files. Naming the
+		// group is the only thing that can mean the same on both sides.
+		return params, fmt.Errorf("name the group to start on %s: `sonar up <group> --host %s`",
+			remoteHostFlag, remoteHostFlag)
 	}
 
 	wd, err := os.Getwd()

--- a/internal/daemon/client/stream.go
+++ b/internal/daemon/client/stream.go
@@ -91,17 +91,11 @@ func (s *Stream) Cancel(ctx context.Context) error {
 // arrive while the reply is still being decoded are buffered against the
 // subscription id, so nothing is lost in the gap.
 func (c *Client) Stream(ctx context.Context, method string, params, result any) (*Stream, error) {
-	var reply struct {
-		SubscriptionID string `json:"subscription_id"`
-	}
-	raw := json.RawMessage(nil)
-	if err := c.Call(ctx, method, params, &raw); err != nil {
+	raw, st, err := c.CallStream(ctx, method, params)
+	if err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(raw, &reply); err != nil {
-		return nil, err
-	}
-	if reply.SubscriptionID == "" {
+	if st == nil {
 		return nil, errors.New("daemon: " + method + " did not return a subscription_id")
 	}
 	if result != nil {
@@ -109,11 +103,36 @@ func (c *Client) Stream(ctx context.Context, method string, params, result any) 
 			return nil, err
 		}
 	}
+	return st, nil
+}
+
+// CallStream calls a method without knowing whether it streams. It returns the
+// raw reply and, when that reply carried a subscription id, the stream its
+// chunks are arriving on; a plain method answers with a nil stream.
+//
+// It exists for the remote-host bridge, which forwards whatever method a client
+// asked for and has to relay the chunks if there are any. Registering the
+// stream here rather than after inspecting the reply is what keeps a chunk that
+// overtakes the caller from being lost: the id is claimed against whatever the
+// read loop has already buffered under it.
+func (c *Client) CallStream(ctx context.Context, method string, params any) (json.RawMessage, *Stream, error) {
+	raw := json.RawMessage(nil)
+	if err := c.Call(ctx, method, params, &raw); err != nil {
+		return nil, nil, err
+	}
+	var reply struct {
+		SubscriptionID string `json:"subscription_id"`
+	}
+	// A result that is not an object cannot be a stream reply, and that is not
+	// an error: plenty of methods answer with a bare value.
+	if err := json.Unmarshal(raw, &reply); err != nil || reply.SubscriptionID == "" {
+		return raw, nil, nil
+	}
 
 	st := c.streamFor(reply.SubscriptionID)
 	st.c, st.id = c, reply.SubscriptionID
 	c.claim(reply.SubscriptionID)
-	return st, nil
+	return raw, st, nil
 }
 
 // claim marks a stream as handed to its caller. A stream that has already

--- a/internal/daemon/conn.go
+++ b/internal/daemon/conn.go
@@ -292,7 +292,10 @@ func (c *Conn) serve(ctx context.Context, msg rpc.Message) {
 	}
 
 	req := &Request{Method: msg.Method, ID: msg.ID, Params: msg.Params, Conn: c, Runtime: c.srv.runtime}
-	result, err := h(ctx, req)
+	// serveRequest is h plus the one thing that happens in front of every
+	// handler: a request naming a remote host goes over that host's bridge
+	// instead of to the handler (hostroute.go).
+	result, err := serveRequest(ctx, req, h)
 	switch {
 	case errors.Is(err, ErrResponseSent):
 		// The handler wrote its own reply.

--- a/internal/daemon/hostroute.go
+++ b/internal/daemon/hostroute.go
@@ -1,0 +1,558 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// Acting on a remote host (remote-hosts spec, "Actions on a remote host").
+//
+// Every method this daemon serves takes an optional `host`. Absent means this
+// machine and nothing changes; a registered host name means the call is
+// forwarded to that host's daemon over its bridge and its answer comes back in
+// the same envelope. The handlers know nothing about it: routing happens once,
+// in front of the dispatcher, which is why `host` works on a method the day it
+// is registered rather than the day someone remembers to thread it through.
+//
+// The forwarded call is the caller's call minus what named the host: the `host`
+// field is dropped and a `"<host>/…"` key is un-prefixed, so the far side reads
+// params it would have received from a client on its own machine.
+
+// remoteCancelTimeout bounds the stream.cancel a relay sends to the far side
+// once its own client has gone. The relay is finished either way; this is only
+// how long it is worth waiting to be polite about it.
+const remoteCancelTimeout = 5 * time.Second
+
+// Router is the seam internal/remote fills in. It is an interface here so this
+// package never imports the bridge (contract §8) and so a test can route
+// somewhere that is not SSH.
+type Router interface {
+	// Known reports whether name is a registered remote host.
+	Known(name string) bool
+	// Forward sends one method to a host's daemon. A non-nil stream means the
+	// far side answered with a subscription id and the chunks are still
+	// coming; the reply is returned either way.
+	Forward(ctx context.Context, host, method string, params json.RawMessage) (json.RawMessage, RemoteStream, error)
+}
+
+// RemoteStream is a streaming method running on another host: its chunks, its
+// single end, and the way to stop it early.
+type RemoteStream interface {
+	Chunks() <-chan json.RawMessage
+	End() <-chan RemoteStreamEnd
+	Cancel(ctx context.Context) error
+}
+
+// RemoteStreamEnd is the far side's stream.end: the method's final payload, or
+// the error it failed with.
+type RemoteStreamEnd struct {
+	Data json.RawMessage
+	Err  *rpc.Error
+}
+
+var (
+	routerMu sync.RWMutex
+	router   Router
+)
+
+// SetRouter installs the remote router. Passing nil removes it, which is what
+// a daemon with no remote support looks like: `host` then only ever names
+// localhost.
+func SetRouter(r Router) {
+	routerMu.Lock()
+	router = r
+	routerMu.Unlock()
+}
+
+// currentRouter returns the installed router, or nil.
+func currentRouter() Router {
+	routerMu.RLock()
+	defer routerMu.RUnlock()
+	return router
+}
+
+// knownHost reports whether name is a registered remote host right now.
+func knownHost(name string) bool {
+	r := currentRouter()
+	return r != nil && r.Known(name)
+}
+
+// hostRoute is what one method's params and result look like from the routing
+// layer: where a host may be named, and whether the keys coming back are port
+// keys that need the host prefix a client's stream would have given them.
+type hostRoute struct {
+	// selector marks params that are, or embed, a Selector at the top level.
+	selector bool
+	// targets marks params carrying a `targets` array of Selectors.
+	targets bool
+	// nameFields are params fields whose value may carry a `"<host>/"` prefix,
+	// because the client is handing back a group or session key.
+	nameFields []string
+	// portKeys marks a result whose `affected` entries are port keys, so a
+	// forwarded answer namespaces them the way the stream does. (No result's
+	// `key` field is a port key: `ports.rename` and `groups.assign` report the
+	// store's own identity there, and `claims.*` a claim key.)
+	portKeys bool
+}
+
+// hostRoutes is the per-method detail. A method that is not listed still takes
+// a top-level `host`; the table only says where else a host can hide and what
+// the result's keys mean.
+var hostRoutes = map[string]hostRoute{
+	"ports.inspect":     {selector: true},
+	"ports.logs":        {selector: true},
+	"ports.rename":      {selector: true, portKeys: true},
+	"groups.assign":     {selector: true, portKeys: true},
+	"ports.kill":        {targets: true, portKeys: true},
+	"groups.kill":       {nameFields: []string{"name"}, portKeys: true},
+	"groups.start":      {nameFields: []string{"name"}, portKeys: true},
+	"groups.inspect":    {nameFields: []string{"name"}},
+	"groups.config.get": {nameFields: []string{"name"}},
+	"sessions.kill":     {nameFields: []string{"id"}, portKeys: true},
+	"sessions.inspect":  {nameFields: []string{"id"}},
+	"claims.acquire":    {portKeys: true},
+	"runs.spawn":        {portKeys: true},
+}
+
+// unroutableMethods never take a host.
+//
+// `state.*` has its own, richer host selection (`{hosts: [...]}`, §39) and is
+// the one place a client sees several machines at once. `stream.cancel` is
+// about a subscription this connection owns, and a relayed stream is cancelled
+// through it, not around it. `daemon.hello` and `daemon.shutdown` are about the
+// daemon the client is attached to. And `remote.*` is the bridge itself:
+// forwarding it would chain hosts, which the design rules out.
+func unroutable(method string) bool {
+	switch {
+	case strings.HasPrefix(method, "state."),
+		strings.HasPrefix(method, "stream."),
+		strings.HasPrefix(method, "remote."):
+		return true
+	case method == "daemon.hello", method == "daemon.shutdown":
+		return true
+	}
+	return false
+}
+
+// routeRequest resolves and strips the host a request names. It returns the
+// host ("" for this machine) and the params the callee should see, which for a
+// local call are the caller's own params with any `key` selector expanded.
+func routeRequest(method string, params json.RawMessage) (string, json.RawMessage, error) {
+	if unroutable(method) {
+		return "", params, nil
+	}
+	fields, ok := decodeObject(params)
+	if !ok {
+		return "", params, nil
+	}
+
+	route := hostRoutes[method]
+	hosts := newHostSet()
+	rewrote := false
+
+	if raw, present := fields["host"]; present {
+		name, err := decodeString(raw)
+		if err != nil {
+			return "", nil, rpc.NewError(rpc.CodeInvalidParams, "host must be a string", "")
+		}
+		if strings.TrimSpace(name) != "" {
+			hosts.add(name)
+		}
+		delete(fields, "host")
+		rewrote = true
+	}
+
+	if route.selector {
+		changed, err := normalizeSelector(fields, hosts)
+		if err != nil {
+			return "", nil, err
+		}
+		rewrote = rewrote || changed
+	}
+	if route.targets {
+		changed, err := normalizeTargets(fields, hosts)
+		if err != nil {
+			return "", nil, err
+		}
+		rewrote = rewrote || changed
+	}
+	for _, name := range route.nameFields {
+		if stripNamePrefix(fields, name, hosts) {
+			rewrote = true
+		}
+	}
+
+	host, err := hosts.one()
+	if err != nil {
+		return "", nil, err
+	}
+	if state.IsLocalhost(host) {
+		host = ""
+	}
+	if !rewrote {
+		// Nothing named a host and nothing needed expanding, which is the
+		// overwhelmingly common case: hand the handler the client's own bytes.
+		return host, params, nil
+	}
+
+	out, err := json.Marshal(fields)
+	if err != nil {
+		return "", nil, rpc.NewError(rpc.CodeInternal, "rewriting params: "+err.Error(), "")
+	}
+	return host, out, nil
+}
+
+// hostSet collects the hosts one request names, so naming two is an error
+// rather than a coin toss.
+type hostSet struct {
+	names []string
+	seen  map[string]bool
+}
+
+func newHostSet() *hostSet { return &hostSet{seen: map[string]bool{}} }
+
+func (h *hostSet) add(name string) {
+	name = state.HostOf(strings.TrimSpace(name))
+	if h.seen[name] {
+		return
+	}
+	h.seen[name] = true
+	h.names = append(h.names, name)
+}
+
+// one returns the single host the request named, or an error when it named
+// more than one. A call acts on one machine: a kill that half succeeded on two
+// hosts has no envelope that could describe it.
+func (h *hostSet) one() (string, error) {
+	switch len(h.names) {
+	case 0:
+		return "", nil
+	case 1:
+		return h.names[0], nil
+	}
+	sorted := append([]string(nil), h.names...)
+	sort.Strings(sorted)
+	return "", rpc.NewError(rpc.CodeInvalidParams,
+		"one call acts on one host, but this one names "+strings.Join(sorted, " and "),
+		"send one call per host")
+}
+
+// normalizeSelector reads the host out of a top-level selector and expands its
+// `key` into port and bind_address.
+func normalizeSelector(fields map[string]json.RawMessage, hosts *hostSet) (bool, error) {
+	raw, present := fields["key"]
+	if !present {
+		return false, nil
+	}
+	delete(fields, "key")
+
+	key, err := decodeString(raw)
+	if err != nil {
+		return true, rpc.NewError(rpc.CodeInvalidParams, "key must be a string", "")
+	}
+	if strings.TrimSpace(key) == "" {
+		return true, nil
+	}
+	for _, field := range []string{"port", "pid", "run_id", "proxy_id"} {
+		if _, dup := fields[field]; dup {
+			return true, rpc.NewError(rpc.CodeInvalidSelector,
+				"key cannot be combined with "+field,
+				`a key is the whole selector: {"key": "3000:127.0.0.1"}`)
+		}
+	}
+
+	host, rest := state.SplitHostPrefix(key, knownHost)
+	if host != "" {
+		hosts.add(host)
+	}
+	port, bind, ok := state.ParsePortKey(rest)
+	if !ok {
+		return true, rpc.NewError(rpc.CodeInvalidSelector,
+			"cannot read "+key+" as a port key",
+			`keys look like "3000", "3000:127.0.0.1" or "hetzner/3000:127.0.0.1"`)
+	}
+	fields["port"] = json.RawMessage(strconv.Itoa(port))
+	if bind != "" {
+		encoded, _ := json.Marshal(bind)
+		fields["bind_address"] = encoded
+	}
+	return true, nil
+}
+
+// normalizeTargets does the same for every selector in a `targets` array.
+func normalizeTargets(fields map[string]json.RawMessage, hosts *hostSet) (bool, error) {
+	raw, present := fields["targets"]
+	if !present {
+		return false, nil
+	}
+	var list []json.RawMessage
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return false, nil // let the handler produce the shape error
+	}
+	rewrote := false
+	for i, item := range list {
+		sel, ok := decodeObject(item)
+		if !ok {
+			continue
+		}
+		if name, present := sel["host"]; present {
+			value, err := decodeString(name)
+			if err != nil {
+				return true, rpc.NewError(rpc.CodeInvalidParams, "host must be a string", "")
+			}
+			if strings.TrimSpace(value) != "" {
+				hosts.add(value)
+			}
+			delete(sel, "host")
+			rewrote = true
+		}
+		changed, err := normalizeSelector(sel, hosts)
+		if err != nil {
+			return true, err
+		}
+		if !changed && !rewrote {
+			continue
+		}
+		rewrote = true
+		encoded, err := json.Marshal(sel)
+		if err != nil {
+			return true, rpc.NewError(rpc.CodeInternal, "rewriting a selector: "+err.Error(), "")
+		}
+		list[i] = encoded
+	}
+	if !rewrote {
+		return false, nil
+	}
+	encoded, err := json.Marshal(list)
+	if err != nil {
+		return true, rpc.NewError(rpc.CodeInternal, "rewriting targets: "+err.Error(), "")
+	}
+	fields["targets"] = encoded
+	return true, nil
+}
+
+// stripNamePrefix takes a `"<host>/"` off a group or session name.
+func stripNamePrefix(fields map[string]json.RawMessage, field string, hosts *hostSet) bool {
+	raw, present := fields[field]
+	if !present {
+		return false
+	}
+	value, err := decodeString(raw)
+	if err != nil {
+		return false // not a string: the handler's business, not ours
+	}
+	host, rest := state.SplitHostPrefix(value, knownHost)
+	if host == "" {
+		return false
+	}
+	hosts.add(host)
+	encoded, _ := json.Marshal(rest)
+	fields[field] = encoded
+	return true
+}
+
+// serveRequest dispatches one request: to the local handler, or across a bridge
+// when the params named a registered host.
+func serveRequest(ctx context.Context, req *Request, h Handler) (any, error) {
+	host, params, err := routeRequest(req.Method, req.Params)
+	if err != nil {
+		return nil, err
+	}
+	req.Params = params
+	if host == "" {
+		return h(ctx, req)
+	}
+	return ForwardTo(ctx, req, host, req.Method, params)
+}
+
+// ForwardTo sends one method to a registered host and answers this connection
+// with what came back: the result verbatim for a plain call, and a relayed
+// stream — local subscription id, chunks as they arrive, `stream.cancel`
+// propagated — for a streaming one.
+//
+// The result is retagged on the way out: rows that call themselves "localhost"
+// are that host's rows from here, and port keys are namespaced the way the
+// state stream namespaces them, so a client can act on what it is handed
+// without knowing which side produced it.
+func ForwardTo(ctx context.Context, req *Request, host, method string, params json.RawMessage) (any, error) {
+	r := currentRouter()
+	if r == nil {
+		return nil, rpc.NewError(rpc.CodeNotFound,
+			"no remote host named "+host,
+			"this daemon has no remote support built in")
+	}
+	if len(params) == 0 {
+		params = json.RawMessage("{}")
+	}
+
+	reply, stream, err := r.Forward(ctx, host, method, params)
+	if err != nil {
+		return nil, err
+	}
+	if stream == nil {
+		return rpc.RemoteCallResult(retagResult(method, host, reply)), nil
+	}
+	return relayStream(ctx, req, host, method, reply, stream)
+}
+
+// relayStream replies with a local subscription id and pumps the far side's
+// chunks onto this connection until it ends.
+func relayStream(ctx context.Context, req *Request, host, method string, reply json.RawMessage, remote RemoteStream) (any, error) {
+	initial := json.RawMessage(retagResult(method, host, reply))
+	return StartStream(ctx, req, initial, func(ctx context.Context, s *Stream) (any, error) {
+		// The local stream is cancelled by stream.cancel, by this connection
+		// dropping and by shutdown. All three mean the same thing to the far
+		// side, and it hears about it as its own stream.cancel.
+		relayed := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), remoteCancelTimeout)
+				_ = remote.Cancel(cancelCtx)
+				cancel()
+			case <-relayed:
+			}
+		}()
+
+		for chunk := range remote.Chunks() {
+			if ctx.Err() != nil {
+				// Cancelled: drain what is still in flight so the far side's
+				// end is read, but stop pushing it at a client that asked to
+				// stop.
+				continue
+			}
+			if err := s.Send(json.RawMessage(retagResult(method, host, chunk))); err != nil {
+				break
+			}
+		}
+		close(relayed)
+
+		end := <-remote.End()
+		if end.Err != nil {
+			return nil, end.Err
+		}
+		if len(end.Data) == 0 {
+			return nil, nil
+		}
+		return json.RawMessage(retagResult(method, host, end.Data)), nil
+	})
+}
+
+// retagResult rewrites a forwarded payload so it describes the host it came
+// from rather than the machine that produced it.
+//
+// Two rules, both mechanical. Every `host` field that says "localhost" (or says
+// nothing) becomes this host's name, at any depth, because a row's `host` is
+// the disambiguator the whole protocol leans on (remote-hosts spec, decision
+// 1). And for the methods whose `affected` holds port keys, those gain the
+// `"<host>/"` prefix the state stream would have given them, so the key in a
+// reply and the key in the stream are the same string.
+//
+// It is a best-effort rewrite: a payload that cannot be parsed is passed
+// through untouched rather than failing a call that already succeeded.
+func retagResult(method, host string, raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 || host == "" {
+		return raw
+	}
+	value, err := decodeAny(raw)
+	if err != nil {
+		return raw
+	}
+	value = retagHosts(value, host)
+	if hostRoutes[method].portKeys {
+		if obj, ok := value.(map[string]any); ok {
+			prefixPortKeys(obj, host)
+		}
+	}
+	out, err := json.Marshal(value)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// retagHosts renames every localhost `host` field in a decoded payload.
+func retagHosts(value any, host string) any {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, item := range v {
+			if key == "host" {
+				if name, ok := item.(string); ok && state.IsLocalhost(name) {
+					v[key] = host
+					continue
+				}
+			}
+			v[key] = retagHosts(item, host)
+		}
+		return v
+	case []any:
+		for i := range v {
+			v[i] = retagHosts(v[i], host)
+		}
+		return v
+	default:
+		return value
+	}
+}
+
+// prefixPortKeys namespaces the port keys in a mutation result.
+func prefixPortKeys(obj map[string]any, host string) {
+	list, ok := obj["affected"].([]any)
+	if !ok {
+		return
+	}
+	for i, item := range list {
+		if key, ok := item.(string); ok && key != "" {
+			list[i] = state.PrefixKey(host, key)
+		}
+	}
+}
+
+// decodeObject reads params as a JSON object, reporting whether they were one.
+// Absent params are an empty object, which is how a method whose fields are all
+// optional is called.
+func decodeObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return map[string]json.RawMessage{}, true
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, false
+	}
+	if fields == nil {
+		fields = map[string]json.RawMessage{}
+	}
+	return fields, true
+}
+
+func decodeString(raw json.RawMessage) (string, error) {
+	if string(raw) == "null" {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", err
+	}
+	return s, nil
+}
+
+// decodeAny decodes a payload with numbers left as they were written, so a pid
+// or a byte count survives the round trip through the retagger unchanged.
+func decodeAny(raw json.RawMessage) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}

--- a/internal/daemon/hostroute.go
+++ b/internal/daemon/hostroute.go
@@ -123,7 +123,7 @@ var hostRoutes = map[string]hostRoute{
 	"runs.spawn":        {portKeys: true},
 }
 
-// unroutableMethods never take a host.
+// unroutable reports the methods that never take a host.
 //
 // `state.*` has its own, richer host selection (`{hosts: [...]}`, §39) and is
 // the one place a client sees several machines at once. `stream.cancel` is
@@ -423,15 +423,18 @@ func relayStream(ctx context.Context, req *Request, host, method string, reply j
 			}
 		}()
 
+		// Every chunk is read, whatever happens to the sending half: the far
+		// side's end is only delivered once its chunks have been, so a relay
+		// that stopped draining would never learn that the stream is over.
+		// A cancelled stream, and one whose client has gone, simply stop
+		// forwarding what they still read.
+		stopped := false
 		for chunk := range remote.Chunks() {
-			if ctx.Err() != nil {
-				// Cancelled: drain what is still in flight so the far side's
-				// end is read, but stop pushing it at a client that asked to
-				// stop.
+			if stopped || ctx.Err() != nil {
 				continue
 			}
 			if err := s.Send(json.RawMessage(retagResult(method, host, chunk))); err != nil {
-				break
+				stopped = true
 			}
 		}
 		close(relayed)

--- a/internal/daemon/hostroute.go
+++ b/internal/daemon/hostroute.go
@@ -390,6 +390,13 @@ func ForwardTo(ctx context.Context, req *Request, host, method string, params js
 			"no remote host named "+host,
 			"this daemon has no remote support built in")
 	}
+	if !r.Known(host) {
+		// A typo must not look like an empty machine, and it must not look
+		// like an internal error either.
+		return nil, rpc.NewError(rpc.CodeNotFound,
+			"no remote host named "+host,
+			"`sonar remote list` shows the registered hosts; `sonar remote add <user@host>` adds one")
+	}
 	if len(params) == 0 {
 		params = json.RawMessage("{}")
 	}

--- a/internal/daemon/hostroute_test.go
+++ b/internal/daemon/hostroute_test.go
@@ -1,0 +1,325 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+)
+
+// fakeRouter registers a couple of host names and records what was forwarded.
+type fakeRouter struct {
+	hosts  map[string]bool
+	host   string
+	method string
+	params string
+	reply  json.RawMessage
+	err    error
+}
+
+func (f *fakeRouter) Known(name string) bool { return f.hosts[name] }
+
+func (f *fakeRouter) Forward(_ context.Context, host, method string, params json.RawMessage) (json.RawMessage, RemoteStream, error) {
+	f.host, f.method, f.params = host, method, string(params)
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	reply := f.reply
+	if reply == nil {
+		reply = json.RawMessage(`{"ok":true}`)
+	}
+	return reply, nil, nil
+}
+
+func withRouter(t *testing.T, hosts ...string) *fakeRouter {
+	t.Helper()
+	r := &fakeRouter{hosts: map[string]bool{}}
+	for _, h := range hosts {
+		r.hosts[h] = true
+	}
+	SetRouter(r)
+	t.Cleanup(func() { SetRouter(nil) })
+	return r
+}
+
+func TestRouteRequestDefaultsToLocalhost(t *testing.T) {
+	withRouter(t, "hetzner")
+
+	for _, params := range []string{
+		`{"port":3000}`,
+		`{"host":""}`,
+		`{"host":"localhost","port":3000}`,
+		`{"targets":[{"port":3000}]}`,
+		``,
+	} {
+		host, _, err := routeRequest("ports.kill", json.RawMessage(params))
+		if err != nil {
+			t.Fatalf("routeRequest(%q): %v", params, err)
+		}
+		if host != "" {
+			t.Errorf("routeRequest(%q) host = %q, want this machine", params, host)
+		}
+	}
+}
+
+// A request that names no host must reach its handler byte for byte: the
+// routing layer is in front of every call, so it has to be invisible when it
+// has nothing to do.
+func TestRouteRequestLeavesUntouchedParamsAlone(t *testing.T) {
+	withRouter(t, "hetzner")
+	params := json.RawMessage(`{"targets":[{"port":3000,"bind_address":"127.0.0.1"}],"tree":true}`)
+	host, out, err := routeRequest("ports.kill", params)
+	if err != nil || host != "" {
+		t.Fatalf("routeRequest = (%q, %v)", host, err)
+	}
+	if string(out) != string(params) {
+		t.Errorf("params were rewritten to %s, want %s", out, params)
+	}
+}
+
+func TestRouteRequestTakesHostOutOfParams(t *testing.T) {
+	withRouter(t, "hetzner")
+
+	cases := []struct {
+		name   string
+		method string
+		params string
+		want   string
+		// wantParams is what the far side must receive: the call, minus what
+		// named the host.
+		wantParams map[string]any
+	}{
+		{
+			name: "top-level host", method: "ports.kill",
+			params: `{"host":"hetzner","targets":[{"port":3000}]}`,
+			want:   "hetzner",
+			wantParams: map[string]any{
+				"targets": []any{map[string]any{"port": 3000.0}},
+			},
+		},
+		{
+			name: "host on a target", method: "ports.kill",
+			params: `{"targets":[{"host":"hetzner","port":3000}]}`,
+			want:   "hetzner",
+			wantParams: map[string]any{
+				"targets": []any{map[string]any{"port": 3000.0}},
+			},
+		},
+		{
+			name: "a delta key as a selector", method: "ports.rename",
+			params: `{"key":"hetzner/3000:127.0.0.1","name":"api"}`,
+			want:   "hetzner",
+			wantParams: map[string]any{
+				"port": 3000.0, "bind_address": "127.0.0.1", "name": "api",
+			},
+		},
+		{
+			name: "a local delta key", method: "ports.inspect",
+			params:     `{"key":"3000:::1"}`,
+			want:       "",
+			wantParams: map[string]any{"port": 3000.0, "bind_address": "::1"},
+		},
+		{
+			name: "a bare port key", method: "ports.inspect",
+			params:     `{"key":"3000"}`,
+			want:       "",
+			wantParams: map[string]any{"port": 3000.0},
+		},
+		{
+			name: "a prefixed group name", method: "groups.kill",
+			params:     `{"name":"hetzner/api"}`,
+			want:       "hetzner",
+			wantParams: map[string]any{"name": "api"},
+		},
+		{
+			name: "a prefixed session id", method: "sessions.kill",
+			params:     `{"id":"hetzner/sess-1"}`,
+			want:       "hetzner",
+			wantParams: map[string]any{"id": "sess-1"},
+		},
+		{
+			// ports.rename's `name` is the new display name, never a key.
+			name: "rename keeps its value", method: "ports.rename",
+			params:     `{"host":"hetzner","port":3000,"name":"hetzner/api"}`,
+			want:       "hetzner",
+			wantParams: map[string]any{"port": 3000.0, "name": "hetzner/api"},
+		},
+		{
+			// A group really called "staging/api" on a host that is not
+			// registered stays whole.
+			name: "an unregistered prefix is part of the name", method: "groups.kill",
+			params:     `{"name":"staging/api"}`,
+			want:       "",
+			wantParams: map[string]any{"name": "staging/api"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			host, out, err := routeRequest(c.method, json.RawMessage(c.params))
+			if err != nil {
+				t.Fatalf("routeRequest: %v", err)
+			}
+			if host != c.want {
+				t.Errorf("host = %q, want %q", host, c.want)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("params %s: %v", out, err)
+			}
+			if !jsonEqual(got, c.wantParams) {
+				t.Errorf("params = %v, want %v", got, c.wantParams)
+			}
+		})
+	}
+}
+
+func TestRouteRequestRefusesTwoHosts(t *testing.T) {
+	withRouter(t, "hetzner", "berlin")
+	_, _, err := routeRequest("ports.kill",
+		json.RawMessage(`{"targets":[{"host":"hetzner","port":3000},{"host":"berlin","port":3001}]}`))
+	if err == nil {
+		t.Fatal("want an error when one call names two hosts")
+	}
+	var re *rpc.Error
+	if !errors.As(err, &re) || re.Data.Code != "invalid_params" {
+		t.Fatalf("err = %v, want invalid_params", err)
+	}
+	if !strings.Contains(err.Error(), "hetzner") || !strings.Contains(err.Error(), "berlin") {
+		t.Errorf("error = %v, want it to name both hosts", err)
+	}
+}
+
+// The same host named twice is one host, not a conflict.
+func TestRouteRequestAcceptsOneHostNamedTwice(t *testing.T) {
+	withRouter(t, "hetzner")
+	host, _, err := routeRequest("ports.kill",
+		json.RawMessage(`{"host":"hetzner","targets":[{"key":"hetzner/3000"},{"port":3001}]}`))
+	if err != nil {
+		t.Fatalf("routeRequest: %v", err)
+	}
+	if host != "hetzner" {
+		t.Errorf("host = %q, want hetzner", host)
+	}
+}
+
+func TestRouteRequestRefusesAKeyBesideAPort(t *testing.T) {
+	withRouter(t, "hetzner")
+	_, _, err := routeRequest("ports.inspect", json.RawMessage(`{"key":"3000","port":3001}`))
+	if err == nil {
+		t.Fatal("want an error for a selector that sets both")
+	}
+	var re *rpc.Error
+	if !errors.As(err, &re) || re.Data.Code != "invalid_selector" {
+		t.Fatalf("err = %v, want invalid_selector", err)
+	}
+}
+
+func TestRouteRequestRefusesAnUnreadableKey(t *testing.T) {
+	withRouter(t, "hetzner")
+	_, _, err := routeRequest("ports.inspect", json.RawMessage(`{"key":"hetzner/not-a-port"}`))
+	if err == nil {
+		t.Fatal("want an error for a key that is not a port key")
+	}
+}
+
+// state.* has its own host selection and must not be caught by this one.
+func TestRouteRequestLeavesStateAndRemoteAlone(t *testing.T) {
+	withRouter(t, "hetzner")
+	for _, method := range []string{
+		"state.subscribe", "state.snapshot", "stream.cancel",
+		"daemon.hello", "daemon.shutdown", "remote.call", "remote.add",
+	} {
+		params := json.RawMessage(`{"host":"hetzner"}`)
+		host, out, err := routeRequest(method, params)
+		if err != nil {
+			t.Fatalf("%s: %v", method, err)
+		}
+		if host != "" {
+			t.Errorf("%s routed to %q, want it left alone", method, host)
+		}
+		if string(out) != string(params) {
+			t.Errorf("%s params = %s, want them untouched", method, out)
+		}
+	}
+}
+
+func TestForwardToUnknownHostWithoutARouter(t *testing.T) {
+	SetRouter(nil)
+	_, err := ForwardTo(context.Background(), &Request{}, "hetzner", "ports.list", nil)
+	var re *rpc.Error
+	if !errors.As(err, &re) || re.Data.Code != "not_found" {
+		t.Fatalf("err = %v, want not_found", err)
+	}
+}
+
+func TestForwardToReturnsTheRemoteResult(t *testing.T) {
+	r := withRouter(t, "hetzner")
+	r.reply = json.RawMessage(`{"ports":[{"host":"localhost","port":3000,"pid":8123456}]}`)
+
+	out, err := ForwardTo(context.Background(), &Request{}, "hetzner", "ports.list",
+		json.RawMessage(`{"all":true}`))
+	if err != nil {
+		t.Fatalf("ForwardTo: %v", err)
+	}
+	if r.host != "hetzner" || r.method != "ports.list" || r.params != `{"all":true}` {
+		t.Errorf("forwarded (%q, %q, %s)", r.host, r.method, r.params)
+	}
+
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"host":"hetzner"`) {
+		t.Errorf("result = %s, want the row retagged to the host it came from", raw)
+	}
+	// A pid larger than float64's exact range must survive the retagging.
+	if !strings.Contains(string(raw), `8123456`) {
+		t.Errorf("result = %s, want the pid unchanged", raw)
+	}
+}
+
+func TestRetagResultNamespacesPortKeys(t *testing.T) {
+	raw := retagResult("ports.kill", "hetzner", json.RawMessage(
+		`{"ok":true,"affected":["3000:127.0.0.1"],"results":[{"host":"localhost","port":3000}]}`))
+
+	var got struct {
+		Affected []string `json:"affected"`
+		Results  []struct {
+			Host string `json:"host"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Affected) != 1 || got.Affected[0] != "hetzner/3000:127.0.0.1" {
+		t.Errorf("affected = %v, want the key the stream uses", got.Affected)
+	}
+	if len(got.Results) != 1 || got.Results[0].Host != "hetzner" {
+		t.Errorf("results = %+v, want the row tagged with the host", got.Results)
+	}
+}
+
+// A method whose `key` is not a port key keeps it: a claim key is not a row.
+func TestRetagResultLeavesNonPortKeysAlone(t *testing.T) {
+	raw := retagResult("claims.release", "hetzner", json.RawMessage(`{"ok":true,"key":"my-project"}`))
+	if !strings.Contains(string(raw), `"my-project"`) {
+		t.Errorf("result = %s, want the claim key untouched", raw)
+	}
+}
+
+func TestRetagResultPassesThroughWhatItCannotParse(t *testing.T) {
+	raw := retagResult("ports.list", "hetzner", json.RawMessage(`not json`))
+	if string(raw) != "not json" {
+		t.Errorf("result = %s, want it passed through", raw)
+	}
+}
+
+func jsonEqual(a, b map[string]any) bool {
+	x, _ := json.Marshal(a)
+	y, _ := json.Marshal(b)
+	return string(x) == string(y)
+}

--- a/internal/daemon/hostroute_test.go
+++ b/internal/daemon/hostroute_test.go
@@ -256,6 +256,18 @@ func TestForwardToUnknownHostWithoutARouter(t *testing.T) {
 	}
 }
 
+func TestForwardToAnUnregisteredHostIsNotFound(t *testing.T) {
+	withRouter(t, "hetzner")
+	_, err := ForwardTo(context.Background(), &Request{}, "berlin", "ports.list", nil)
+	var re *rpc.Error
+	if !errors.As(err, &re) || re.Data.Code != "not_found" {
+		t.Fatalf("err = %v, want not_found", err)
+	}
+	if !strings.Contains(err.Error(), "berlin") {
+		t.Errorf("err = %v, want it to name the host", err)
+	}
+}
+
 func TestForwardToReturnsTheRemoteResult(t *testing.T) {
 	r := withRouter(t, "hetzner")
 	r.reply = json.RawMessage(`{"ports":[{"host":"localhost","port":3000,"pid":8123456}]}`)

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -185,6 +185,7 @@ type PortsRenameResult struct {
 }
 
 type PortsNextParams struct {
+	HostParams
 	Start    int     `json:"start,omitempty"`
 	End      int     `json:"end,omitempty"`
 	Count    int     `json:"count,omitempty"`
@@ -404,6 +405,7 @@ type ConfigProblem struct {
 // default is a preview; Force is the wire form of `sonar init --force` and is
 // the only way past an existing file (contract §4, §16).
 type GroupsInitParams struct {
+	HostParams
 	RootDir string `json:"root_dir"`
 	Write   bool   `json:"write,omitempty"`
 	Force   bool   `json:"force,omitempty"`
@@ -419,6 +421,7 @@ type GroupsInitResult struct {
 // ------------------------------------------------------------------ runs ---
 
 type RunsRegisterParams struct {
+	HostParams
 	PID       int     `json:"pid"`
 	PPID      int     `json:"ppid"`
 	Group     string  `json:"group"`
@@ -443,6 +446,7 @@ type RunsRegisterResult struct {
 }
 
 type RunsUnregisterParams struct {
+	HostParams
 	PID int `json:"pid"`
 }
 
@@ -467,6 +471,7 @@ type RunRecord struct {
 }
 
 type RunsSpawnParams struct {
+	HostParams
 	Argv             []string          `json:"argv"`
 	Cwd              string            `json:"cwd"`
 	Env              map[string]string `json:"env,omitempty"`
@@ -494,6 +499,7 @@ type RunsSpawnResult struct {
 // schema has always carried it and every other duration on this wire is in
 // milliseconds. Neither set means DefaultTTL (24h).
 type ClaimsAcquireParams struct {
+	HostParams
 	Project    string `json:"project,omitempty"`
 	Worktree   string `json:"worktree,omitempty"`
 	Key        string `json:"key,omitempty"`
@@ -510,6 +516,7 @@ type ClaimsAcquireResult struct {
 }
 
 type ClaimsReleaseParams struct {
+	HostParams
 	Key string `json:"key"`
 }
 
@@ -559,6 +566,7 @@ type ConfigGetResult struct {
 }
 
 type ConfigSetParams struct {
+	HostParams
 	Patch map[string]any `json:"patch"`
 }
 

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -17,14 +17,37 @@ import (
 
 // ---------------------------------------------------------------- shared ---
 
-// Selector addresses one port (contract §3). Exactly one of Port, PID, RunID
-// and ProxyID is set; BindAddress only disambiguates Port.
+// HostParams is the optional `host` a method takes to act on a registered
+// remote host instead of this machine (remote-hosts spec, "Actions on a remote
+// host"). Absent means localhost, which is what every client written before
+// remote hosts existed sends, so their calls keep meaning what they meant
+// (contract §39).
+//
+// The daemon accepts it on every method it serves except `state.*`, `stream.*`,
+// `daemon.hello`, `daemon.shutdown` and the `remote.*` family. It is embedded
+// in the params types below where it is worth spelling out in the schema.
+type HostParams struct {
+	// Host names a registered remote host. Empty or "localhost" is this
+	// machine.
+	Host string `json:"host,omitempty"`
+}
+
+// Selector addresses one port (contract §3). Exactly one of Port, PID, RunID,
+// ProxyID and Key is set; BindAddress only disambiguates Port.
 type Selector struct {
+	HostParams
 	Port        *int    `json:"port,omitempty"`
 	PID         *int    `json:"pid,omitempty"`
 	BindAddress *string `json:"bind_address,omitempty"`
 	RunID       *string `json:"run_id,omitempty"`
 	ProxyID     *string `json:"proxy_id,omitempty"`
+	// Key is a delta key handed straight back as a selector: `"<port>"`,
+	// `"<port>:<bind_address>"`, or either of those behind a `"<host>/"`
+	// prefix naming a registered host. A client that holds the key the stream
+	// gave it does not have to take it apart to act on the row. The daemon
+	// expands it into Host, Port and BindAddress before any handler sees it,
+	// so it never combines with them.
+	Key string `json:"key,omitempty"`
 }
 
 // MutationResult is the minimum every mutating method returns (contract §3).
@@ -112,6 +135,7 @@ type StateSubscribeParams struct {
 // ----------------------------------------------------------------- ports ---
 
 type PortsListParams struct {
+	HostParams
 	Group     *string `json:"group,omitempty"`
 	Filter    *string `json:"filter,omitempty"` // docker | user | system
 	All       bool    `json:"all,omitempty"`
@@ -140,6 +164,7 @@ type Connection struct {
 }
 
 type PortsKillParams struct {
+	HostParams
 	Targets  []Selector `json:"targets"`
 	Tree     bool       `json:"tree,omitempty"`
 	Force    bool       `json:"force,omitempty"`
@@ -171,6 +196,7 @@ type PortsNextResult struct {
 }
 
 type PortsWaitParams struct {
+	HostParams
 	Ports      []int   `json:"ports,omitempty"`
 	RunID      *string `json:"run_id,omitempty"`
 	Any        bool    `json:"any,omitempty"`
@@ -190,6 +216,7 @@ type PortsWaitEnd struct {
 }
 
 type PortsHealthParams struct {
+	HostParams
 	Ports []int `json:"ports,omitempty"`
 }
 
@@ -241,6 +268,7 @@ type GraphEdge struct {
 }
 
 type PortsHistoryParams struct {
+	HostParams
 	Port  *int    `json:"port,omitempty"`
 	Since *string `json:"since,omitempty"`
 	Limit int     `json:"limit,omitempty"`
@@ -266,6 +294,7 @@ type GroupsListResult struct {
 }
 
 type GroupsInspectParams struct {
+	HostParams
 	Name string `json:"name"`
 }
 
@@ -275,6 +304,7 @@ type GroupsInspectResult struct {
 }
 
 type GroupsKillParams struct {
+	HostParams
 	Name    string `json:"name"`
 	Force   bool   `json:"force,omitempty"`
 	GraceMs int    `json:"grace_ms,omitempty"`
@@ -282,6 +312,7 @@ type GroupsKillParams struct {
 }
 
 type GroupsStartParams struct {
+	HostParams
 	Name             *string  `json:"name,omitempty"`
 	ConfigPath       *string  `json:"config_path,omitempty"`
 	Only             []string `json:"only,omitempty"`
@@ -332,6 +363,7 @@ type GroupConfig struct {
 }
 
 type GroupsConfigGetParams struct {
+	HostParams
 	Name *string `json:"name,omitempty"`
 	Path *string `json:"path,omitempty"`
 }
@@ -342,6 +374,7 @@ type GroupsConfigGetResult struct {
 }
 
 type GroupsConfigSetParams struct {
+	HostParams
 	Path     string               `json:"path"`
 	Services []groups.ServiceEdit `json:"services"`
 }
@@ -492,6 +525,7 @@ type ClaimsListResult struct {
 // -------------------------------------------------------------- sessions ---
 
 type SessionsListParams struct {
+	HostParams
 	ActiveOnly bool `json:"active_only,omitempty"`
 }
 
@@ -500,6 +534,7 @@ type SessionsListResult struct {
 }
 
 type SessionsInspectParams struct {
+	HostParams
 	ID string `json:"id"`
 }
 
@@ -510,6 +545,7 @@ type SessionsInspectResult struct {
 }
 
 type SessionsKillParams struct {
+	HostParams
 	ID     string `json:"id"`
 	Tree   bool   `json:"tree,omitempty"`
 	Force  bool   `json:"force,omitempty"`

--- a/internal/daemon/rpc/schema.go
+++ b/internal/daemon/rpc/schema.go
@@ -270,7 +270,7 @@ func init() {
 	// Daemon lifecycle.
 	Describe("daemon.hello", DaemonHelloParams{}, DaemonHelloResult{}, nil, nil)
 	Describe("daemon.shutdown", Empty{}, OKResult{}, nil, nil)
-	Describe("daemon.status", Empty{}, DaemonStatusResult{}, nil, nil)
+	Describe("daemon.status", HostParams{}, DaemonStatusResult{}, nil, nil)
 	Describe("daemon.schema", Empty{}, DaemonSchemaResult{}, nil, nil)
 
 	// State.
@@ -288,16 +288,16 @@ func init() {
 	Describe("ports.wait", PortsWaitParams{}, StreamStart{}, PortsWaitChunk{}, PortsWaitEnd{})
 	Describe("ports.health", PortsHealthParams{}, PortsHealthResult{}, nil, nil)
 	Describe("ports.logs", PortsLogsParams{}, PortsLogsResult{}, PortsLogsChunk{}, StreamEnd{})
-	Describe("ports.graph", Empty{}, PortsGraphResult{}, nil, nil)
+	Describe("ports.graph", HostParams{}, PortsGraphResult{}, nil, nil)
 	Describe("ports.history", PortsHistoryParams{}, PortsHistoryResult{}, nil, nil)
 
 	// Groups.
-	Describe("groups.list", Empty{}, GroupsListResult{}, nil, nil)
+	Describe("groups.list", HostParams{}, GroupsListResult{}, nil, nil)
 	Describe("groups.inspect", GroupsInspectParams{}, GroupsInspectResult{}, nil, nil)
 	Describe("groups.kill", GroupsKillParams{}, KillEnvelope{}, nil, nil)
 	Describe("groups.start", GroupsStartParams{}, GroupsStartResult{}, GroupsStartChunk{}, GroupsStartEnd{})
 	Describe("groups.assign", GroupsAssignParams{}, GroupsAssignResult{}, nil, nil)
-	Describe("groups.reload", Empty{}, GroupsReloadResult{}, nil, nil)
+	Describe("groups.reload", HostParams{}, GroupsReloadResult{}, nil, nil)
 	Describe("groups.config.get", GroupsConfigGetParams{}, GroupsConfigGetResult{}, nil, nil)
 	Describe("groups.config.set", GroupsConfigSetParams{}, GroupsConfigSetResult{}, nil, nil)
 	Describe("groups.init", GroupsInitParams{}, GroupsInitResult{}, nil, nil)
@@ -305,13 +305,13 @@ func init() {
 	// Runs.
 	Describe("runs.register", RunsRegisterParams{}, RunsRegisterResult{}, nil, nil)
 	Describe("runs.unregister", RunsUnregisterParams{}, OKResult{}, nil, nil)
-	Describe("runs.list", Empty{}, RunsListResult{}, nil, nil)
+	Describe("runs.list", HostParams{}, RunsListResult{}, nil, nil)
 	Describe("runs.spawn", RunsSpawnParams{}, RunsSpawnResult{}, nil, nil)
 
 	// Claims (spec 2, slice M5).
 	Describe("claims.acquire", ClaimsAcquireParams{}, ClaimsAcquireResult{}, nil, nil)
 	Describe("claims.release", ClaimsReleaseParams{}, ClaimsReleaseResult{}, nil, nil)
-	Describe("claims.list", Empty{}, ClaimsListResult{}, nil, nil)
+	Describe("claims.list", HostParams{}, ClaimsListResult{}, nil, nil)
 
 	// Sessions (spec 2, slice M4).
 	Describe("sessions.list", SessionsListParams{}, SessionsListResult{}, nil, nil)
@@ -319,9 +319,9 @@ func init() {
 	Describe("sessions.kill", SessionsKillParams{}, KillEnvelope{}, nil, nil)
 
 	// Config.
-	Describe("config.get", Empty{}, ConfigGetResult{}, nil, nil)
+	Describe("config.get", HostParams{}, ConfigGetResult{}, nil, nil)
 	Describe("config.set", ConfigSetParams{}, ConfigSetResult{}, nil, nil)
-	Describe("config.path", Empty{}, ConfigPathResult{}, nil, nil)
+	Describe("config.path", HostParams{}, ConfigPathResult{}, nil, nil)
 
 	// Remote hosts.
 	Describe("remote.scan", RemoteScanParams{}, RemoteScanResult{}, nil, nil)

--- a/internal/display/table.go
+++ b/internal/display/table.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -17,6 +18,7 @@ var DefaultColumns = []string{"port", "process", "group", "container", "image", 
 
 // AllColumns lists every supported column name.
 var AllColumns = []string{
+	"host",
 	"port", "process", "pid", "type", "url",
 	"cpu", "mem", "threads", "uptime", "state", "connections",
 	"container", "image", "containerport", "compose", "project",
@@ -46,6 +48,7 @@ func RenderTable(w io.Writer, pp []ports.ListeningPort, opts TableOptions) {
 	if len(cols) == 0 {
 		cols = DefaultColumns
 	}
+	cols = withHostColumn(cols, filtered)
 
 	// Build header row
 	headers := make([]string, len(cols))
@@ -132,6 +135,36 @@ func padRight(s string, width int) string {
 	return s + strings.Repeat(" ", width-vl)
 }
 
+// withHostColumn puts HOST in front of the table as soon as the rows come from
+// more than one machine. One host needs no column — every row would say the
+// same thing — and two hosts need one in every view, not only the one where
+// someone remembered to ask for it.
+func withHostColumn(cols []string, rows []ports.ListeningPort) []string {
+	if len(rows) == 0 || slices.Contains(cols, "host") || !multiHost(rows) {
+		return cols
+	}
+	return append([]string{"host"}, cols...)
+}
+
+// multiHost reports whether the rows name more than one machine.
+func multiHost(rows []ports.ListeningPort) bool {
+	first := hostLabel(rows[0])
+	for _, r := range rows[1:] {
+		if hostLabel(r) != first {
+			return true
+		}
+	}
+	return false
+}
+
+// hostLabel is what the HOST column prints: a row with no host is this machine.
+func hostLabel(p ports.ListeningPort) string {
+	if p.Host == "" {
+		return "localhost"
+	}
+	return p.Host
+}
+
 func columnLabel(col string) string {
 	switch col {
 	case "containerport":
@@ -152,6 +185,8 @@ func columnLabel(col string) string {
 		return "THR"
 	case "connections":
 		return "CONN"
+	case "host":
+		return "HOST"
 	case "health":
 		return "HEALTH"
 	case "latency":
@@ -165,6 +200,8 @@ func columnLabel(col string) string {
 
 func columnValue(p ports.ListeningPort, col string) string {
 	switch col {
+	case "host":
+		return Cyan(hostLabel(p))
 	case "port":
 		return BoldCyan(fmt.Sprintf("%d", p.Port))
 	case "process":

--- a/internal/killer/killer.go
+++ b/internal/killer/killer.go
@@ -140,7 +140,13 @@ func KillPorts(ctx context.Context, targets []Target, opts Options) []Result {
 	if snapshot == nil {
 		snapshot = scanPorts()
 	}
-	return newEngine().kill(ctx, snapshot, targets, opts)
+	rows := newEngine().kill(ctx, snapshot, targets, opts)
+	for i := range rows {
+		// The killer only ever acts on the machine it runs on. A row from a
+		// remote host is retagged by whatever forwarded the call.
+		rows[i].Host = state.LocalhostName
+	}
+	return rows
 }
 
 // scanPorts takes the enriched scan the killer needs to resolve targets: the

--- a/internal/ports/model.go
+++ b/internal/ports/model.go
@@ -46,6 +46,12 @@ type ListeningPort struct {
 	Type        PortType
 	IsApp       bool // true for desktop apps (Figma, Discord, etc.)
 
+	// Host is the machine this row was seen on: empty or "localhost" for a
+	// direct scan, and the registered name for a row that reached the CLI
+	// through the daemon from a remote host. It is what puts a HOST column on
+	// `sonar list --host "*"`.
+	Host string
+
 	// Display is a display name that was already resolved elsewhere. The
 	// daemon sets it when it converts a published state.Port back into a
 	// scanner row: the wire shape does not carry the parent cmdline

--- a/internal/remote/actions_integration_test.go
+++ b/internal/remote/actions_integration_test.go
@@ -356,3 +356,42 @@ services:
 		return seen >= 2
 	})
 }
+
+// TestCancelReachesTheRemoteStream: `stream.cancel` on the local subscription
+// id stops the work on the other machine, not just the forwarding here. The
+// wait is given a minute; if the cancel did not travel, the stream would still
+// be open when the test's own deadline runs out.
+func TestCancelReachesTheRemoteStream(t *testing.T) {
+	e := newBridgeEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+	register(t, ctx, c, "fake")
+
+	// A port nothing will ever listen on, so the wait runs until it is told
+	// to stop.
+	stream, err := c.Stream(ctx, "ports.wait", rpc.PortsWaitParams{
+		HostParams: rpc.HostParams{Host: "fake"},
+		Ports:      []int{freePort(t)},
+		TimeoutMs:  60_000,
+		IntervalMs: 250,
+	}, nil)
+	if err != nil {
+		t.Fatalf("ports.wait on a remote host: %v", err)
+	}
+	defer stream.Close()
+
+	if err := stream.Cancel(ctx); err != nil {
+		t.Fatalf("stream.cancel: %v", err)
+	}
+	select {
+	case end := <-stream.End():
+		if end.Err != nil {
+			t.Fatalf("a cancelled stream must end cleanly, got %v", end.Err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the cancel never reached the remote stream: it is still running")
+	}
+}

--- a/internal/remote/actions_integration_test.go
+++ b/internal/remote/actions_integration_test.go
@@ -1,0 +1,358 @@
+//go:build integration
+
+// Acting on a remote host, end to end over the same fake-ssh bridge the 3A.2
+// tests use: a kill, a group start with its stream, and a rename addressed by
+// the delta key a client already holds. Two real daemons, the real spawn, the
+// real relay — only the network is missing.
+//
+// Run with `go test -tags integration ./internal/remote/...`.
+package remote_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// buildListener compiles a helper that listens on the port it is given and
+// blocks. A kill needs a real process holding a real socket; the test process
+// itself is not a candidate.
+var buildListener = sync.OnceValues(func() (string, error) {
+	dir, err := os.MkdirTemp("", "sonar-remote-itest-listener")
+	if err != nil {
+		return "", err
+	}
+	src := filepath.Join(dir, "main.go")
+	program := `package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func main() {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer ln.Close()
+	fmt.Println("listening on", os.Args[1])
+	for {
+		time.Sleep(time.Second)
+	}
+}
+`
+	if err := os.WriteFile(src, []byte(program), 0o644); err != nil {
+		return "", err
+	}
+	bin := filepath.Join(dir, "listener")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("building the listener helper: %v: %s", err, out)
+	}
+	return bin, nil
+})
+
+// freePort returns a port nothing is listening on right now.
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// startListener runs the helper and waits until it is accepting.
+func startListener(t *testing.T, port int) *exec.Cmd {
+	t.Helper()
+	bin, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(bin, strconv.Itoa(port))
+	cmd.WaitDelay = 5 * time.Second
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting the listener: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+strconv.Itoa(port), 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return cmd
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the listener never came up on %d", port)
+	return nil
+}
+
+// register adds the fake host and waits for its bridge to connect.
+func register(t *testing.T, ctx context.Context, c *client.Client, name string) {
+	t.Helper()
+	if err := c.Call(ctx, "remote.add", rpc.RemoteAddParams{Target: "deploy@fake", Name: name}, nil); err != nil {
+		t.Fatalf("remote.add: %v", err)
+	}
+	waitUntil(t, ctx, "the host to connect", func() bool {
+		var list rpc.RemoteListResult
+		if err := c.Call(ctx, "remote.list", rpc.Empty{}, &list); err != nil {
+			return false
+		}
+		for _, h := range list.Hosts {
+			if h.Name == name && h.Status == state.HostConnected {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// waitForRemotePort waits until a port shows up in the multiplexed rows under
+// the given host, and returns its row.
+func waitForRemotePort(t *testing.T, ctx context.Context, c *client.Client, host string, port int) state.Port {
+	t.Helper()
+	var found state.Port
+	waitUntil(t, ctx, fmt.Sprintf("port %d to appear on %s", port, host), func() bool {
+		for _, p := range snapshot(t, ctx, c, []string{"*"}).Ports {
+			if p.Host == host && p.Port == port {
+				found = p
+				return true
+			}
+		}
+		return false
+	})
+	return found
+}
+
+// TestKillAPortOnARemoteHost is the step's acceptance path: `ports.kill` with a
+// host kills on that machine, and the envelope says so — the rows carry the
+// host and `affected` carries the key the state stream uses for it.
+func TestKillAPortOnARemoteHost(t *testing.T) {
+	e := newBridgeEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+	register(t, ctx, c, "fake")
+
+	port := freePort(t)
+	listener := startListener(t, port)
+	row := waitForRemotePort(t, ctx, c, "fake", port)
+
+	var env rpc.KillEnvelope
+	if err := c.Call(ctx, "ports.kill", rpc.PortsKillParams{
+		HostParams: rpc.HostParams{Host: "fake"},
+		Targets:    []rpc.Selector{{Port: &port}},
+	}, &env); err != nil {
+		t.Fatalf("ports.kill on a remote host: %v", err)
+	}
+	if !env.OK || len(env.Results) == 0 {
+		t.Fatalf("kill envelope = %+v, want a successful kill", env)
+	}
+	for _, r := range env.Results {
+		if r.Host != "fake" {
+			t.Errorf("result row host = %q, want fake", r.Host)
+		}
+	}
+	wantKey := fmt.Sprintf("fake/%d:%s", port, row.BindAddress)
+	if len(env.Affected) != 1 || env.Affected[0] != wantKey {
+		t.Errorf("affected = %v, want [%s] — the key the stream uses", env.Affected, wantKey)
+	}
+
+	// The process really is gone, and its row leaves the multiplexed state.
+	if err := listener.Wait(); err == nil {
+		t.Log("the listener exited cleanly")
+	}
+	waitUntil(t, ctx, "the killed port to leave the stream", func() bool {
+		for _, p := range snapshot(t, ctx, c, []string{"*"}).Ports {
+			if p.Host == "fake" && p.Port == port {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// TestRenameOnARemoteHostByItsDeltaKey: a client hands back the key it was
+// given, and that alone says which machine the row is on.
+func TestRenameOnARemoteHostByItsDeltaKey(t *testing.T) {
+	e := newBridgeEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+	register(t, ctx, c, "fake")
+
+	port := freePort(t)
+	startListener(t, port)
+	row := waitForRemotePort(t, ctx, c, "fake", port)
+	key := row.Key()
+
+	name := "named-by-its-key"
+	var res rpc.PortsRenameResult
+	if err := c.Call(ctx, "ports.rename", rpc.PortsRenameParams{
+		Selector: rpc.Selector{Key: key},
+		Name:     &name,
+	}, &res); err != nil {
+		t.Fatalf("ports.rename by key: %v", err)
+	}
+	// `affected` is where the port key lives; `key` is the store's own
+	// identity for the rename and is not namespaced.
+	if len(res.Affected) != 1 || res.Affected[0] != key {
+		t.Errorf("affected = %v, want [%s] — the key the caller sent", res.Affected, key)
+	}
+	if res.Name == nil || *res.Name != name {
+		t.Fatalf("rename result = %+v", res)
+	}
+
+	waitUntil(t, ctx, "the rename to reach the multiplexed rows", func() bool {
+		for _, p := range snapshot(t, ctx, c, []string{"*"}).Ports {
+			if p.Host == "fake" && p.Port == port && p.Name != nil && *p.Name == name {
+				return true
+			}
+		}
+		return false
+	})
+
+	// The write went to the other machine; the local row for the same port is
+	// untouched.
+	for _, p := range snapshot(t, ctx, c, nil).Ports {
+		if p.Port == port && p.Name != nil && *p.Name == name {
+			t.Error("the rename addressed by a remote key also renamed the local row")
+		}
+	}
+}
+
+// TestGroupsStartOnARemoteHostStreams: the group runs on the other machine and
+// its chunks arrive here, one per service, under this connection's own
+// subscription id.
+func TestGroupsStartOnARemoteHostStreams(t *testing.T) {
+	listenerBin, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newBridgeEnv(t)
+	// The project lives inside the *remote* daemon's home: it is that daemon
+	// that reads the file and spawns the services.
+	project := filepath.Join(e.remoteHome, "demo")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	apiPort, webPort := freePort(t), freePort(t)
+	config := fmt.Sprintf(`name: demo
+services:
+  - name: api
+    cmd: '%s %d'
+    port: %d
+  - name: web
+    cmd: '%s %d'
+    port: %d
+`, listenerBin, apiPort, apiPort, listenerBin, webPort, webPort)
+	configPath := filepath.Join(project, ".sonar.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e.serve()
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+	register(t, ctx, c, "fake")
+	t.Cleanup(func() {
+		// Whatever the group started belongs to the other machine's daemon,
+		// and outlives this test unless it is stopped.
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer stopCancel()
+		_ = c.Call(stopCtx, "groups.kill", rpc.GroupsKillParams{
+			HostParams: rpc.HostParams{Host: "fake"}, Name: "demo", Force: true,
+		}, nil)
+	})
+
+	var start rpc.GroupsStartResult
+	stream, err := c.Stream(ctx, "groups.start", rpc.GroupsStartParams{
+		HostParams: rpc.HostParams{Host: "fake"},
+		ConfigPath: &configPath,
+	}, &start)
+	if err != nil {
+		t.Fatalf("groups.start on a remote host: %v", err)
+	}
+	defer stream.Close()
+	if start.SubscriptionID == "" {
+		t.Fatal("a relayed stream must reply with this daemon's own subscription id")
+	}
+	if stream.ID() != start.SubscriptionID {
+		t.Errorf("stream id = %q, reply said %q", stream.ID(), start.SubscriptionID)
+	}
+
+	started := map[string]int{}
+	for raw := range stream.Chunks() {
+		var chunk rpc.GroupsStartChunk
+		if err := json.Unmarshal(raw, &chunk); err != nil {
+			t.Fatalf("decoding a relayed chunk: %v", err)
+		}
+		if chunk.Error != "" {
+			t.Errorf("service %s failed on the remote host: %s", chunk.Service, chunk.Error)
+			continue
+		}
+		started[chunk.Service] = chunk.PID
+	}
+	end := <-stream.End()
+	if end.Err != nil {
+		t.Fatalf("the relayed stream ended with an error: %v", end.Err)
+	}
+	var summary rpc.GroupsStartEnd
+	if err := end.Decode(&summary); err != nil {
+		t.Fatalf("decoding the relayed end: %v", err)
+	}
+
+	for _, svc := range []string{"api", "web"} {
+		if _, ok := started[svc]; !ok {
+			t.Errorf("no chunk arrived for %s; got %v", svc, started)
+		}
+	}
+	if len(summary.Started)+len(summary.Skipped) != 2 || len(summary.Errors) != 0 {
+		t.Errorf("summary = %+v, want both services accounted for", summary)
+	}
+
+	// And what it started is on the other machine, in the local stream.
+	waitUntil(t, ctx, "the started services to reach the multiplexed rows", func() bool {
+		seen := 0
+		for _, p := range snapshot(t, ctx, c, []string{"*"}).Ports {
+			if p.Host == "fake" && (p.Port == apiPort || p.Port == webPort) {
+				seen++
+			}
+		}
+		return seen >= 2
+	})
+}

--- a/internal/remote/bridge.go
+++ b/internal/remote/bridge.go
@@ -137,6 +137,20 @@ func (b *bridge) Config() Host {
 // verbatim. It fails fast while the bridge is down rather than queueing: a
 // caller wants to know that the host is unreachable, not to block on it.
 func (b *bridge) Call(ctx context.Context, method string, params json.RawMessage) (json.RawMessage, error) {
+	cli, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	var out json.RawMessage
+	if err := cli.Call(ctx, method, params, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// client is the live connection, or the error a caller should see instead of
+// one: which state the host is in, and what it said last.
+func (b *bridge) client() (*client.Client, error) {
 	b.mu.RLock()
 	cli := b.cli
 	status, reason := b.status.Status, b.status.StatusReason
@@ -150,11 +164,7 @@ func (b *bridge) Call(ctx context.Context, method string, params json.RawMessage
 		return nil, rpc.NewError(rpc.CodeNotFound, detail,
 			"`sonar remote list` shows the connection; `sonar remote install "+b.cfg.Name+"` puts a daemon on it")
 	}
-	var out json.RawMessage
-	if err := cli.Call(ctx, method, params, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
+	return cli, nil
 }
 
 // run is the connect / subscribe / reconnect loop. It never gives up: a host

--- a/internal/remote/forward.go
+++ b/internal/remote/forward.go
@@ -1,0 +1,85 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+)
+
+// The manager as the daemon's remote router (daemon.Router). Everything the
+// dispatcher needs in order to send a method somewhere else is here: whether a
+// name is a host, and how to run one call on it — including a streaming one,
+// where the chunks have to keep arriving after the reply.
+
+// Known reports whether name is a registered host. The routing layer asks
+// before reading a `"<host>/…"` prefix off a key, so a group whose name happens
+// to look like one is never mistaken for a remote row.
+func (m *Manager) Known(name string) bool { return m.Has(name) }
+
+// Forward runs one method on a host's daemon. A streaming method answers with
+// a subscription id and keeps going, and the returned stream is how the local
+// daemon relays it; everything else answers once, with a nil stream.
+func (m *Manager) Forward(ctx context.Context, host, method string, params json.RawMessage) (json.RawMessage, daemon.RemoteStream, error) {
+	m.mu.RLock()
+	b, ok := m.bridges[host]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, nil, ErrUnknownHost
+	}
+	return b.Forward(ctx, method, params)
+}
+
+// Forward is Call, with the streaming half. It fails fast while the bridge is
+// down for the same reason Call does: a caller wants to hear that the host is
+// unreachable, not to wait for it.
+func (b *bridge) Forward(ctx context.Context, method string, params json.RawMessage) (json.RawMessage, daemon.RemoteStream, error) {
+	cli, err := b.client()
+	if err != nil {
+		return nil, nil, err
+	}
+	raw, st, err := cli.CallStream(ctx, method, params)
+	if err != nil {
+		return nil, nil, err
+	}
+	if st == nil {
+		return raw, nil, nil
+	}
+	return raw, newRelay(st), nil
+}
+
+// relay adapts a client stream to the interface the daemon's routing layer
+// consumes, which cannot name a client type: internal/daemon/client imports
+// internal/daemon, so the dependency only points one way.
+type relay struct {
+	stream *client.Stream
+	ends   chan daemon.RemoteStreamEnd
+	once   sync.Once
+}
+
+func newRelay(s *client.Stream) *relay {
+	r := &relay{stream: s, ends: make(chan daemon.RemoteStreamEnd, 1)}
+	go func() {
+		defer close(r.ends)
+		for end := range s.End() {
+			r.ends <- daemon.RemoteStreamEnd{Data: end.Data, Err: end.Err}
+		}
+		// The far side is finished, so the client-side pump can go too.
+		s.Close()
+	}()
+	return r
+}
+
+func (r *relay) Chunks() <-chan json.RawMessage { return r.stream.Chunks() }
+
+func (r *relay) End() <-chan daemon.RemoteStreamEnd { return r.ends }
+
+// Cancel asks the remote daemon to stop the stream. It is sent once however
+// many times the relay is torn down.
+func (r *relay) Cancel(ctx context.Context) error {
+	var err error
+	r.once.Do(func() { err = r.stream.Cancel(ctx) })
+	return err
+}

--- a/internal/remote/forward_test.go
+++ b/internal/remote/forward_test.go
@@ -1,0 +1,177 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+)
+
+// A streaming method on the far side comes back as a stream on this side: the
+// reply carries the remote's subscription id, the chunks keep arriving after
+// it, and cancelling reaches the remote daemon.
+
+// streamer teaches the fake daemon one streaming method: it replies with a
+// subscription id, pushes the chunks a test gives it, and ends when the test
+// says so or when the local side cancels.
+type streamer struct {
+	fake      *fakeDaemon
+	id        string
+	cancelled chan struct{}
+}
+
+func newStreamer(f *fakeDaemon, method, id string) *streamer {
+	s := &streamer{fake: f, id: id, cancelled: make(chan struct{}, 1)}
+	f.handle(method, func(json.RawMessage) (any, *rpc.Error) {
+		return map[string]any{"ok": true, "affected": []string{}, "subscription_id": id}, nil
+	})
+	f.handle(rpc.MethodStreamCancel, func(params json.RawMessage) (any, *rpc.Error) {
+		var p rpc.StreamCancel
+		_ = json.Unmarshal(params, &p)
+		if p.ID == id {
+			select {
+			case s.cancelled <- struct{}{}:
+			default:
+			}
+			s.end(map[string]any{"started": []string{}})
+		}
+		return rpc.OKResult{OK: true}, nil
+	})
+	return s
+}
+
+func (s *streamer) chunk(v any) {
+	raw, _ := json.Marshal(v)
+	s.notify(rpc.MethodStreamChunk, rpc.StreamChunk{ID: s.id, Data: raw})
+}
+
+func (s *streamer) end(v any) {
+	raw, _ := json.Marshal(v)
+	s.notify(rpc.MethodStreamEnd, rpc.StreamEnd{ID: s.id, Data: raw})
+}
+
+func (s *streamer) notify(method string, params any) {
+	s.fake.mu.Lock()
+	enc := s.fake.enc
+	s.fake.mu.Unlock()
+	if enc == nil {
+		return
+	}
+	raw, _ := json.Marshal(params)
+	_ = enc.Encode(rpc.Notification{JSONRPC: rpc.Version, Method: method, Params: raw})
+}
+
+func TestForwardRelaysAStream(t *testing.T) {
+	m, fake, _, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+	s := newStreamer(fake, "groups.start", "sub-7")
+	fake.waitSubscribed(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	reply, stream, err := m.Forward(ctx, "hetzner", "groups.start", json.RawMessage(`{"name":"api"}`))
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if stream == nil {
+		t.Fatal("a reply with a subscription id must come back as a stream")
+	}
+	var start rpc.GroupsStartResult
+	if err := json.Unmarshal(reply, &start); err != nil {
+		t.Fatal(err)
+	}
+	if start.SubscriptionID != "sub-7" {
+		t.Errorf("reply = %s, want the remote's subscription id", reply)
+	}
+
+	s.chunk(rpc.GroupsStartChunk{Service: "api", PID: 4242})
+	select {
+	case raw := <-stream.Chunks():
+		var chunk rpc.GroupsStartChunk
+		if err := json.Unmarshal(raw, &chunk); err != nil {
+			t.Fatal(err)
+		}
+		if chunk.Service != "api" || chunk.PID != 4242 {
+			t.Errorf("chunk = %+v", chunk)
+		}
+	case <-time.After(testTimeout):
+		t.Fatal("the chunk never arrived")
+	}
+
+	s.end(rpc.GroupsStartEnd{Started: []string{"api"}})
+	select {
+	case end := <-stream.End():
+		if end.Err != nil {
+			t.Fatalf("stream ended with %v", end.Err)
+		}
+		var summary rpc.GroupsStartEnd
+		if err := json.Unmarshal(end.Data, &summary); err != nil {
+			t.Fatal(err)
+		}
+		if len(summary.Started) != 1 || summary.Started[0] != "api" {
+			t.Errorf("end = %+v", summary)
+		}
+	case <-time.After(testTimeout):
+		t.Fatal("the stream never ended")
+	}
+}
+
+// Cancelling the relayed stream cancels the remote one: the far side is what
+// is doing the work, and it has to stop.
+func TestForwardPropagatesCancel(t *testing.T) {
+	m, fake, _, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+	s := newStreamer(fake, "ports.logs", "sub-9")
+	fake.waitSubscribed(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	_, stream, err := m.Forward(ctx, "hetzner", "ports.logs", json.RawMessage(`{"port":3000,"follow":true}`))
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if stream == nil {
+		t.Fatal("follow:true must come back as a stream")
+	}
+	if err := stream.Cancel(ctx); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	select {
+	case <-s.cancelled:
+	case <-time.After(testTimeout):
+		t.Fatal("the remote daemon never saw the stream.cancel")
+	}
+	select {
+	case <-stream.End():
+	case <-time.After(testTimeout):
+		t.Fatal("a cancelled stream must still end")
+	}
+}
+
+// A plain method is not a stream, however hard the relay looks.
+func TestForwardOfAPlainMethodHasNoStream(t *testing.T) {
+	m, fake, _, _ := newTestManager(t, Host{Name: "hetzner", Target: "deploy@box"})
+	fake.handle("ports.list", func(json.RawMessage) (any, *rpc.Error) {
+		return rpc.PortsListResult{}, nil
+	})
+	fake.waitSubscribed(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	_, stream, err := m.Forward(ctx, "hetzner", "ports.list", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	if stream != nil {
+		t.Error("ports.list is not a streaming method")
+	}
+}
+
+func TestForwardOnAnUnknownHostFails(t *testing.T) {
+	m, _, _, _ := newTestManager(t)
+	if _, _, err := m.Forward(context.Background(), "nope", "ports.list", nil); err == nil {
+		t.Fatal("want an error for an unregistered host")
+	}
+}

--- a/internal/remote/handlers.go
+++ b/internal/remote/handlers.go
@@ -49,6 +49,7 @@ func init() {
 
 	daemon.OnStart(start)
 	daemon.OnShutdown(func(bool) {
+		daemon.SetRouter(nil)
 		if m := Current(); m != nil {
 			m.Stop()
 			setManager(nil)
@@ -72,6 +73,7 @@ func start(rt *daemon.Runtime) {
 		OnEvent:  rt.Server().BroadcastEvent,
 	})
 	setManager(m)
+	daemon.SetRouter(m)
 	rt.Scanner.SetRemote(m.Rows)
 	m.Start(context.Background(), hosts)
 	if len(hosts) > 0 {
@@ -180,18 +182,25 @@ func handleCall(ctx context.Context, req *daemon.Request) (any, error) {
 			"call "+p.Method+" directly instead")
 	}
 
+	if !m.Has(p.Host) {
+		return nil, unknownHostError(m, p.Host)
+	}
+
 	params := p.Params
 	if len(params) == 0 {
 		params = json.RawMessage("{}")
 	}
-	out, err := m.Call(ctx, p.Host, p.Method, params)
+	// The typed path and the generic one are the same path: `remote.call
+	// {host, method}` and `<method> {host}` both end in daemon.ForwardTo, so a
+	// streaming method streams either way and a result is retagged either way.
+	out, err := daemon.ForwardTo(ctx, req, p.Host, p.Method, params)
 	if err != nil {
 		if errors.Is(err, ErrUnknownHost) {
 			return nil, unknownHostError(m, p.Host)
 		}
 		return nil, err
 	}
-	return rpc.RemoteCallResult(out), nil
+	return out, nil
 }
 
 // TargetOf is the SSH destination a remote.add call names. Some clients spell

--- a/internal/remote/handlers.go
+++ b/internal/remote/handlers.go
@@ -159,6 +159,12 @@ func handleRemove(_ context.Context, req *daemon.Request) (any, error) {
 // same rules as the local one, so there is no read-only mode (remote-hosts
 // spec, decision 3).
 //
+// It is the generic form of the `host` field every method now takes, and takes
+// exactly the same path (contract §43): a streaming method streams, and the
+// rows that come back say which host they are from rather than calling
+// themselves "localhost". The params are still passed through untouched — a
+// caller that spells the method out is spelling its params out too.
+//
 // `remote.call` is deliberately not a recursion guard's business: the far side
 // subscribes to nothing but its own machine, so forwarding `remote.call` to a
 // host that has hosts of its own reaches exactly one level, which is what a

--- a/internal/remoteinstall/install.go
+++ b/internal/remoteinstall/install.go
@@ -10,6 +10,9 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
 )
 
 // Options is one `sonar remote install` run.
@@ -66,8 +69,8 @@ type Progress func(step, detail string)
 // The whole download happens on the far end (spec, decision 2): this side only
 // resolves which release asset to fetch and what its sha256 must be, writes a
 // shell script that says so, and pipes it to `sh -s` over one ssh session. Two
-// short sessions bracket it: `uname -s -m` before, to pick the asset, and
-// `sonar version` plus `sonar daemon status` after, to prove it worked.
+// short sessions bracket it: `uname -s -m` before, to pick the asset, and a
+// `daemon.hello` over `sonar daemon stdio` after, to prove it worked.
 //
 // Re-running upgrades in place: the binary is replaced atomically and the
 // service restarted, so an install and an update are the same operation.
@@ -170,13 +173,24 @@ type daemonStatus struct {
 
 // check runs the post-install verification and fills in the result.
 //
-// When step 3A.2's `sonar daemon stdio` lands this becomes a `daemon.hello`
-// over the bridge, which proves the protocol as well as the process. Until
-// then `daemon status` over a second ssh session is the same answer one hop
-// further out.
+// It is a real `daemon.hello` over `ssh <target> sonar daemon stdio` — the same
+// session the bridge opens — so what it proves is what the next thing to happen
+// actually needs: the binary runs, its daemon is up, and it speaks a protocol
+// major this build can talk to. `daemon status --json` over a second ssh
+// session, which is what 3A.3 shipped, could only prove the first two, and one
+// hop further out (contract §40, §43).
+//
+// The one case that cannot be checked this way is --no-service: nothing was
+// started, so there is no daemon to speak to and the binary itself is all there
+// is to ask.
 func check(ctx context.Context, r runner, res *Result, progress Progress) error {
 	progress(StepCheck, res.BinPath)
 
+	if res.Service == ServiceNone {
+		return checkBinary(ctx, r, res)
+	}
+
+	var lastErr error
 	for attempt := 0; attempt < checkAttempts; attempt++ {
 		if attempt > 0 {
 			select {
@@ -185,33 +199,78 @@ func check(ctx context.Context, r runner, res *Result, progress Progress) error 
 			case <-time.After(checkBackoff):
 			}
 		}
-		out, err := r.output(ctx, verifyCommand)
+		hello, err := helloOverStdio(ctx, r)
 		if err != nil {
-			return err
+			// systemctl returns as soon as it has forked the unit, so the
+			// first attempt can legitimately find nothing listening.
+			lastErr = err
+			continue
 		}
-
-		res.RemoteVersion = parseVersionLine(out)
-		if res.RemoteVersion == "" {
-			return fmt.Errorf("installed %s on %s, but `%s version` printed nothing usable: %s",
-				res.Version, res.Target, res.BinPath, strings.TrimSpace(firstLine(out)))
-		}
-		if res.RemoteVersion != res.Version {
-			return fmt.Errorf("installed %s on %s, but the binary there reports %s",
-				res.Version, res.Target, res.RemoteVersion)
-		}
-
-		if status, ok := parseDaemonStatus(out); ok {
-			res.DaemonRunning = status.Running
-			res.DaemonPID = status.PID
-		}
-		if res.DaemonRunning || res.Service == ServiceNone {
-			break
-		}
+		res.RemoteVersion = hello.DaemonVersion
+		res.DaemonRunning, res.DaemonPID = true, hello.PID
+		break
 	}
 
-	if res.Service != ServiceNone && !res.DaemonRunning {
-		return fmt.Errorf("installed %s on %s, but its daemon is not running\nhint: `ssh %s %s daemon log` says why",
-			res.Version, res.Target, res.Target, res.BinPath)
+	if !res.DaemonRunning {
+		return fmt.Errorf("installed %s on %s, but its daemon never answered: %v\nhint: `ssh %s %s daemon log` says why",
+			res.Version, res.Target, lastErr, res.Target, res.BinPath)
+	}
+	if res.RemoteVersion == "" {
+		return fmt.Errorf("installed %s on %s, but its daemon does not report a version",
+			res.Version, res.Target)
+	}
+	if res.RemoteVersion != res.Version {
+		return fmt.Errorf("installed %s on %s, but the daemon there reports %s",
+			res.Version, res.Target, res.RemoteVersion)
+	}
+	return nil
+}
+
+// helloOverStdio opens one `sonar daemon stdio` session and completes the
+// handshake. `--no-autostart` is deliberate: the check is asking whether the
+// service this install set up is running, and a daemon it started itself would
+// answer the wrong question.
+func helloOverStdio(ctx context.Context, r runner) (rpc.DaemonHelloResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, helloTimeout)
+	defer cancel()
+
+	stream, err := r.stdio(ctx, `"`+BinPath+`" daemon stdio --no-autostart`)
+	if err != nil {
+		return rpc.DaemonHelloResult{}, err
+	}
+	defer stream.Close()
+
+	c, err := client.Attach(ctx, stream, "ssh://"+r.target, client.ClientInfo{
+		Name: "cli", Version: "remote-install",
+	})
+	if err != nil {
+		return rpc.DaemonHelloResult{}, err
+	}
+	defer c.Close()
+	return c.Hello(), nil
+}
+
+// helloTimeout bounds one handshake attempt. A cold ssh session pays for the
+// TCP handshake, the key exchange and a login shell before anything sonar does.
+const helloTimeout = 30 * time.Second
+
+// checkBinary is the --no-service path: ask the installed binary what it is.
+func checkBinary(ctx context.Context, r runner, res *Result) error {
+	out, err := r.output(ctx, verifyCommand)
+	if err != nil {
+		return err
+	}
+	res.RemoteVersion = parseVersionLine(out)
+	if res.RemoteVersion == "" {
+		return fmt.Errorf("installed %s on %s, but `%s version` printed nothing usable: %s",
+			res.Version, res.Target, res.BinPath, strings.TrimSpace(firstLine(out)))
+	}
+	if res.RemoteVersion != res.Version {
+		return fmt.Errorf("installed %s on %s, but the binary there reports %s",
+			res.Version, res.Target, res.RemoteVersion)
+	}
+	if status, ok := parseDaemonStatus(out); ok {
+		res.DaemonRunning, res.DaemonPID = status.Running, status.PID
 	}
 	return nil
 }

--- a/internal/remoteinstall/ssh.go
+++ b/internal/remoteinstall/ssh.go
@@ -3,12 +3,14 @@ package remoteinstall
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -98,6 +100,71 @@ func (r runner) stream(ctx context.Context, remoteCmd string, stdin io.Reader, o
 	if err := cmd.Wait(); err != nil {
 		return sshError(r.target, err, stderr.String())
 	}
+	return nil
+}
+
+// stdio runs a remote command and hands back its stdin and stdout as one
+// stream, which is what a JSON-RPC session over ssh is. It is the same shape
+// internal/remote's bridge dials; this one lives for a single handshake.
+//
+// Closing the stream closes the far side's stdin and, if that is not taken as a
+// hint, kills the ssh process.
+func (r runner) stdio(ctx context.Context, remoteCmd string) (io.ReadWriteCloser, error) {
+	cmd := r.command(ctx, remoteCmd)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("running ssh: %w", err)
+	}
+	return &stdioSession{cmd: cmd, in: stdin, out: stdout, errs: &stderr, target: r.target}, nil
+}
+
+// stdioSession is one `ssh <target> sonar daemon stdio` seen as a stream.
+type stdioSession struct {
+	cmd    *exec.Cmd
+	in     io.WriteCloser
+	out    io.ReadCloser
+	errs   *bytes.Buffer
+	target string
+	once   sync.Once
+}
+
+func (s *stdioSession) Read(b []byte) (int, error) {
+	n, err := s.out.Read(b)
+	if errors.Is(err, io.EOF) {
+		// The far side hanging up is only the whole story when ssh and the
+		// remote shell had nothing to say. When they did — "command not
+		// found", "Permission denied" — that is the diagnosis.
+		if msg := firstErrorLine(s.errs.String()); msg != "" {
+			return n, sshError(s.target, err, msg)
+		}
+	}
+	return n, err
+}
+
+func (s *stdioSession) Write(b []byte) (int, error) { return s.in.Write(b) }
+
+func (s *stdioSession) Close() error {
+	s.once.Do(func() {
+		_ = s.in.Close()
+		_ = s.out.Close()
+		if s.cmd.Process != nil {
+			_ = s.cmd.Process.Kill()
+		}
+		_ = s.cmd.Wait()
+	})
 	return nil
 }
 

--- a/internal/state/convert.go
+++ b/internal/state/convert.go
@@ -8,9 +8,10 @@ import "github.com/raskrebs/sonar/internal/ports"
 // byte-identical rows.
 func FromListening(lp ports.ListeningPort) Port {
 	p := Port{
-		// A row built straight from a scan is this machine's own. The daemon
-		// re-tags rows it multiplexes in from a remote bridge.
-		Host:        LocalhostName,
+		// A row built straight from a scan is this machine's own; a row that
+		// came back from the daemon already knows which host it is from. The
+		// daemon re-tags rows it multiplexes in from a remote bridge.
+		Host:        HostOf(lp.Host),
 		Port:        lp.Port,
 		BindAddress: lp.BindAddress,
 		IPVersion:   lp.IPVersion,

--- a/internal/state/key.go
+++ b/internal/state/key.go
@@ -1,0 +1,54 @@
+package state
+
+import (
+	"strconv"
+	"strings"
+)
+
+// The other half of PrefixKey: taking a delta key apart again.
+//
+// Clients hold the keys the stream gave them — `"3000:127.0.0.1"` for a local
+// row, `"hetzner/3000:127.0.0.1"` for a remote one — and the natural thing to
+// do with one is to hand it straight back as a selector. These two functions
+// are what makes that work, on the daemon side, without every handler learning
+// the grammar.
+
+// SplitHostPrefix takes a `"<host>/<rest>"` key apart. The prefix is only read
+// as a host when known says so, which keeps a group whose name happens to
+// contain a slash from being mistaken for a remote row: sonar knows exactly
+// which host names exist, so it never has to guess.
+//
+// A key with no recognised prefix comes back unchanged with an empty host,
+// which is the localhost case and the overwhelmingly common one.
+func SplitHostPrefix(key string, known func(string) bool) (host, rest string) {
+	name, after, found := strings.Cut(key, "/")
+	if !found || name == "" || after == "" {
+		return "", key
+	}
+	if name == LocalhostName {
+		return LocalhostName, after
+	}
+	if known != nil && known(name) {
+		return name, after
+	}
+	return "", key
+}
+
+// ParsePortKey reads the `"<port>"` or `"<port>:<bind_address>"` half of a port
+// key. The bind address may itself contain colons (`"::1"`, `"::"`), so the
+// split is at the first one only.
+func ParsePortKey(key string) (port int, bind string, ok bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return 0, "", false
+	}
+	head, tail, found := strings.Cut(key, ":")
+	n, err := strconv.Atoi(head)
+	if err != nil || n <= 0 || n > 65535 {
+		return 0, "", false
+	}
+	if !found {
+		return n, "", true
+	}
+	return n, tail, true
+}

--- a/internal/state/key_test.go
+++ b/internal/state/key_test.go
@@ -1,0 +1,81 @@
+package state
+
+import "testing"
+
+func TestSplitHostPrefix(t *testing.T) {
+	known := func(name string) bool { return name == "hetzner" }
+
+	cases := []struct {
+		key       string
+		wantHost  string
+		wantRest  string
+		knownFunc func(string) bool
+	}{
+		{"3000:127.0.0.1", "", "3000:127.0.0.1", known},
+		{"hetzner/3000:127.0.0.1", "hetzner", "3000:127.0.0.1", known},
+		{"localhost/3000:127.0.0.1", "localhost", "3000:127.0.0.1", known},
+		// An unregistered prefix is not a host: it is part of the name, and a
+		// group may legitimately be called that.
+		{"nope/3000", "", "nope/3000", known},
+		{"my/group", "", "my/group", known},
+		{"hetzner/api", "hetzner", "api", known},
+		// Nothing is known when there are no hosts at all.
+		{"hetzner/3000", "", "hetzner/3000", nil},
+		// Degenerate forms stay whole.
+		{"/3000", "", "/3000", known},
+		{"hetzner/", "", "hetzner/", known},
+		{"", "", "", known},
+	}
+	for _, c := range cases {
+		host, rest := SplitHostPrefix(c.key, c.knownFunc)
+		if host != c.wantHost || rest != c.wantRest {
+			t.Errorf("SplitHostPrefix(%q) = (%q, %q), want (%q, %q)",
+				c.key, host, rest, c.wantHost, c.wantRest)
+		}
+	}
+}
+
+func TestParsePortKey(t *testing.T) {
+	cases := []struct {
+		key      string
+		wantPort int
+		wantBind string
+		wantOK   bool
+	}{
+		{"3000", 3000, "", true},
+		{"3000:127.0.0.1", 3000, "127.0.0.1", true},
+		{"3000:0.0.0.0", 3000, "0.0.0.0", true},
+		// An IPv6 bind address is full of colons; only the first one splits.
+		{"8080:::1", 8080, "::1", true},
+		{"8080:::", 8080, "::", true},
+		{"8080:*", 8080, "*", true},
+		{"", 0, "", false},
+		{"api", 0, "", false},
+		{"0:127.0.0.1", 0, "", false},
+		{"70000", 0, "", false},
+	}
+	for _, c := range cases {
+		port, bind, ok := ParsePortKey(c.key)
+		if port != c.wantPort || bind != c.wantBind || ok != c.wantOK {
+			t.Errorf("ParsePortKey(%q) = (%d, %q, %v), want (%d, %q, %v)",
+				c.key, port, bind, ok, c.wantPort, c.wantBind, c.wantOK)
+		}
+	}
+}
+
+// The two halves must compose: what PrefixKey builds, SplitHostPrefix and
+// ParsePortKey take apart again.
+func TestKeyRoundTrip(t *testing.T) {
+	known := func(name string) bool { return name == "hetzner" }
+	for _, host := range []string{"", LocalhostName, "hetzner"} {
+		p := Port{Host: host, Port: 3000, BindAddress: "::1"}
+		gotHost, rest := SplitHostPrefix(p.Key(), known)
+		if HostOf(gotHost) != HostOf(host) {
+			t.Errorf("host of %q = %q, want %q", p.Key(), gotHost, host)
+		}
+		port, bind, ok := ParsePortKey(rest)
+		if !ok || port != 3000 || bind != "::1" {
+			t.Errorf("ParsePortKey(%q) = (%d, %q, %v)", rest, port, bind, ok)
+		}
+	}
+}

--- a/internal/state/kill.go
+++ b/internal/state/kill.go
@@ -33,6 +33,10 @@ var AllKillMethods = []KillMethod{
 // emits one row per signalled process, children before parents, every row
 // carrying the port of the listener whose tree it belongs to.
 type KillResult struct {
+	// Host is the machine the row happened on: "localhost" for this one, the
+	// registered name for a kill that was forwarded to a remote host (contract
+	// §39: every row carries a host, and local rows say so).
+	Host        string     `json:"host"`
 	Port        int        `json:"port"`
 	BindAddress string     `json:"bind_address"`
 	PID         int        `json:"pid"`

--- a/internal/state/tolistening.go
+++ b/internal/state/tolistening.go
@@ -19,6 +19,7 @@ import (
 // ever published.
 func ToListening(p Port) ports.ListeningPort {
 	lp := ports.ListeningPort{
+		Host:        p.Host,
 		Port:        p.Port,
 		PID:         p.PID,
 		PPID:        p.PPID,


### PR DESCRIPTION
Every method except `state.*`, `stream.*`, `daemon.hello`, `daemon.shutdown` and `remote.*` accepts `host` (top-level, on a selector, as a `<host>/` prefix on a key or name) and is forwarded to that host through the bridge, results retagged with the host and streams relayed under the local subscription id. `--host <name>` on `kill`, `kill-all`, `down`, `up`, `logs`, `rename` and `assign`; `sonar list --host "*"` with an automatic HOST column. The post-install check from `sonar remote install` now does `daemon.hello` over `sonar daemon stdio`.