### PR TITLE
fix: isolate every test binary from the live sonar install and refuse to run one as the daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,8 +606,10 @@ services:               # label custom/unknown ports
 ```
 
 Invalid values are ignored with a warning and sonar carries on with defaults.
-Environment overrides that have no config key: `SONAR_DB`, `SONAR_SOCKET`, and
-`SONAR_NO_HINTS=1` to silence the migration notices below.
+Environment overrides that have no config key: `SONAR_DB`, `SONAR_SOCKET`,
+`SONAR_NO_HINTS=1` to silence the migration notices below, and
+`SONAR_NO_AUTOSTART=1` to stop any sonar client from starting a daemon it did
+not find — useful in CI, where a build should never leave a process behind.
 
 ### Agents: MCP, skills and hooks
 

--- a/internal/claims/main_test.go
+++ b/internal/claims/main_test.go
@@ -1,0 +1,13 @@
+package claims
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/cmd/isolation_test.go
+++ b/internal/cmd/isolation_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/install"
+	"github.com/raskrebs/sonar/internal/store"
+	"github.com/raskrebs/sonar/internal/testenv"
+	"github.com/spf13/cobra"
+)
+
+// This is the package that leaked. Its tests drive the real commands, so every
+// path the CLI resolves has to land in the test's own temp directory — checked
+// through the production resolvers, not through a restatement of them.
+func TestEverythingTheCLIResolvesIsIsolated(t *testing.T) {
+	testenv.RequireIsolated(t,
+		config.Path(),
+		store.Path(),
+		daemon.ConfigDir(),
+		daemon.SocketPath(),
+		daemon.LogPath(),
+		daemon.LockPath(),
+		install.Home(),
+	)
+
+	// The live install is the thing these tests spent an afternoon writing to,
+	// so it gets named explicitly rather than only implied by the temp check.
+	if live := testenv.RealHome(); live != "" {
+		if under(config.Path(), filepath.Join(live, ".config", "sonar")) {
+			t.Fatalf("config.Path() = %s: the tests are pointed at the live install", config.Path())
+		}
+		if under(store.Path(), filepath.Join(live, ".config", "sonar")) {
+			t.Fatalf("store.Path() = %s: the tests would write to the live database", store.Path())
+		}
+	}
+}
+
+func under(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	return err == nil && !strings.HasPrefix(rel, "..")
+}
+
+// The autostart path is what forked `cmd.test serve --detach`. Two independent
+// things now stop it, and both are checked here because either alone would
+// have been enough to prevent the 2,150 leaked processes.
+func TestAutostartIsRefusedInTests(t *testing.T) {
+	// One: the process-wide ban TestMain sets.
+	err := client.Autostart(context.Background(), "", daemon.SocketPath())
+	if err == nil {
+		t.Fatal("Autostart succeeded in a test binary")
+	}
+	if !strings.Contains(err.Error(), client.NoAutostartEnv) {
+		t.Errorf("error = %v, want it to name %s", err, client.NoAutostartEnv)
+	}
+
+	// Two: even with the ban lifted, the executable is a test binary.
+	testenv.AllowAutostart(t)
+	err = client.Autostart(context.Background(), "", daemon.SocketPath())
+	if err == nil {
+		t.Fatal("Autostart succeeded with a Go test binary as the daemon")
+	}
+	if !strings.Contains(err.Error(), "test binary") {
+		t.Errorf("error = %v, want it to say the binary is a test binary", err)
+	}
+}
+
+// The production seam on the other side: `sonar serve` inside a test binary
+// refuses rather than re-running the suite in the background.
+func TestServeRefusesToRunAsATestBinary(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := serveRun(cmd, nil)
+	if err == nil {
+		t.Fatal("serve started inside a test binary")
+	}
+	if !strings.Contains(err.Error(), daemon.AllowTestDaemonEnv) {
+		t.Errorf("error = %v, want it to name the opt-out %s", err, daemon.AllowTestDaemonEnv)
+	}
+
+	t.Setenv(daemon.AllowTestDaemonEnv, "1")
+	if err := refuseTestBinaryDaemon(); err != nil {
+		t.Errorf("the explicit opt-in did not lift the guard: %v", err)
+	}
+}
+
+// Nothing here starts a daemon of its own, so nothing may be left running.
+// TestMain checks this for the whole binary; this makes the failure land on a
+// named test when it is this package's fault.
+func TestNoDaemonSurvivesThisPackage(t *testing.T) {
+	testenv.RequireNoLeakedDaemons(t)
+}

--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -41,6 +41,10 @@ func init() {
 }
 
 func serveRun(cmd *cobra.Command, _ []string) error {
+	if err := refuseTestBinaryDaemon(); err != nil {
+		return err
+	}
+
 	socket := daemon.SocketPath()
 
 	if serveDetach {
@@ -79,6 +83,24 @@ func serveRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	return nil
+}
+
+// refuseTestBinaryDaemon stops a Go test binary from becoming the daemon.
+//
+// `go test` links a package into <pkg>.test, and Go's flag parser stops at the
+// first non-flag argument — so `cmd.test serve --detach` silently ignores both
+// words and runs the entire test suite in the background against the config
+// directory it inherited. Every such process is a stray test run holding the
+// user's real ~/.config/sonar open, not a daemon (step 1A.20). Both entry
+// points are covered: `serve` refuses here, and `serve --detach` re-execs this
+// same binary, so it never gets far enough to fork.
+func refuseTestBinaryDaemon() error {
+	exe, err := os.Executable()
+	if err != nil || !daemon.IsTestBinary(exe) || daemon.TestDaemonAllowed() {
+		return nil
+	}
+	return fmt.Errorf("refusing to run %s as the sonar daemon: it is a Go test binary, so this would re-run the test suite rather than serve\nhint: start a daemon in-process from the test, or set %s=1 if you really mean it",
+		filepath.Base(exe), daemon.AllowTestDaemonEnv)
 }
 
 // detachDaemon re-execs this binary as a background `sonar serve` and waits for

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -175,6 +175,9 @@ const template = `# sonar configuration
 #                  (default: what 'sonar daemon path' prints)
 #   SONAR_NO_HINTS set to 1 to silence the migration notices the renamed
 #                  commands print
+#   SONAR_NO_AUTOSTART
+#                  set to 1 to stop clients starting a daemon that is not
+#                  already running; they report it as unavailable instead
 `
 
 // WriteTemplate writes a commented starter config to Path(), creating the

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/daemon/client/autostart.go
+++ b/internal/daemon/client/autostart.go
@@ -14,13 +14,33 @@ import (
 // pollInterval is how often Autostart retries the dial while waiting.
 const pollInterval = 25 * time.Millisecond
 
+// NoAutostartEnv disables autostart for a whole process tree. `sonar` never
+// starts a daemon behind the back of anything that sets it, which is what the
+// test harness (internal/testenv) and CI use to keep a build from leaving a
+// daemon running on the machine.
+const NoAutostartEnv = "SONAR_NO_AUTOSTART"
+
 // Autostart spawns `sonar serve --detach` and waits, up to AutostartTimeout,
 // for the socket to accept connections (contract §7). binary defaults to the
 // running executable, so a client always starts the daemon it was built with.
+//
+// It refuses in two cases, both of them "this is not a sonar install": when
+// NoAutostartEnv is set, and when the executable it would spawn is a Go test
+// binary (see daemon.IsTestBinary — that spawn re-runs the test suite in the
+// background rather than starting a daemon).
 func Autostart(ctx context.Context, binary, socket string) error {
+	if daemon.EnvEnabled(os.Getenv(NoAutostartEnv)) {
+		return fmt.Errorf("%w: autostart is disabled by %s=%s",
+			ErrNotRunning, NoAutostartEnv, os.Getenv(NoAutostartEnv))
+	}
+
 	exe, err := resolveBinary(binary)
 	if err != nil {
 		return err
+	}
+	if daemon.IsTestBinary(exe) && !daemon.TestDaemonAllowed() {
+		return fmt.Errorf("%w: refusing to autostart %s: it is a Go test binary, and `%s serve --detach` re-runs the whole test suite in the background instead of starting a daemon\nhint: a test needs an in-process daemon, or %s=1 to override",
+			ErrNotRunning, filepath.Base(exe), filepath.Base(exe), daemon.AllowTestDaemonEnv)
 	}
 
 	cmd := exec.Command(exe, "serve", "--detach")

--- a/internal/daemon/client/autostart_guard_test.go
+++ b/internal/daemon/client/autostart_guard_test.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon"
+)
+
+// Autostart is the one function in the tree that starts a process the caller
+// did not ask for by name, so both of its refusals are pinned.
+
+func TestAutostartHonoursTheEnvironmentSwitch(t *testing.T) {
+	t.Setenv(NoAutostartEnv, "1")
+	err := Autostart(context.Background(), filepath.Join(t.TempDir(), "sonar"), "")
+	if err == nil {
+		t.Fatal("Autostart ran with autostart disabled")
+	}
+	if !strings.Contains(err.Error(), NoAutostartEnv) {
+		t.Errorf("error = %v, want it to name %s", err, NoAutostartEnv)
+	}
+	if !isNotRunning(err) {
+		t.Errorf("error = %v, want it to wrap ErrNotRunning so callers still fall back", err)
+	}
+}
+
+// The belt-and-braces guard: even with autostart allowed, a Go test binary is
+// never spawned as the daemon. Handing it `serve --detach` would re-run the
+// whole suite in the background instead (step 1A.20).
+func TestAutostartRefusesATestBinary(t *testing.T) {
+	t.Setenv(NoAutostartEnv, "")
+	// It exits non-zero, so the opt-in case below fails fast on the spawn
+	// rather than sitting out the three-second wait for a socket.
+	fake := filepath.Join(t.TempDir(), "guardfake.test")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Autostart(context.Background(), fake, "")
+	if err == nil {
+		t.Fatal("Autostart spawned a Go test binary as the daemon")
+	}
+	if !strings.Contains(err.Error(), "test binary") || !strings.Contains(err.Error(), daemon.AllowTestDaemonEnv) {
+		t.Errorf("error = %v, want it to explain the refusal and name the opt-in", err)
+	}
+
+	// The opt-in exists so a harness that really means it can say so.
+	t.Setenv(daemon.AllowTestDaemonEnv, "1")
+	err = Autostart(context.Background(), fake, filepath.Join(t.TempDir(), "d.sock"))
+	if err != nil && strings.Contains(err.Error(), "test binary") {
+		t.Errorf("the opt-in did not lift the guard: %v", err)
+	}
+}
+
+func isNotRunning(err error) bool { return strings.Contains(err.Error(), ErrNotRunning.Error()) }

--- a/internal/daemon/client/main_test.go
+++ b/internal/daemon/client/main_test.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/daemon/groupstart/start_test.go
+++ b/internal/daemon/groupstart/start_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/raskrebs/sonar/internal/groups"
 	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/testenv"
 )
 
 // The child side of every test here: re-running this binary with
@@ -30,9 +31,12 @@ const (
 	envDelay  = "SONAR_TEST_LISTEN_DELAY"
 )
 
+// TestMain doubles as the service a group starts. A service is not a test run,
+// so only the test branch is isolated; the child inherits the environment its
+// parent was already isolated into.
 func TestMain(m *testing.M) {
 	if os.Getenv(envListen) == "" {
-		os.Exit(m.Run())
+		os.Exit(testenv.Run(m))
 	}
 	if d, err := time.ParseDuration(os.Getenv(envDelay)); err == nil && d > 0 {
 		time.Sleep(d)

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/runs"
 	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/testenv"
 )
 
 // buildBinary compiles the sonar CLI once per test run.
@@ -155,6 +156,14 @@ func (e *env) command(args ...string) *exec.Cmd {
 		"SONAR_SOCKET="+e.socket,
 		// XDG_RUNTIME_DIR would otherwise outrank HOME for the log path.
 		"XDG_RUNTIME_DIR=",
+		// The test binary is isolated with one SONAR_DB for the whole run
+		// (internal/testenv); clearing it puts this env's database under this
+		// env's HOME, which is what a test that restarts a daemon and expects
+		// its own rows back is asking for.
+		"SONAR_DB=",
+		// These children are the real `sonar`, and the tests here are the ones
+		// that drive its autostart on purpose.
+		testenv.ChildEnv(),
 	)
 	return cmd
 }
@@ -431,11 +440,14 @@ func TestAutostart(t *testing.T) {
 	}
 
 	// Connect uses the running executable by default; point it at the built
-	// binary and give the child the same isolated HOME.
+	// binary and give the child the same isolated HOME. Autostart is off for
+	// the test binary as a whole, and this is the test that exists to drive it.
+	testenv.AllowAutostart(t)
 	t.Setenv("HOME", e.home)
 	t.Setenv("USERPROFILE", e.home)
 	t.Setenv("SONAR_SOCKET", e.socket)
 	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("SONAR_DB", "")
 
 	c, err := client.Connect(ctx, client.ClientInfo{
 		Name: "cli", Version: "itest", Socket: e.socket, BinaryPath: e.bin,

--- a/internal/daemon/main_test.go
+++ b/internal/daemon/main_test.go
@@ -1,0 +1,13 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/daemon/rpc/main_test.go
+++ b/internal/daemon/rpc/main_test.go
@@ -1,0 +1,13 @@
+package rpc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/daemon/runsreg/main_test.go
+++ b/internal/daemon/runsreg/main_test.go
@@ -1,0 +1,13 @@
+package runsreg
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/daemon/testguard.go
+++ b/internal/daemon/testguard.go
@@ -1,0 +1,52 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A Go test binary must never become a sonar daemon.
+//
+// `go test` links each package into an executable named <pkg>.test. Handing
+// that executable the arguments `serve --detach` does not start a daemon: Go's
+// flag package stops parsing at the first non-flag argument, so `serve` and
+// `--detach` are ignored and the binary runs the whole test suite again, in
+// the background, against whatever HOME it inherited. A test that reaches the
+// autostart path therefore forks a copy of itself every time it runs, and any
+// test in that copy which reaches the same path forks again — which is how one
+// afternoon of `go test` left 2,150 `cmd.test serve --detach` processes behind
+// and exhausted swap (step 1A.20).
+//
+// The guard lives here because both ends need it: the client that would spawn
+// the daemon (internal/daemon/client.Autostart) and the `sonar serve` that
+// would become one (internal/cmd).
+
+// AllowTestDaemonEnv opts a test binary back in to acting as a daemon. It
+// exists so the guard can be exercised, and so a future harness that genuinely
+// wants a test binary as its daemon can say so out loud. Nothing in the tree
+// sets it.
+const AllowTestDaemonEnv = "SONAR_ALLOW_TEST_DAEMON"
+
+// IsTestBinary reports whether path names a Go test binary. `go test` always
+// names one <pkg>.test (<pkg>.test.exe on Windows), whether it runs it from
+// the build cache or `go test -c` writes it out.
+func IsTestBinary(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	base = strings.TrimSuffix(base, ".exe")
+	return strings.HasSuffix(base, ".test")
+}
+
+// TestDaemonAllowed reports whether AllowTestDaemonEnv opts this process in.
+func TestDaemonAllowed() bool { return EnvEnabled(os.Getenv(AllowTestDaemonEnv)) }
+
+// EnvEnabled reads a boolean environment variable the way the shell reads one:
+// unset, empty, "0", "false" and "no" are off, anything else is on. Sonar's
+// env switches are all opt-in flags, so "set to anything" has to mean on.
+func EnvEnabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "0", "false", "no":
+		return false
+	}
+	return true
+}

--- a/internal/daemon/testguard_test.go
+++ b/internal/daemon/testguard_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import "testing"
+
+func TestIsTestBinary(t *testing.T) {
+	tests := map[string]bool{
+		"/tmp/go-build123/b001/cmd.test":     true,
+		"/tmp/go-build123/b001/daemon.test":  true,
+		`C:\Temp\go-build\b001\cmd.test.exe`: true,
+		"cmd.test":                           true,
+		"/usr/local/bin/sonar":               false,
+		`C:\Program Files\sonar\sonar.exe`:   false,
+		"/tmp/sonar-itest-bin123/sonar":      false,
+		"/home/dev/testing/sonar":            false,
+		"/home/dev/sonar.test.backup/sonar":  false,
+	}
+	for path, want := range tests {
+		if got := IsTestBinary(path); got != want {
+			t.Errorf("IsTestBinary(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestEnvEnabled(t *testing.T) {
+	off := []string{"", "0", "false", "no", " FALSE "}
+	for _, v := range off {
+		if EnvEnabled(v) {
+			t.Errorf("EnvEnabled(%q) = true, want false", v)
+		}
+	}
+	for _, v := range []string{"1", "true", "yes", "anything"} {
+		if !EnvEnabled(v) {
+			t.Errorf("EnvEnabled(%q) = false, want true", v)
+		}
+	}
+}
+
+func TestTestDaemonAllowedFollowsTheEnvironment(t *testing.T) {
+	if TestDaemonAllowed() {
+		t.Fatalf("%s is set in a test run; the guard is disarmed", AllowTestDaemonEnv)
+	}
+	t.Setenv(AllowTestDaemonEnv, "1")
+	if !TestDaemonAllowed() {
+		t.Error("the explicit opt-in was not honoured")
+	}
+}

--- a/internal/display/main_test.go
+++ b/internal/display/main_test.go
@@ -1,0 +1,13 @@
+package display
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/groups/main_test.go
+++ b/internal/groups/main_test.go
@@ -1,0 +1,13 @@
+package groups
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/hooks/main_test.go
+++ b/internal/hooks/main_test.go
@@ -1,0 +1,13 @@
+package hooks
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/hoststats/main_test.go
+++ b/internal/hoststats/main_test.go
@@ -1,0 +1,13 @@
+package hoststats
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/install/main_test.go
+++ b/internal/install/main_test.go
@@ -1,0 +1,13 @@
+package install
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/killer/integration_test.go
+++ b/internal/killer/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/raskrebs/sonar/internal/docker"
 	"github.com/raskrebs/sonar/internal/ports"
 	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/testenv"
 )
 
 // This file exercises the killer against real processes: a shell that spawns a
@@ -34,12 +35,14 @@ const (
 
 // TestMain doubles as the helper process: re-executing the test binary with
 // SONAR_KILLER_HELPER_PORT set turns it into a listener instead of a test run.
+// A helper is not a test run, so it is not the thing testenv isolates — it
+// inherits the environment its parent was already isolated into.
 func TestMain(m *testing.M) {
 	if port := os.Getenv(envHelperPort); port != "" {
 		runHelper(port, os.Getenv(envHelperChild), os.Getenv(envHelperIgnore) != "")
 		return
 	}
-	os.Exit(m.Run())
+	os.Exit(testenv.Run(m))
 }
 
 // runHelper listens on port, optionally spawns a child helper on childPort, and

--- a/internal/mcpserver/fakedaemon/main_test.go
+++ b/internal/mcpserver/fakedaemon/main_test.go
@@ -1,0 +1,13 @@
+package fakedaemon_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/mcpserver/integration_test.go
+++ b/internal/mcpserver/integration_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/testenv"
 )
 
 func TestRealDaemonToolsList(t *testing.T) {
@@ -270,7 +271,8 @@ func TestSocketFlagOverridesTheEnvironment(t *testing.T) {
 	cmd := exec.Command(e.bin, "mcp", "--socket", e.socket, "--log-level", "debug")
 	// SONAR_SOCKET is deliberately absent: only the flag says where to dial.
 	cmd.Env = append(os.Environ(),
-		"HOME="+e.home, "USERPROFILE="+e.home, "XDG_RUNTIME_DIR=", "SONAR_NO_HINTS=1")
+		"HOME="+e.home, "USERPROFILE="+e.home, "XDG_RUNTIME_DIR=", "SONAR_NO_HINTS=1",
+		"SONAR_DB=", testenv.ChildEnv())
 	cmd.Stderr = &stderrSink{e: e}
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "sonar-itest", Version: "1"}, nil)
@@ -330,6 +332,13 @@ func (e *realEnv) env() []string {
 		"XDG_RUNTIME_DIR=",
 		"SONAR_SOCKET="+e.socket,
 		"SONAR_NO_HINTS=1",
+		// The test binary is isolated with one SONAR_DB for the whole run
+		// (internal/testenv); clear it so this env's daemon keeps its rows
+		// under this env's HOME.
+		"SONAR_DB=",
+		// `sonar mcp` autostarting a daemon of its own is the thing these
+		// tests are here to exercise.
+		testenv.ChildEnv(),
 	)
 }
 

--- a/internal/mcpserver/main_test.go
+++ b/internal/mcpserver/main_test.go
@@ -1,0 +1,13 @@
+package mcpserver
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/ports/main_test.go
+++ b/internal/ports/main_test.go
@@ -1,0 +1,13 @@
+package ports
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/remote/main_test.go
+++ b/internal/remote/main_test.go
@@ -1,0 +1,13 @@
+package remote
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/remote/ssh_integration_test.go
+++ b/internal/remote/ssh_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/raskrebs/sonar/internal/daemon/client"
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/state"
+	"github.com/raskrebs/sonar/internal/testenv"
 )
 
 // buildBinary compiles the sonar CLI once per test run.
@@ -133,6 +134,13 @@ func (e *bridgeEnv) env() []string {
 		"USERPROFILE="+e.localHome,
 		"SONAR_SOCKET="+e.localSocket,
 		"XDG_RUNTIME_DIR=",
+		// One SONAR_DB is set for the whole isolated test binary
+		// (internal/testenv); clear it so each side keeps its own database
+		// under its own HOME.
+		"SONAR_DB=",
+		// The far side of the fake ssh autostarts its own daemon, which is
+		// the behaviour under test.
+		testenv.ChildEnv(),
 		"PATH="+e.binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"FAKE_SSH_BIN="+e.bin,
 		"FAKE_SSH_HOME="+e.remoteHome,
@@ -179,6 +187,7 @@ func (e *bridgeEnv) stopRemoteDaemon() {
 		"USERPROFILE="+e.remoteHome,
 		"SONAR_SOCKET="+e.remoteSock,
 		"XDG_RUNTIME_DIR=",
+		"SONAR_DB=",
 	)
 	cmd.WaitDelay = 5 * time.Second
 	_ = cmd.Run()

--- a/internal/remoteinstall/main_test.go
+++ b/internal/remoteinstall/main_test.go
@@ -1,0 +1,13 @@
+package remoteinstall
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/runs/main_test.go
+++ b/internal/runs/main_test.go
@@ -1,0 +1,13 @@
+package runs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/scanner/main_test.go
+++ b/internal/scanner/main_test.go
@@ -1,0 +1,13 @@
+package scanner
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/selfupdate/main_test.go
+++ b/internal/selfupdate/main_test.go
@@ -1,0 +1,13 @@
+package selfupdate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/sessions/main_test.go
+++ b/internal/sessions/main_test.go
@@ -1,0 +1,13 @@
+package sessions
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/spawn/main_test.go
+++ b/internal/spawn/main_test.go
@@ -1,0 +1,13 @@
+package spawn
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/state/main_test.go
+++ b/internal/state/main_test.go
@@ -1,0 +1,13 @@
+package state
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/store/main_test.go
+++ b/internal/store/main_test.go
@@ -1,0 +1,13 @@
+package store
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/testenv/leaks.go
+++ b/internal/testenv/leaks.go
@@ -1,0 +1,150 @@
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The leak gate.
+//
+// A test that reaches the CLI's autostart path spawns "<this binary> serve
+// --detach". The guards in internal/daemon and internal/daemon/client stop
+// that spawn from happening at all, but a guard can be bypassed (a harness
+// sets SONAR_ALLOW_TEST_DAEMON, a new code path forgets to consult it), and a
+// leak is silent: the parent test passes and the stray process lives on. So
+// every isolated package also *looks*, after its tests have run, and fails the
+// run if anything is still there.
+
+// Daemon is one stray process left behind by this test binary.
+type Daemon struct {
+	PID     int
+	Command string
+}
+
+func (d Daemon) String() string { return fmt.Sprintf("pid %d: %s", d.PID, d.Command) }
+
+// AssertNoLeakedDaemons reports every process this test binary left running as
+// a daemon, kills them, and prints what it found. It returns the leaks so
+// TestMain can turn a non-empty result into a failing exit code; Run already
+// does that.
+//
+// Windows has no ps and no cheap way to read another process's command line
+// from Go, so the check is unix-only. The guards it backs up are not.
+func AssertNoLeakedDaemons() []Daemon {
+	// A cleanup that has asked a daemon to stop is racing us: the socket is
+	// already gone but the process has not been reaped. Give teardown a moment
+	// before calling it a leak, so the gate catches real leaks and not slow
+	// exits.
+	var leaked []Daemon
+	for deadline := time.Now().Add(2 * time.Second); ; {
+		if leaked = LeakedDaemons(); len(leaked) == 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(leaked) == 0 {
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "\ntestenv: %d leaked daemon process(es) survived this test binary:\n", len(leaked))
+	for _, d := range leaked {
+		fmt.Fprintf(os.Stderr, "  %s\n", d)
+		if p, err := os.FindProcess(d.PID); err == nil {
+			_ = p.Kill()
+		}
+	}
+	fmt.Fprintf(os.Stderr, "testenv: they were killed, but a test started a daemon it did not stop.\n")
+	return leaked
+}
+
+// RequireNoLeakedDaemons is AssertNoLeakedDaemons for a single test.
+func RequireNoLeakedDaemons(t testing.TB) {
+	t.Helper()
+	if leaked := AssertNoLeakedDaemons(); len(leaked) > 0 {
+		t.Fatalf("the test left %d daemon process(es) running: %v", len(leaked), leaked)
+	}
+}
+
+// LeakedDaemons lists running processes that this test run should have
+// stopped: this test binary running as `serve`, and any `sonar serve` started
+// from a binary the tests built into a temp directory. Nothing installed on
+// the machine matches either shape, so a developer's own daemon is never
+// mistaken for a leak.
+func LeakedDaemons() []Daemon {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	out, err := exec.Command("ps", "-axo", "pid=,command=").Output()
+	if err != nil {
+		// No ps (a minimal container): the gate is best-effort, and the
+		// guards are what actually prevent the leak.
+		return nil
+	}
+
+	self := os.Getpid()
+	var leaked []Daemon
+	for _, line := range strings.Split(string(out), "\n") {
+		pid, cmdline, ok := splitPS(line)
+		if !ok || pid == self {
+			continue
+		}
+		if isDaemonOf(exe, cmdline) || isTempBuiltDaemon(cmdline) {
+			leaked = append(leaked, Daemon{PID: pid, Command: cmdline})
+		}
+	}
+	return leaked
+}
+
+// splitPS pulls the pid and the command line out of one `ps -axo pid=,command=`
+// row.
+func splitPS(line string) (int, string, bool) {
+	line = strings.TrimSpace(line)
+	space := strings.IndexByte(line, ' ')
+	if space < 0 {
+		return 0, "", false
+	}
+	pid, err := strconv.Atoi(line[:space])
+	if err != nil {
+		return 0, "", false
+	}
+	return pid, strings.TrimSpace(line[space+1:]), true
+}
+
+// isDaemonOf reports whether cmdline is exe running as a daemon. `serve` is
+// the only argument that makes a sonar process a daemon, and it is always the
+// first one.
+//
+// The match is on the full path and nothing looser. `go test ./...` runs
+// packages in parallel and names every test binary <pkg>.test, so matching on
+// the file name would let one package's gate fail on another package's
+// process — which is a flaky gate, and a flaky gate gets deleted.
+func isDaemonOf(exe, cmdline string) bool {
+	rest, ok := strings.CutPrefix(cmdline, exe+" ")
+	if !ok {
+		return false
+	}
+	fields := strings.Fields(rest)
+	return len(fields) > 0 && fields[0] == "serve"
+}
+
+// isTempBuiltDaemon reports whether cmdline is a `sonar serve` running from a
+// binary under the temp directory — which only the integration harnesses, who
+// build one there, ever produce.
+func isTempBuiltDaemon(cmdline string) bool {
+	fields := strings.Fields(cmdline)
+	if len(fields) < 2 || fields[1] != "serve" {
+		return false
+	}
+	name := strings.TrimSuffix(strings.ToLower(filepath.Base(fields[0])), ".exe")
+	return name == "sonar" && under(fields[0], os.TempDir())
+}

--- a/internal/testenv/main_test.go
+++ b/internal/testenv/main_test.go
@@ -1,0 +1,8 @@
+package testenv
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) { os.Exit(Run(m)) }

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -1,0 +1,272 @@
+// Package testenv isolates a Go test binary from the machine it runs on.
+//
+// Every path sonar resolves from the environment — the config directory, the
+// database, the socket, the daemon log, the run logs — hangs off HOME, so a
+// test that reaches any of them reaches the developer's live install. Two
+// things went wrong at once before step 1A.20: in-process test daemons opened
+// the real ~/.config/sonar/sonar.db, and a test that touched the CLI's
+// autostart path forked `<pkg>.test serve --detach`, which is not a daemon but
+// a background re-run of the whole suite (see daemon.IsTestBinary). One
+// afternoon of `go test` left 2,150 of those behind and exhausted swap.
+//
+// The fix is isolation by construction rather than per test: every package
+// whose tests can reach the daemon or the config directory calls Run from its
+// TestMain, and from then on nothing in that binary can find the real install
+// even if it tries.
+//
+// Usage:
+//
+//	func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }
+//
+// A TestMain that also serves as a helper-process entry point isolates itself
+// and keeps control:
+//
+//	func TestMain(m *testing.M) {
+//		if os.Getenv(envHelper) != "" { runHelper(); return }
+//		os.Exit(testenv.Run(m))
+//	}
+//
+// This package deliberately imports nothing from the module: it is linked into
+// every test binary that uses it, and a helper that dragged in the daemon and
+// SQLite would make a display-only test binary far heavier than its subject.
+// The check that the *real* resolvers agree lives in the packages that already
+// import them, via Isolated.
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Environment variables Isolate sets. They are the complete set sonar honours
+// for locating anything; adding a new one means adding it here too.
+const (
+	noAutostartEnv = "SONAR_NO_AUTOSTART"
+	socketEnv      = "SONAR_SOCKET"
+	dbEnv          = "SONAR_DB"
+	allowTestEnv   = "SONAR_ALLOW_TEST_DAEMON"
+)
+
+// root is the isolated HOME, and sockRoot the short directory holding the
+// socket. They are set once, by Isolate, before any test runs.
+var (
+	root     string
+	sockRoot string
+	realHome string
+)
+
+// Run isolates the process, runs the tests, and fails the run if the suite
+// left a daemon behind. It returns the exit code TestMain should pass to
+// os.Exit.
+func Run(m *testing.M) int {
+	cleanup := Isolate()
+	defer cleanup()
+
+	code := m.Run()
+
+	if leaked := AssertNoLeakedDaemons(); len(leaked) > 0 && code == 0 {
+		code = 1
+	}
+	return code
+}
+
+// Isolate points every path sonar resolves from the environment at a private
+// temp directory, and switches daemon autostart off. It returns a cleanup that
+// removes the directories.
+//
+// It exits the process rather than returning an error when it cannot make the
+// environment safe: a test binary that keeps going here writes to the
+// developer's real install, and there is no test result worth that.
+func Isolate() func() {
+	realHome, _ = os.UserHomeDir()
+	preserveGoEnv()
+
+	home, err := os.MkdirTemp("", "sonar-testhome")
+	if err != nil {
+		die("creating an isolated HOME: %v", err)
+	}
+	// Not under home: macOS caps a unix socket path at about 104 bytes and
+	// "<tmp>/sonar-testhome<random>/.config/sonar/daemon.sock" is over it.
+	sock, err := os.MkdirTemp("", "snrt")
+	if err != nil {
+		die("creating an isolated socket directory: %v", err)
+	}
+	root, sockRoot = home, sock
+
+	configDir := filepath.Join(home, ".config", "sonar")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		die("creating %s: %v", configDir, err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "run"), 0o700); err != nil {
+		die("creating the isolated XDG_RUNTIME_DIR: %v", err)
+	}
+
+	set("HOME", home)                                      // unix
+	set("USERPROFILE", home)                               // windows
+	set("XDG_CONFIG_HOME", filepath.Join(home, ".config")) // freedesktop
+	set("XDG_RUNTIME_DIR", filepath.Join(home, "run"))     // outranks HOME for the socket
+	set(dbEnv, filepath.Join(configDir, "sonar.db"))
+	set(socketEnv, socketPath(sock))
+	set(noAutostartEnv, "1")
+	// A leftover opt-in from the developer's shell must not disarm the guard
+	// that keeps a test binary from becoming a daemon.
+	if err := os.Unsetenv(allowTestEnv); err != nil {
+		die("unsetting %s: %v", allowTestEnv, err)
+	}
+
+	// Belt and braces: prove the environment now resolves somewhere else. A
+	// sandbox that silently ignored Setenv would otherwise leave every test
+	// pointing at the live install.
+	if realHome != "" && sameDir(os.Getenv("HOME"), realHome) {
+		die("HOME is still %s; refusing to run tests against the live install", realHome)
+	}
+	if !Isolated(configDir) {
+		die("the isolated config directory %s is not under %s", configDir, os.TempDir())
+	}
+
+	return func() {
+		os.RemoveAll(home)
+		os.RemoveAll(sock)
+	}
+}
+
+// preserveGoEnv pins the Go toolchain's caches to where they already are.
+//
+// Go derives GOPATH, GOCACHE, GOMODCACHE and GOENV from the home directory,
+// and several integration harnesses run `go build` to produce the real `sonar`
+// binary they drive. Moving HOME without this points those builds at an empty
+// module cache inside a temp directory that is deleted at the end of the run:
+// they re-download the whole module graph, and offline they simply fail.
+// Resolving the defaults here, while HOME is still the real one, is exactly
+// what the toolchain would have done. A variable already set in the
+// environment is left alone — it does not depend on HOME in the first place.
+func preserveGoEnv() {
+	if cache, err := os.UserCacheDir(); err == nil {
+		setDefault("GOCACHE", filepath.Join(cache, "go-build"))
+	}
+	if cfg, err := os.UserConfigDir(); err == nil {
+		setDefault("GOENV", filepath.Join(cfg, "go", "env"))
+	}
+	if realHome != "" {
+		setDefault("GOPATH", filepath.Join(realHome, "go"))
+	}
+	if gopath := os.Getenv("GOPATH"); gopath != "" {
+		setDefault("GOMODCACHE", filepath.Join(gopath, "pkg", "mod"))
+	}
+}
+
+func setDefault(key, value string) {
+	if os.Getenv(key) == "" && value != "" {
+		set(key, value)
+	}
+}
+
+// Root is the isolated HOME. It is empty before Isolate runs.
+func Root() string { return root }
+
+// RealHome is the home directory this run displaced: the one the developer's
+// live sonar install lives in. Isolate is the only chance to read it, because
+// afterwards os.UserHomeDir answers with Root.
+func RealHome() string { return realHome }
+
+// ConfigDir is the isolated ~/.config/sonar.
+func ConfigDir() string { return filepath.Join(root, ".config", "sonar") }
+
+// Isolated reports whether path lies inside this run's temp directories. It is
+// what a package's own TestMain uses to check the real resolvers agree:
+//
+//	if !testenv.Isolated(config.Path(), store.Path(), daemon.SocketPath()) { ... }
+func Isolated(paths ...string) bool {
+	if len(paths) == 0 {
+		return false
+	}
+	for _, p := range paths {
+		if p == "" || !(under(p, root) || under(p, sockRoot) || under(p, os.TempDir())) {
+			return false
+		}
+	}
+	return true
+}
+
+// RequireIsolated fails the test unless every path is inside this run's temp
+// directories.
+func RequireIsolated(t testing.TB, paths ...string) {
+	t.Helper()
+	for _, p := range paths {
+		if !Isolated(p) {
+			t.Fatalf("%s is outside the isolated test environment (HOME=%s, TMPDIR=%s)",
+				p, root, os.TempDir())
+		}
+	}
+}
+
+// AllowAutostart lets one test use the real autostart path, and restores the
+// ban afterwards. Only a test that owns the daemon it starts and stops it in a
+// cleanup may call it.
+func AllowAutostart(t testing.TB) {
+	t.Helper()
+	t.Setenv(noAutostartEnv, "")
+}
+
+// ChildEnv is what a harness appends to a child process's environment when
+// that child is the real `sonar` binary and is allowed to autostart a daemon
+// of its own. The child is not a test binary, so only the process-wide ban has
+// to be lifted.
+func ChildEnv() string { return noAutostartEnv + "=" }
+
+func socketPath(dir string) string {
+	// Named pipes share one flat namespace, so a Windows test binary takes an
+	// address stamped with its pid rather than a path.
+	if os.PathSeparator == '\\' {
+		return fmt.Sprintf(`\\.\pipe\sonar-test-%d`, os.Getpid())
+	}
+	return filepath.Join(dir, "d.sock")
+}
+
+func set(key, value string) {
+	if err := os.Setenv(key, value); err != nil {
+		die("setting %s: %v", key, err)
+	}
+}
+
+func under(path, dir string) bool {
+	if dir == "" {
+		return false
+	}
+	rel, err := filepath.Rel(resolve(dir), resolve(path))
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func sameDir(a, b string) bool { return resolve(a) == resolve(b) }
+
+// resolve cleans a path and follows symlinks where it can. /var on macOS is a
+// symlink to /private/var, so os.TempDir() and a path built from HOME can name
+// the same directory in two spellings. A path that does not exist yet — a
+// database file a test has not created — still has to resolve, so the walk
+// stops at the deepest ancestor that does and keeps the rest verbatim.
+func resolve(path string) string {
+	path = filepath.Clean(path)
+	rest := ""
+	for dir := path; ; {
+		if p, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(p, rest)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return path
+		}
+		rest = filepath.Join(filepath.Base(dir), rest)
+		dir = parent
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "testenv: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -1,0 +1,122 @@
+package testenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The guarantee the whole package exists for: after TestMain, nothing this
+// binary resolves from the environment points at the machine's real install.
+func TestIsolateMovesEverythingIntoTempDir(t *testing.T) {
+	if Root() == "" {
+		t.Fatal("Isolate did not run before the tests")
+	}
+	RequireIsolated(t, Root(), ConfigDir(), os.Getenv("HOME"), os.Getenv("SONAR_DB"))
+
+	real, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("resolving the home directory: %v", err)
+	}
+	if real != Root() {
+		t.Fatalf("os.UserHomeDir() = %s, want the isolated %s", real, Root())
+	}
+	if _, err := os.Stat(ConfigDir()); err != nil {
+		t.Errorf("the isolated config directory is not there: %v", err)
+	}
+}
+
+// Autostart is off for the whole binary, and the opt-in a developer may have
+// in their shell does not survive into a test run.
+func TestIsolateDisablesAutostart(t *testing.T) {
+	if got := os.Getenv(noAutostartEnv); got == "" {
+		t.Errorf("%s = %q, want it set", noAutostartEnv, got)
+	}
+	if got, ok := os.LookupEnv(allowTestEnv); ok {
+		t.Errorf("%s = %q, want it unset", allowTestEnv, got)
+	}
+}
+
+// Isolation must not take the Go build cache with it: the integration
+// harnesses run `go build` to make the binary they drive, and a module cache
+// inside the throwaway HOME means re-downloading the module graph every run,
+// and failing outright with no network.
+func TestIsolateKeepsTheGoCachesWhereTheyWere(t *testing.T) {
+	for _, key := range []string{"GOCACHE", "GOMODCACHE", "GOPATH"} {
+		v := os.Getenv(key)
+		if v == "" {
+			t.Errorf("%s is unset; a `go build` from a test would rebuild the world", key)
+			continue
+		}
+		if Isolated(v) {
+			t.Errorf("%s = %s, which is inside the throwaway test environment", key, v)
+		}
+	}
+}
+
+func TestIsolatedRejectsPathsOutside(t *testing.T) {
+	if Isolated("/etc/passwd") {
+		t.Error("/etc/passwd counted as isolated")
+	}
+	if Isolated() {
+		t.Error("no paths at all counted as isolated")
+	}
+	if !Isolated(filepath.Join(Root(), ".config", "sonar", "sonar.db")) {
+		t.Error("a path under the isolated HOME did not count as isolated")
+	}
+}
+
+// The leak gate reads `ps` output, so the parsing is worth pinning: a gate
+// that quietly matched nothing would be worse than no gate.
+func TestIsDaemonOf(t *testing.T) {
+	const exe = "/tmp/go-build123/b001/cmd.test"
+	tests := []struct {
+		cmdline string
+		want    bool
+	}{
+		{exe + " serve --detach", true},
+		{exe + " serve", true},
+		{exe + " -test.run=TestX", false},
+		{exe, false},
+		// Another package's test binary is another package's problem: `go test
+		// ./...` runs them at the same time.
+		{"/tmp/go-build123/b002/cmd.test serve --detach", false},
+		{"cmd.test serve", false},
+		{"/usr/local/bin/sonar serve", false}, // the developer's own daemon
+		{"grep serve", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isDaemonOf(exe, tt.cmdline); got != tt.want {
+			t.Errorf("isDaemonOf(%q) = %v, want %v", tt.cmdline, got, tt.want)
+		}
+	}
+}
+
+func TestIsTempBuiltDaemon(t *testing.T) {
+	inTemp := filepath.Join(os.TempDir(), "sonar-itest-bin123", "sonar")
+	if !isTempBuiltDaemon(inTemp + " serve") {
+		t.Errorf("%s serve was not recognised as a test-built daemon", inTemp)
+	}
+	if isTempBuiltDaemon("/usr/local/bin/sonar serve") {
+		t.Error("an installed sonar daemon was mistaken for a test leak")
+	}
+	if isTempBuiltDaemon(inTemp + " list") {
+		t.Error("`sonar list` was mistaken for a daemon")
+	}
+}
+
+func TestSplitPS(t *testing.T) {
+	pid, cmdline, ok := splitPS("  4242 /path/to/cmd.test serve --detach")
+	if !ok || pid != 4242 || cmdline != "/path/to/cmd.test serve --detach" {
+		t.Errorf("splitPS = (%d, %q, %v)", pid, cmdline, ok)
+	}
+	if _, _, ok := splitPS("not-a-row"); ok {
+		t.Error("a malformed ps row parsed as a process")
+	}
+}
+
+// Nothing in this package starts a daemon, so the gate has to agree.
+func TestNoDaemonsLeakFromThisBinary(t *testing.T) {
+	RequireNoLeakedDaemons(t)
+}

--- a/internal/tray/main_test.go
+++ b/internal/tray/main_test.go
@@ -1,0 +1,13 @@
+package tray
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }


### PR DESCRIPTION
Every package that can reach the daemon gets a TestMain that moves HOME, config, DB and socket to a per-run temp dir, sets SONAR_NO_AUTOSTART, refuses to run against the real config dir, and fails the run if a daemon outlives the test binary. client.Autostart refuses to spawn a .test binary and serve refuses to run inside one. Motivated by 2,150 leaked cmd.test serve daemons.