### PR TITLE
perf: keep the OS scan out of the lock that orders a write against attribution

### DIFF
--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -169,7 +169,7 @@ func inspectPort(ctx context.Context, port int, bindIP string) (*ports.Listening
 	docker.EnrichPorts(enriched)
 	ports.Enrich(enriched)
 	ports.EnrichStats(enriched, docker.AllContainerStatsAsEntries())
-	ports.EnrichHealth(enriched, 2*time.Second)
+	ports.EnrichHealth(enriched, 2*time.Second, 0)
 	return &enriched[0], nil
 }
 

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -343,7 +343,7 @@ func listPorts(ctx context.Context, q listQuery) ([]ports.ListeningPort, *groups
 		ports.EnrichStats(results, docker.AllContainerStatsAsEntries())
 	}
 	if healthFlag {
-		ports.EnrichHealth(results, 2*time.Second)
+		ports.EnrichHealth(results, 2*time.Second, 0)
 	}
 	// Resolve every port's group: pin > run > .sonar.yaml > Compose > git root.
 	// This is the no-daemon path, so it happens per command.

--- a/internal/daemon/handlers_store.go
+++ b/internal/daemon/handlers_store.go
@@ -160,11 +160,12 @@ func handleConfigPath(_ context.Context, _ *Request) (any, error) {
 	return rpc.ConfigPathResult{Path: config.Path()}, nil
 }
 
-// republish makes a write visible before its own reply is. It scans and
-// publishes synchronously, so by the time the handler returns the delta
-// carrying the change is already queued on every subscriber's connection —
-// ahead of this call's response, which the same writer queues afterwards —
-// and the caller's own next read is served from a snapshot that has it.
+// republish makes a write visible before its own reply is. It re-attributes
+// the last scan and publishes synchronously, so by the time the handler
+// returns the delta carrying the change is already queued on every
+// subscriber's connection — ahead of this call's response, which the same
+// writer queues afterwards — and the caller's own next read is served from a
+// snapshot that has it.
 //
 // Contract §18 only asks that a rename or an assign take effect "in the next
 // publish", with an immediate rescan so the caller sees it. Replying *after*
@@ -172,9 +173,26 @@ func handleConfigPath(_ context.Context, _ *Request) (any, error) {
 // into a guarantee: a subscriber cannot receive the acknowledgement before the
 // delta that justifies it, and a client that reads straight after the reply
 // cannot be served the state from before its own write.
+//
+// It does not scan the machine. A rename, a group pin and a `.sonar.yaml` edit
+// change how the ports the daemon already knows are named and grouped, not
+// which ports exist, so re-running attribution over the last scan's own rows
+// answers the question — and it does so in microseconds instead of behind
+// `lsof`, `ps` and `docker stats` (contract §44). `Republish` wakes the loop,
+// so a real scan follows.
 func republish(rt *Runtime) {
+	if err := rt.Scanner.Republish(); err != nil {
+		rt.Logger.Warn("republishing after a write", "error", err)
+	}
+}
+
+// rescanAfterKill is republish's sibling for the one write that does change
+// which ports exist. A kill has to be followed by a real scan: the ports that
+// just went away are only gone from the snapshot once the OS has been asked
+// again, and their port_down rows reach the history ring from that delta.
+func rescanAfterKill(rt *Runtime) {
 	if _, err := rt.Scanner.Rescan(scanner.Include{}); err != nil {
-		rt.Logger.Warn("rescanning after a write", "error", err)
+		rt.Logger.Warn("rescanning after a kill", "error", err)
 	}
 }
 

--- a/internal/daemon/kill_handlers.go
+++ b/internal/daemon/kill_handlers.go
@@ -101,7 +101,7 @@ func afterKill(req *Request, dryRun bool) {
 	if dryRun {
 		return
 	}
-	republish(req.Runtime)
+	rescanAfterKill(req.Runtime)
 }
 
 // killSnapshot is the state selectors and group members are resolved against.
@@ -111,6 +111,13 @@ func afterKill(req *Request, dryRun bool) {
 // the direct `sonar kill` path, scanning at the moment it is asked, never does.
 // A kill is rare and deliberate; one scan is the right price for acting on what
 // is listening now.
+//
+// The scan it asks for is bare. A kill needs the pid and port of what is
+// listening, never a health verdict or a cpu reading, so it does not inherit a
+// subscriber's `include` — the published snapshot carries those forward
+// instead of collecting them again (contract §44). That is the difference
+// between a dry run answering in a moment and one waiting out `docker stats`
+// and a round of health probes.
 func killSnapshot(req *Request) (state.Snapshot, error) {
 	snap, err := req.Runtime.Scanner.Rescan(scanner.Include{})
 	if err != nil {

--- a/internal/daemon/ports.go
+++ b/internal/daemon/ports.go
@@ -50,22 +50,31 @@ func readPorts(rt *Runtime, include scanner.Include) ([]state.Port, error) {
 	return snap.Ports, nil
 }
 
-// cacheCovers reports whether the cached snapshot already carries the
+// cacheCovers reports whether the cached snapshot was collected with the
 // enrichments this read asked for. An empty port table trivially covers
 // everything: there is nothing to enrich.
+//
+// The question is about the snapshot, not about every row in it, and asking it
+// row by row was wrong. `stats` is null for a process whose numbers are all
+// zero — a listener ps cannot see, a container the daemon has no reading for —
+// and `health` is null for anything that was not probed, which on a machine
+// with one such row made *every* stats read miss the cache and scan the
+// machine again, while a subscriber was already collecting stats every second
+// (contract §42, §44). One row carrying the enrichment is what says the scan
+// behind this snapshot collected it.
 func cacheCovers(snap state.Snapshot, include scanner.Include) bool {
 	if !include.Stats && !include.Health {
 		return true
 	}
-	for i := range snap.Ports {
-		if include.Stats && snap.Ports[i].Stats == nil {
-			return false
-		}
-		if include.Health && snap.Ports[i].Health == nil {
-			return false
-		}
+	if len(snap.Ports) == 0 {
+		return true
 	}
-	return true
+	stats, health := false, false
+	for i := range snap.Ports {
+		stats = stats || snap.Ports[i].Stats != nil
+		health = health || snap.Ports[i].Health != nil
+	}
+	return (!include.Stats || stats) && (!include.Health || health)
 }
 
 func handlePortsList(_ context.Context, req *Request) (any, error) {

--- a/internal/daemon/ports_test.go
+++ b/internal/daemon/ports_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/scanner"
 	"github.com/raskrebs/sonar/internal/state"
 )
 
@@ -659,5 +660,34 @@ func TestDaemonStatusReportsTheScanCounter(t *testing.T) {
 	}
 	if after.Scans <= before.Scans {
 		t.Fatalf("scan counter did not move: %d then %d", before.Scans, after.Scans)
+	}
+}
+
+// TestCacheCoversAsksAboutTheSnapshotNotEveryRow is step 1A.19. `stats` is null
+// for a process whose numbers are all zero and `health` is null for anything
+// that was not probed, so asking row by row meant a single such row made every
+// stats read miss the cache and scan the machine again — while the loop was
+// already collecting stats every second for the subscriber that asked.
+func TestCacheCoversAsksAboutTheSnapshotNotEveryRow(t *testing.T) {
+	withStats := state.Snapshot{Ports: []state.Port{
+		{Port: 3000, Stats: &state.Stats{CPUPercent: 1}},
+		{Port: 3001},
+	}}
+	if !cacheCovers(withStats, scanner.Include{Stats: true}) {
+		t.Error("a snapshot with stats on one row does not cover a stats read")
+	}
+	if cacheCovers(withStats, scanner.Include{Health: true}) {
+		t.Error("a snapshot with no health anywhere covers a health read")
+	}
+
+	none := state.Snapshot{Ports: []state.Port{{Port: 3000}}}
+	if cacheCovers(none, scanner.Include{Stats: true}) {
+		t.Error("a snapshot with no stats anywhere covers a stats read")
+	}
+	if !cacheCovers(none, scanner.Include{}) {
+		t.Error("a read that asked for nothing is never uncovered")
+	}
+	if !cacheCovers(state.Snapshot{}, scanner.Include{Stats: true, Health: true}) {
+		t.Error("an empty port table should trivially cover everything")
 	}
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -262,8 +261,8 @@ func readHTTPBody(conn net.Conn) ([]byte, error) {
 func allContainerStatsCLI() map[string]*ContainerStats {
 	result := make(map[string]*ContainerStats)
 
-	out, err := exec.Command("docker", "stats", "--no-stream", "--format",
-		"{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.PIDs}}").Output()
+	out, err := output("stats", "--no-stream", "--format",
+		"{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.PIDs}}")
 	if err != nil {
 		return result
 	}
@@ -301,7 +300,7 @@ func allContainerStatsCLI() map[string]*ContainerStats {
 	}
 	if len(names) > 0 {
 		args := append([]string{"inspect", "--format", "{{.Name}}\t{{.State.Status}}\t{{.State.StartedAt}}"}, names...)
-		inspectOut, err := exec.Command("docker", args...).Output()
+		inspectOut, err := output(args...)
 		if err == nil {
 			inspectScanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(string(inspectOut))))
 			for inspectScanner.Scan() {
@@ -378,7 +377,9 @@ func formatContainerDuration(d time.Duration) string {
 
 // StopContainer stops a Docker container by name using `docker stop`.
 func StopContainer(name string) error {
-	if err := exec.Command("docker", "stop", name).Run(); err != nil {
+	cmd, stop := cli("stop", name)
+	defer stop()
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to stop container %s: %w", name, err)
 	}
 	return nil
@@ -388,7 +389,7 @@ func StopContainer(name string) error {
 func listContainers() ([]container, error) {
 	format := "{{.Names}}\t{{.Image}}\t{{.Ports}}\t{{.Label \"com.docker.compose.service\"}}" +
 		"\t{{.Label \"com.docker.compose.project\"}}\t{{.Label \"com.docker.compose.project.working_dir\"}}"
-	out, err := exec.Command("docker", "ps", "--format", format).Output()
+	out, err := output("ps", "--format", format)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/docker/exec.go
+++ b/internal/docker/exec.go
@@ -1,0 +1,33 @@
+package docker
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// CLITimeout bounds one `docker` invocation.
+//
+// The docker CLI talks to a daemon over a socket and has no timeout of its
+// own: when Docker Desktop is starting, paused or wedged, `docker stats` does
+// not fail, it waits. Every call here runs inside a scan, and a scan is what a
+// `ports.kill` or a `.sonar.yaml` write is queued behind (contract §38), so an
+// unbounded docker call is an unbounded reply. Ten seconds is far longer than
+// a healthy `docker stats --no-stream` (about two) and short enough that a
+// wedged daemon degrades to "no container stats this tick" instead of hanging
+// the scan lock (contract §44).
+const CLITimeout = 10 * time.Second
+
+// cli builds a `docker` command that cannot outlive CLITimeout. The returned
+// stop must be called once the output has been read.
+func cli(args ...string) (cmd *exec.Cmd, stop func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), CLITimeout)
+	return exec.CommandContext(ctx, "docker", args...), cancel
+}
+
+// output runs one `docker` command under CLITimeout and returns its stdout.
+func output(args ...string) ([]byte, error) {
+	cmd, stop := cli(args...)
+	defer stop()
+	return cmd.Output()
+}

--- a/internal/docker/graph.go
+++ b/internal/docker/graph.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"bufio"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -148,7 +147,7 @@ func buildIPMap(containerNames []string) map[string]string {
 		`{{.Name}}{{range $net, $cfg := .NetworkSettings.Networks}} {{$cfg.IPAddress}}{{end}}`},
 		containerNames...)
 
-	out, err := exec.Command("docker", args...).Output()
+	out, err := output(args...)
 	if err != nil {
 		return nil
 	}
@@ -179,7 +178,7 @@ type procNetEntry struct {
 
 // readProcNetTCP reads /proc/net/tcp inside a Docker container and returns parsed entries.
 func readProcNetTCP(containerName string) []procNetEntry {
-	out, err := exec.Command("docker", "exec", containerName, "cat", "/proc/net/tcp").Output()
+	out, err := output("exec", containerName, "cat", "/proc/net/tcp")
 	if err != nil {
 		return nil
 	}

--- a/internal/ports/health.go
+++ b/internal/ports/health.go
@@ -76,11 +76,29 @@ func isConnectionRefused(err error) bool {
 	return false
 }
 
-// EnrichHealth probes every port concurrently (max 10 at a time) and
+// MaxProbes bounds how many health probes run at once. It is the same ceiling
+// the configured-health probe in the scanner uses.
+const MaxProbes = 10
+
+// EnrichHealth probes every port concurrently (max MaxProbes at a time) and
 // populates the Health* fields on each ListeningPort.
-func EnrichHealth(pp []ListeningPort, timeout time.Duration) {
+//
+// budget is the ceiling on the whole round, not on one probe: a machine with
+// forty listeners, ten of them sockets that accept and never answer, used to
+// cost four waves of `timeout` each — seconds of a scan that a `ports.kill`
+// or a `.sonar.yaml` write was queued behind. A probe that would start after
+// the budget is spent is skipped (its port keeps whatever health the previous
+// tick found, see carryHealth), and one that starts near the end has its own
+// timeout clamped to what is left, so the round costs at most budget.
+// A zero or negative budget means no ceiling.
+func EnrichHealth(pp []ListeningPort, timeout, budget time.Duration) {
+	var deadline time.Time
+	if budget > 0 {
+		deadline = time.Now().Add(budget)
+	}
+
 	var wg sync.WaitGroup
-	sem := make(chan struct{}, 10)
+	sem := make(chan struct{}, MaxProbes)
 
 	for i := range pp {
 		wg.Add(1)
@@ -88,11 +106,32 @@ func EnrichHealth(pp []ListeningPort, timeout time.Duration) {
 		go func(idx int) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			result := ProbeHealth(pp[idx].BindAddress, pp[idx].Port, "/", timeout)
+			t, ok := ProbeBudget(timeout, deadline)
+			if !ok {
+				return
+			}
+			result := ProbeHealth(pp[idx].BindAddress, pp[idx].Port, "/", t)
 			pp[idx].HealthStatus = result.Status
 			pp[idx].HealthCode = result.StatusCode
 			pp[idx].HealthLatency = result.Latency
 		}(i)
 	}
 	wg.Wait()
+}
+
+// ProbeBudget is the timeout one probe may use before deadline, and whether it
+// is worth starting at all. A zero deadline means no budget: the probe gets its
+// full timeout.
+func ProbeBudget(timeout time.Duration, deadline time.Time) (time.Duration, bool) {
+	if deadline.IsZero() {
+		return timeout, true
+	}
+	left := time.Until(deadline)
+	if left <= 0 {
+		return 0, false
+	}
+	if left < timeout {
+		return left, true
+	}
+	return timeout, true
 }

--- a/internal/ports/health_test.go
+++ b/internal/ports/health_test.go
@@ -2,8 +2,11 @@ package ports
 
 import (
 	"errors"
+	"net"
 	"net/url"
+	"strconv"
 	"testing"
+	"time"
 )
 
 func TestIsConnectionRefused(t *testing.T) {
@@ -40,5 +43,63 @@ func TestIsConnectionRefused(t *testing.T) {
 				t.Errorf("isConnectionRefused(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestEnrichHealthRoundIsBudgeted is step 1A.19. Ten probes run at once, so
+// forty listeners that accept and never answer used to cost four waves of the
+// per-probe timeout — inside the scan a kill or a `.sonar.yaml` write is queued
+// behind. The round is bounded now; the ports it did not reach keep whatever
+// the previous tick found (see carryHealth in the scanner).
+func TestEnrichHealthRoundIsBudgeted(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("no loopback listener: %v", err)
+	}
+	defer ln.Close()
+	// Accept and never answer, which is what makes a probe wait out its
+	// timeout rather than fail fast.
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer c.Close()
+		}
+	}()
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pp := make([]ListeningPort, 40)
+	for i := range pp {
+		pp[i] = ListeningPort{Port: port, BindAddress: "127.0.0.1"}
+	}
+
+	start := time.Now()
+	EnrichHealth(pp, time.Second, 300*time.Millisecond)
+	took := time.Since(start)
+
+	if took > 2*time.Second {
+		t.Fatalf("a round of 40 probes took %s, want it bounded by the budget", took)
+	}
+}
+
+func TestProbeBudget(t *testing.T) {
+	if d, ok := ProbeBudget(2*time.Second, time.Time{}); !ok || d != 2*time.Second {
+		t.Errorf("no deadline: got %s/%v, want the full timeout", d, ok)
+	}
+	if _, ok := ProbeBudget(time.Second, time.Now().Add(-time.Millisecond)); ok {
+		t.Error("a spent budget should not start another probe")
+	}
+	d, ok := ProbeBudget(time.Second, time.Now().Add(50*time.Millisecond))
+	if !ok || d > 50*time.Millisecond {
+		t.Errorf("near the deadline: got %s/%v, want the timeout clamped to what is left", d, ok)
 	}
 }

--- a/internal/scanner/health.go
+++ b/internal/scanner/health.go
@@ -10,7 +10,7 @@ import (
 
 // maxHealthProbes bounds how many configured health checks run at once, the
 // same ceiling the opt-in probe uses.
-const maxHealthProbes = 10
+const maxHealthProbes = ports.MaxProbes
 
 // Probe is one health check. Options.Probe replaces it for tests; production
 // is ports.ProbeHealth.
@@ -24,13 +24,24 @@ type Probe func(host string, port int, path string, timeout time.Duration) ports
 // the service *is*, not a statistic a client may or may not want, so the
 // daemon polls it as part of state (step 1A.7). Everything else about it is the
 // same probe — one HTTP GET, HealthTimeout, ten in flight.
-func probeConfigured(rows []state.Port, gg []state.Group, probe Probe) {
+func probeConfigured(rows []state.Port, gg []state.Group, probe Probe, budget time.Duration) {
 	targets := healthTargets(rows, gg)
 	if len(targets) == 0 {
 		return
 	}
 
+	// The whole round is bounded, not just one probe. This runs inside the
+	// scan, which every write handler's republish and every kill's rescan is
+	// queued behind (contract §38), so a project that declares health paths on
+	// a dozen services — half of them accepting and never answering — must not
+	// be able to add waves of HealthTimeout to somebody's "Save" button.
+	var deadline time.Time
+	if budget > 0 {
+		deadline = time.Now().Add(budget)
+	}
+
 	results := make([]state.Health, len(targets))
+	probed := make([]bool, len(targets))
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, maxHealthProbes)
 	for i := range targets {
@@ -39,8 +50,12 @@ func probeConfigured(rows []state.Port, gg []state.Group, probe Probe) {
 		go func(i int) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			timeout, ok := ports.ProbeBudget(HealthTimeout, deadline)
+			if !ok {
+				return
+			}
 			t := targets[i]
-			r := probe(t.host, t.port, t.path, HealthTimeout)
+			r := probe(t.host, t.port, t.path, timeout)
 			status, reason := state.NormalizeHealth(r.Status)
 			results[i] = state.Health{
 				Status:     status,
@@ -49,11 +64,17 @@ func probeConfigured(rows []state.Port, gg []state.Group, probe Probe) {
 				Reason:     reason,
 				Configured: true,
 			}
+			probed[i] = true
 		}(i)
 	}
 	wg.Wait()
 
 	for i, t := range targets {
+		if !probed[i] {
+			// Left for carryHealth: the previous tick's verdict beats a
+			// flicker to "unknown" for a probe that never ran.
+			continue
+		}
 		h := results[i]
 		for _, idx := range t.rows {
 			row := h

--- a/internal/scanner/latency_test.go
+++ b/internal/scanner/latency_test.go
@@ -277,3 +277,102 @@ func TestConfiguredHealthRoundIsBudgeted(t *testing.T) {
 		t.Fatal("the first probe should still have run and landed")
 	}
 }
+
+// TestRescanAlwaysScansOnAStoppedClock is the Windows regression from PR #75.
+//
+// Coalescing used to ask "did a scan begin after I asked?" with timestamps.
+// `time.Now` on Windows moves in steps of up to about 15 ms, so the scan that
+// had *just* finished read as having begun at the same instant as the call
+// that followed it, and a kill's rescan was answered with the snapshot it was
+// explicitly not allowed to use (contract §17, §25). The clock is stopped here
+// on purpose: that is the coarsest clock there is, and the rescan must still
+// scan on it.
+func TestRescanAlwaysScansOnAStoppedClock(t *testing.T) {
+	frozen := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	var scans atomic.Int64
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Now:           func() time.Time { return frozen },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			scans.Add(1)
+			return []ports.ListeningPort{{Port: 8123, PID: 42, Process: "python3"}}, nil
+		},
+	})
+
+	if _, err := l.Snapshot(Include{}); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := scans.Load(); got != 1 {
+		t.Fatalf("scans after priming = %d, want 1", got)
+	}
+
+	for i := 2; i <= 4; i++ {
+		if _, err := l.Rescan(Include{}); err != nil {
+			t.Fatalf("Rescan: %v", err)
+		}
+		if got := scans.Load(); got != int64(i) {
+			t.Fatalf("scans after Rescan %d = %d, want %d: a forced scan never coalesces", i-1, got, i)
+		}
+	}
+}
+
+// TestReadCoalescesOntoAScanThatBeganAfterIt is the other side of the same
+// counter: the read path may be handed the result of a scan that demonstrably
+// started after it asked, and may not be handed the one that was already
+// running. Neither answer depends on the clock.
+func TestReadCoalescesOntoAScanThatBeganAfterIt(t *testing.T) {
+	frozen := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var scans atomic.Int64
+
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Now:           func() time.Time { return frozen },
+		Scan: func(inc Include) ([]ports.ListeningPort, error) {
+			scans.Add(1)
+			if inc.Stats {
+				close(entered)
+				<-release
+			}
+			return []ports.ListeningPort{{Port: 8123, PID: 42, Process: "python3"}}, nil
+		},
+	})
+
+	// A read that arrives while the tick's scan is in flight must not be
+	// served by it: that scan began first.
+	go l.scanAndPublish(Include{Stats: true})
+	<-entered
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := l.Snapshot(Include{}); err != nil {
+			t.Errorf("Snapshot: %v", err)
+		}
+	}()
+	close(release)
+	<-done
+	if got := scans.Load(); got != 2 {
+		t.Fatalf("scans = %d, want the read to scan for itself rather than take the one already running", got)
+	}
+
+	// A second read behind the first coalesces onto it: it began later.
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := l.Rescan(Include{}); err != nil {
+				t.Errorf("Rescan: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	// Four forced rescans are four scans; the point of this half is only that
+	// the counter, not the clock, is what decides.
+	if got := scans.Load(); got != 6 {
+		t.Fatalf("scans = %d, want each forced rescan to scan", got)
+	}
+}

--- a/internal/scanner/latency_test.go
+++ b/internal/scanner/latency_test.go
@@ -317,11 +317,18 @@ func TestRescanAlwaysScansOnAStoppedClock(t *testing.T) {
 	}
 }
 
-// TestReadCoalescesOntoAScanThatBeganAfterIt is the other side of the same
-// counter: the read path may be handed the result of a scan that demonstrably
-// started after it asked, and may not be handed the one that was already
-// running. Neither answer depends on the clock.
-func TestReadCoalescesOntoAScanThatBeganAfterIt(t *testing.T) {
+// TestReadDoesNotCoalesceOntoAScanThatBeganBeforeIt is the other side of the counter:
+// a read that arrives while a scan is in flight must scan for itself, because
+// that scan began first and saw a machine this caller has not seen yet.
+//
+// The tick's OS half is held on a channel for the whole assertion, so the read
+// is guaranteed to arrive mid-flight and the tick is guaranteed not to have
+// committed. An earlier version released the tick and then counted scans,
+// which made the result depend on whether the tick committed before the read
+// reached the cache — it did on Linux and not on macOS or Windows, and the
+// test failed on whichever runner won that race rather than on the behaviour
+// it was written for.
+func TestReadDoesNotCoalesceOntoAScanThatBeganBeforeIt(t *testing.T) {
 	frozen := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
 	entered := make(chan struct{})
 	release := make(chan struct{})
@@ -341,38 +348,62 @@ func TestReadCoalescesOntoAScanThatBeganAfterIt(t *testing.T) {
 		},
 	})
 
-	// A read that arrives while the tick's scan is in flight must not be
-	// served by it: that scan began first.
-	go l.scanAndPublish(Include{Stats: true})
-	<-entered
-	done := make(chan struct{})
+	tick := make(chan struct{})
 	go func() {
-		defer close(done)
-		if _, err := l.Snapshot(Include{}); err != nil {
-			t.Errorf("Snapshot: %v", err)
-		}
+		defer close(tick)
+		l.scanAndPublish(Include{Stats: true})
 	}()
-	close(release)
-	<-done
+	<-entered
+
+	// The tick holds the run gate, not the RPC gate: overlapping is the point
+	// (contract §44). The read scans and returns while the tick is still
+	// blocked, so this assertion cannot race the tick's commit.
+	if _, err := l.Snapshot(Include{}); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
 	if got := scans.Load(); got != 2 {
 		t.Fatalf("scans = %d, want the read to scan for itself rather than take the one already running", got)
 	}
 
-	// A second read behind the first coalesces onto it: it began later.
-	var wg sync.WaitGroup
-	for i := 0; i < 4; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if _, err := l.Rescan(Include{}); err != nil {
-				t.Errorf("Rescan: %v", err)
-			}
-		}()
+	close(release)
+	<-tick
+}
+
+// TestCoalescingComparesScanNumbersNotTheClock states the rule directly, with
+// no goroutines and a stopped clock: a read may be handed a scan that began
+// after it asked, and never the one that was already running. Both answers
+// come from the scan counter, so they are the same on every platform.
+func TestCoalescingComparesScanNumbersNotTheClock(t *testing.T) {
+	frozen := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Now:           func() time.Time { return frozen },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{{Port: 8123, PID: 42, Process: "python3"}}, nil
+		},
+	})
+	if _, err := l.Snapshot(Include{}); err != nil {
+		t.Fatalf("Snapshot: %v", err)
 	}
-	wg.Wait()
-	// Four forced rescans are four scans; the point of this half is only that
-	// the counter, not the clock, is what decides.
-	if got := scans.Load(); got != 6 {
-		t.Fatalf("scans = %d, want each forced rescan to scan", got)
+	if got := l.scanGeneration(); got != 1 {
+		t.Fatalf("scan generation = %d, want 1 after one scan", got)
+	}
+
+	// Asked before scan 1 began: scan 1 answers it.
+	if _, ok := l.scannedSince(0, Include{}); !ok {
+		t.Error("a scan that began after the caller asked should answer it")
+	}
+	// Asked while (or after) scan 1 was running: it does not.
+	if _, ok := l.scannedSince(1, Include{}); ok {
+		t.Error("the scan that was already running must not answer a later caller")
+	}
+	// Health is never coalesced: the probes run on their own cadence.
+	if _, ok := l.scannedSince(0, Include{Health: true}); ok {
+		t.Error("a health read should never coalesce")
+	}
+	// Stats are only coalesced onto a snapshot that carries them.
+	if _, ok := l.scannedSince(0, Include{Stats: true}); ok {
+		t.Error("a stats read should not coalesce onto a snapshot with no stats")
 	}
 }

--- a/internal/scanner/latency_test.go
+++ b/internal/scanner/latency_test.go
@@ -1,0 +1,279 @@
+package scanner
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// Step 1A.19. Everything here is about what a handler pays for, not about what
+// it publishes: the shape of the answers is pinned by the 1A.15, 1A.7 and
+// 1A.16 tests next to these.
+
+// TestRepublishDoesNotScan is the step's headline. A store write's republish
+// used to run a whole scan — `lsof`, `ps`, `docker stats`, a round of health
+// probes — before its own reply, which is what made "Save color" in the app
+// take double figures of seconds.
+func TestRepublishDoesNotScan(t *testing.T) {
+	st := openStore(t)
+	var scans atomic.Int64
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Store:         st,
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			scans.Add(1)
+			return []ports.ListeningPort{{Port: 8123, PID: 42, Process: "python3"}}, nil
+		},
+	})
+
+	if _, err := l.Snapshot(Include{}); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if got := scans.Load(); got != 1 {
+		t.Fatalf("scans after the first read = %d, want 1", got)
+	}
+
+	if err := st.SetRename("port:8123", "storefront"); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Republish(); err != nil {
+		t.Fatalf("Republish: %v", err)
+	}
+	if got := scans.Load(); got != 1 {
+		t.Fatalf("scans after Republish = %d, want no new scan", got)
+	}
+
+	snap := l.Cached()
+	if len(snap.Ports) != 1 || snap.Ports[0].DisplayName != "storefront" {
+		t.Fatalf("cached snapshot = %+v, want the rename published from it", snap.Ports)
+	}
+}
+
+// TestRepublishPublishesBeforeItReturns keeps contract §18's ordering: the
+// delta carrying the change is on the wire before the handler's reply, which
+// is the reason republish is synchronous at all.
+func TestRepublishPublishesBeforeItReturns(t *testing.T) {
+	st := openStore(t)
+	var mu sync.Mutex
+	var names []string
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Store:         st,
+		Demand:        func() (int, Include) { return 1, Include{} },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{{Port: 8123, PID: 42, Process: "python3"}}, nil
+		},
+		Publish: func(_, next state.Snapshot, _ []state.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			for _, p := range next.Ports {
+				names = append(names, p.DisplayName)
+			}
+		},
+	})
+	if _, err := l.Snapshot(Include{}); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if err := st.SetRename("port:8123", "storefront"); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Republish(); err != nil {
+		t.Fatalf("Republish: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(names) == 0 || names[len(names)-1] != "storefront" {
+		t.Fatalf("published names = %v, want the rename published by the time Republish returned", names)
+	}
+}
+
+// TestRepublishBeforeAnyScanFallsBackToOne: with nothing scanned yet there is
+// nothing to re-attribute, and the write still has to reach the wire.
+func TestRepublishBeforeAnyScanFallsBackToOne(t *testing.T) {
+	var scans atomic.Int64
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			scans.Add(1)
+			return []ports.ListeningPort{{Port: 8123, PID: 42, Process: "python3"}}, nil
+		},
+	})
+	if err := l.Republish(); err != nil {
+		t.Fatalf("Republish: %v", err)
+	}
+	if got := scans.Load(); got != 1 {
+		t.Fatalf("scans = %d, want one scan when there is no snapshot to re-attribute", got)
+	}
+}
+
+// TestRPCScanDoesNotInheritDemandButKeepsIt is the other half of the fix. A
+// scan an RPC starts collects what the *caller* asked for; what the
+// subscribers asked for is copied forward from the last snapshot instead of
+// being collected again, so `ports.kill` never waits on `docker stats` or a
+// health probe (contract §44) and no subscriber sees stats blink away.
+func TestRPCScanDoesNotInheritDemandButKeepsIt(t *testing.T) {
+	var mu sync.Mutex
+	var asked []Include
+
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Demand:        func() (int, Include) { return 1, Include{Stats: true, Health: true} },
+		Scan: func(inc Include) ([]ports.ListeningPort, error) {
+			mu.Lock()
+			asked = append(asked, inc)
+			mu.Unlock()
+			row := ports.ListeningPort{Port: 8123, PID: 42, Process: "python3"}
+			if inc.Stats {
+				row.CPUPercent = 12.5
+				row.MemoryRSS = 4096
+			}
+			if inc.Health {
+				row.HealthStatus = "healthy"
+			}
+			return []ports.ListeningPort{row}, nil
+		},
+	})
+
+	// The loop's own tick collects the demand.
+	l.scanAndPublish(Include{Stats: true, Health: true})
+	ticked := l.Cached()
+	if len(ticked.Ports) != 1 || ticked.Ports[0].Health == nil {
+		t.Fatalf("the tick published %+v, want a probed row", ticked.Ports)
+	}
+	want := *ticked.Ports[0].Health
+
+	// A kill's rescan asks for nothing.
+	snap, err := l.Rescan(Include{})
+	if err != nil {
+		t.Fatalf("Rescan: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]Include{}, asked...)
+	mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("scans = %d, want the tick and the rescan", len(got))
+	}
+	if got[1].Stats || got[1].Health {
+		t.Fatalf("the rescan collected %+v, want a bare scan", got[1])
+	}
+	if len(snap.Ports) != 1 {
+		t.Fatalf("ports = %+v", snap.Ports)
+	}
+	if snap.Ports[0].Stats == nil || snap.Ports[0].Stats.CPUPercent != 12.5 {
+		t.Fatalf("stats = %+v, want the subscriber's last reading carried forward", snap.Ports[0].Stats)
+	}
+	if snap.Ports[0].Health == nil || *snap.Ports[0].Health != want {
+		t.Fatalf("health = %+v, want the tick's verdict %+v carried forward", snap.Ports[0].Health, want)
+	}
+}
+
+// TestOlderScanNeverOvertakesANewerOne is what lets an RPC's bare scan run
+// alongside the loop's expensive one: overlapping is fine, going backwards is
+// not. A scan whose OS half began before the published snapshot's must not
+// commit (contract §44).
+func TestOlderScanNeverOvertakesANewerOne(t *testing.T) {
+	release := make(chan struct{})
+	var slow atomic.Bool
+
+	l := New(Options{
+		HostStats:     fixedHost,
+		DaemonVersion: "test",
+		Scan: func(inc Include) ([]ports.ListeningPort, error) {
+			if inc.Stats {
+				// The loop's tick: started first, finishes last, and still
+				// sees the port that the bare scan below saw go away.
+				slow.Store(true)
+				<-release
+				return []ports.ListeningPort{
+					{Port: 8123, PID: 42, Process: "python3"},
+					{Port: 8124, PID: 43, Process: "python3"},
+				}, nil
+			}
+			return []ports.ListeningPort{{Port: 8123, PID: 42, Process: "python3"}}, nil
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		l.scanAndPublish(Include{Stats: true})
+	}()
+	for !slow.Load() {
+		time.Sleep(time.Millisecond)
+	}
+
+	// The bare scan starts second and commits first: one port.
+	if _, err := l.Rescan(Include{}); err != nil {
+		t.Fatalf("Rescan: %v", err)
+	}
+	if got := len(l.Cached().Ports); got != 1 {
+		t.Fatalf("ports after the rescan = %d, want 1", got)
+	}
+
+	close(release)
+	<-done
+
+	if got := len(l.Cached().Ports); got != 1 {
+		t.Fatalf("ports after the older scan committed = %d, want the newer scan to still win", got)
+	}
+}
+
+// TestLockForGivesUp pins the deadline every handler path takes a gate with. A
+// scan that never returns must not turn into a reply that never comes.
+func TestLockForGivesUp(t *testing.T) {
+	gate := make(chan struct{}, 1)
+	lock(gate)
+	start := time.Now()
+	if lockFor(gate, 20*time.Millisecond) {
+		t.Fatal("lockFor took a gate that was held")
+	}
+	if waited := time.Since(start); waited < 20*time.Millisecond {
+		t.Fatalf("gave up after %s, want at least the budget", waited)
+	}
+	unlock(gate)
+	if !lockFor(gate, time.Second) {
+		t.Fatal("lockFor could not take a free gate")
+	}
+	unlock(gate)
+}
+
+// TestConfiguredHealthRoundIsBudgeted: a service that accepts and never
+// answers must not add waves of HealthTimeout to the scan every write is
+// queued behind.
+func TestConfiguredHealthRoundIsBudgeted(t *testing.T) {
+	rows := make([]state.Port, 0, 40)
+	gg := []state.Group{{Name: "slow"}}
+	for i := 0; i < 40; i++ {
+		port := 9000 + i
+		rows = append(rows, state.Port{Port: port, BindAddress: "127.0.0.1"})
+		path := "/healthz"
+		p := port
+		gg[0].Services = append(gg[0].Services, state.Service{
+			Name: "svc", Health: &path, PortActual: &p,
+		})
+	}
+
+	start := time.Now()
+	probeConfigured(rows, gg, func(string, int, string, time.Duration) ports.HealthResult {
+		time.Sleep(50 * time.Millisecond)
+		return ports.HealthResult{Status: "timeout"}
+	}, 80*time.Millisecond)
+	took := time.Since(start)
+
+	if took > 400*time.Millisecond {
+		t.Fatalf("a round of 40 probes took %s, want it bounded by the budget", took)
+	}
+	if rows[0].Health == nil {
+		t.Fatal("the first probe should still have run and landed")
+	}
+}

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -37,6 +37,21 @@ const (
 	HealthCadence = 10 * time.Second
 	// HealthTimeout bounds a single probe.
 	HealthTimeout = 2 * time.Second
+	// HealthBudget bounds a whole round of opt-in health probes, however many
+	// ports are listening. Ten probes run at once, so without a ceiling a
+	// machine with forty listeners costs four waves of HealthTimeout — and a
+	// write handler's republish is queued behind the scan that pays it
+	// (contract §44).
+	HealthBudget = 4 * time.Second
+	// ConfiguredHealthBudget is the same ceiling for the `.sonar.yaml` health
+	// paths, which are probed on every tick rather than on HealthCadence.
+	ConfiguredHealthBudget = 2 * time.Second
+	// ScanLockBudget bounds how long a handler waits for one of the loop's
+	// gates before it gives up and answers from the last good snapshot. A scan is bounded
+	// (the probes have budgets and the docker calls have timeouts), so
+	// reaching this means the daemon is wedged; the point is that a reply is
+	// still impossible to hang (contract §44).
+	ScanLockBudget = 15 * time.Second
 	// HostStatsTimeout bounds one collection of the machine's own load.
 	HostStatsTimeout = 3 * time.Second
 	// StatsInterval is the fixed cadence of the stats-only tick: per-process
@@ -153,18 +168,45 @@ type Loop struct {
 
 	attr attribution
 
-	// scanMu serializes a whole scan — the OS call, the attribution that
-	// reads the store, the commit into the cache and the publish — against
-	// every other scan. Without it only the commit was serialized, and two
-	// scans could overlap: the tick a read woke could load the rename table
-	// *before* `ports.rename` wrote to it and still commit *after* the
-	// rescan the write triggered, overwriting the renamed snapshot with the
-	// stale one and publishing a delta that put the old display_name back.
-	// Holding it end to end makes the rule "a scan that starts after a write
-	// sees it, and a scan that started before one can never land after it"
-	// true by construction, and keeps delta seq order the same as publish
-	// order.
-	scanMu sync.Mutex
+	// runGate admits one OS scan at a time. It is held from a scan's first
+	// system call to its last, so two scans can never overlap and a slow one
+	// can never commit port rows on top of a newer one's. Only scanning takes
+	// it: a republish and a remote host's rows need no OS call at all.
+	//
+	// It is a buffered channel rather than a sync.Mutex because a handler that
+	// waits for it has to wait *with a deadline* (contract §44).
+	runGate chan struct{}
+
+	// rpcGate does the same for the scans an RPC starts: one at a time, so ten
+	// clients reading at once still cost the machine one scan. It is separate
+	// from runGate on purpose. A `ports.kill` needs a bare port list and gets
+	// it in a moment; the loop's own tick is collecting stats, which means
+	// `docker stats` and a machine-wide `lsof`, and queueing the first behind
+	// the second is what made a dry-run kill take double figures of seconds
+	// (contract §44). The two can overlap because ordering no longer depends
+	// on them not overlapping: attribution and the commit are serialized by
+	// orderGate, and a scan whose OS half is older than the published snapshot
+	// never commits (see commitScan).
+	rpcGate chan struct{}
+
+	// orderGate is what 1A.15's scanMu really guards: the attribution that
+	// reads the store, the commit into the cache and the publish, taken by
+	// everything that publishes a re-attributed snapshot — a scan, a store
+	// write's republish, a remote host's rows changing.
+	//
+	// The rule it buys is unchanged (contract §38): a scan's attribution
+	// happens either wholly before a store write or wholly after it, so the
+	// tick that loaded the rename table before `ports.rename` wrote to it can
+	// no longer commit on top of the write and put the old display_name back.
+	// What changed in 1A.19 is where it starts. It used to be taken before the
+	// OS scan, which meant a rename, a group pin or a "Save color" waited out
+	// `lsof`, `ps`, `docker stats` and a round of health probes before its own
+	// microsecond of work — seconds of latency for a guarantee that only ever
+	// needed the store-reading half. Ordering is about attribution, not about
+	// asking the kernel which sockets are open (contract §44).
+	//
+	// Lock order is runGate, then orderGate, then commitMu; never the reverse.
+	orderGate chan struct{}
 
 	// commitMu is the narrower half of that promise: it is held across the
 	// commit into the cache *and* the publish that follows, by everything
@@ -191,9 +233,15 @@ type Loop struct {
 	// local is the last scan's own rows, before the remote hosts were merged
 	// in. RemoteChanged republishes from it, so a remote host's delta costs
 	// nothing on the local machine: no OS scan, no attribution, no probes.
-	local        state.Rows
+	local state.Rows
+	// lastPorts is the OS half of the last scan, before attribution. Republish
+	// re-attributes it instead of scanning the machine again, which is what
+	// makes a rename or a `.sonar.yaml` write cost microseconds rather than a
+	// full scan (contract §44).
+	lastPorts    []ports.ListeningPort
 	haveSnap     bool
 	lastScanAt   time.Time
+	lastScanFrom time.Time
 	lastHealthAt time.Time
 	interval     time.Duration
 	seq          uint64
@@ -236,9 +284,38 @@ func New(opts Options) *Loop {
 		now:       now,
 		wake:      make(chan struct{}, 1),
 		statsWake: make(chan struct{}, 1),
+		runGate:   make(chan struct{}, 1),
+		rpcGate:   make(chan struct{}, 1),
+		orderGate: make(chan struct{}, 1),
 		interval:  BaseInterval,
 	}
 }
+
+// lock takes one of the loop's channel mutexes and waits as long as it takes.
+// The scan loop itself uses this: it has nobody to answer to.
+func lock(gate chan struct{}) { gate <- struct{}{} }
+
+// lockFor takes one, giving up after d, and reports whether it got it. Every
+// handler-initiated path uses this rather than lock, so a reply can never wait
+// on a gate forever (contract §44).
+func lockFor(gate chan struct{}, d time.Duration) bool {
+	select {
+	case gate <- struct{}{}:
+		return true
+	default:
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case gate <- struct{}{}:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+// unlock releases one.
+func unlock(gate chan struct{}) { <-gate }
 
 // osScan is the production scan: the same pipeline `sonar list` runs, so the
 // daemon and the no-daemon path emit byte-identical rows.
@@ -419,11 +496,20 @@ func (l *Loop) Run(ctx context.Context) {
 			}
 		}
 
-		l.scanAndPublish(include)
-
-		l.mu.Lock()
-		wait := l.interval
-		l.mu.Unlock()
+		// A scan an RPC ran a moment ago is this tick's scan. Wake means "the
+		// state you are holding may be stale", and a scan younger than the
+		// current interval is not: without this floor every `ports.kill`,
+		// every `sonar list` that missed the cache and every write woke the
+		// loop into a second full scan, which is one more scan for the next
+		// caller to be queued behind (contract §44).
+		wait := l.dueIn()
+		if wait <= 0 {
+			l.scanAndPublish(include)
+			wait = l.dueIn()
+		}
+		if wait <= 0 {
+			wait = BaseInterval
+		}
 
 		if !timer.Stop() {
 			select {
@@ -449,10 +535,10 @@ func (l *Loop) Run(ctx context.Context) {
 // publishes when something changed. One scan at a time (see scanMu); the
 // publish itself happens inside scanLocked, under commitMu.
 func (l *Loop) scanAndPublish(include Include) {
-	l.scanMu.Lock()
-	defer l.scanMu.Unlock()
+	lock(l.runGate)
+	defer unlock(l.runGate)
 
-	_, prev, _, err := l.scanLocked(include)
+	_, prev, _, err := l.scanLocked(include, Include{})
 	if err != nil {
 		l.opts.Logger.Warn("scan failed, keeping last good state", "error", err)
 		// A scan_error carries no snapshot and takes no seq, so it needs no
@@ -476,13 +562,21 @@ func (l *Loop) publish(prev, next state.Snapshot, events []state.Event) {
 // scanLocked performs a scan and swaps it into the cache. It returns the new
 // snapshot, the one it replaced, and whether anything a client cares about
 // changed.
-func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed bool, err error) {
+//
+// collect is what this scan asks the OS for. carry is what the *subscribers*
+// want the published snapshot to keep but this caller has no reason to pay
+// for: those fields are copied forward from the previous snapshot instead of
+// being collected again (contract §44). The scan loop's own tick passes its
+// demand as collect and nothing as carry; an RPC passes the caller's own
+// include as collect and the subscribers' as carry.
+func (l *Loop) scanLocked(collect, carry Include) (next, prev state.Snapshot, changed bool, err error) {
 	// Read outside the mutex: Demand takes the server's own lock, which the
 	// server holds while calling back into the loop.
 	subs, _ := l.opts.Demand()
-	wantHealth := include.Health && l.healthDue()
+	wantHealth := collect.Health && l.healthDue()
 
-	pp, err := l.opts.Scan(include)
+	startedAt := l.now()
+	pp, err := l.opts.Scan(collect)
 	if err != nil {
 		l.mu.Lock()
 		l.lastErr = err
@@ -494,8 +588,20 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 	}
 
 	if wantHealth {
-		ports.EnrichHealth(pp, HealthTimeout)
+		ports.EnrichHealth(pp, HealthTimeout, HealthBudget)
 	}
+
+	// The machine's own load, read before the ordering gate: on macOS it forks
+	// `ps`, and nothing about it is ordered against a store write.
+	host := l.collectHost()
+
+	// Everything from here on is the ordered half of the scan: the attribution
+	// that reads the store, the commit, and the publish. It is serialized
+	// against every store write's republish and against every other publisher,
+	// and the publish rides inside it so a later seq can never reach a client
+	// first (contract §38, §44).
+	lock(l.orderGate)
+	defer unlock(l.orderGate)
 
 	// Resolve every port's group with the pins the store holds, apply the
 	// stored renames and build the group collection, all before the snapshot
@@ -504,54 +610,94 @@ func (l *Loop) scanLocked(include Include) (next, prev state.Snapshot, changed b
 
 	sessionRows := l.sessions(rows)
 
-	// The machine's own load, read outside the mutex: on macOS it forks `ps`.
-	host := l.collectHost()
-
 	// Configured health comes after attribution because it is the groups that
 	// say which port has a `health:` path. It runs on every tick regardless of
 	// `include`: a health path in a `.sonar.yaml` is part of what the service
-	// is, not an opt-in statistic (step 1A.7).
-	probeConfigured(rows, groupRows, l.opts.Probe)
+	// is, not an opt-in statistic (step 1A.7). Its budget is what keeps this
+	// short enough to sit inside the ordering gate.
+	probeConfigured(rows, groupRows, l.opts.Probe, ConfiguredHealthBudget)
 
-	// Everything from here on is the commit: the point at which this scan
-	// becomes the published state. It is serialized against every other
-	// publisher, and the publish rides inside it so a later seq can never
-	// reach a client first (contract §38).
 	l.commitMu.Lock()
 	defer l.commitMu.Unlock()
 
-	next, prev, changed = l.commitScan(subs, include, wantHealth, rows, groupRows, sessionRows, host)
+	next, prev, changed = l.commitScan(commit{
+		subs:      subs,
+		collect:   collect,
+		carry:     carry,
+		health:    wantHealth,
+		startedAt: startedAt,
+		pp:        pp,
+		rows:      rows,
+		groups:    groupRows,
+		sessions:  sessionRows,
+		host:      host,
+	})
 	if changed {
 		l.publish(prev, next, deriveEvents(prev, next, l.nowRFC3339()))
 	}
 	return next, prev, changed, nil
 }
 
+// commit is one finished scan on its way into the cache.
+type commit struct {
+	subs      int
+	collect   Include
+	carry     Include
+	health    bool
+	startedAt time.Time
+	pp        []ports.ListeningPort
+	rows      []state.Port
+	groups    []state.Group
+	sessions  []state.SessionRecord
+	host      state.Host
+}
+
 // commitScan swaps a finished scan into the cache and adapts the interval.
-// Caller holds scanMu and commitMu; this takes l.mu for the swap itself.
-func (l *Loop) commitScan(
-	subs int, include Include, wantHealth bool,
-	rows []state.Port, groupRows []state.Group, sessionRows []state.SessionRecord,
-	host state.Host,
-) (next, prev state.Snapshot, changed bool) {
+// Caller holds the ordering gate and commitMu; this takes l.mu for the swap
+// itself.
+func (l *Loop) commitScan(c commit) (next, prev state.Snapshot, changed bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.subs = subs
+	l.subs = c.subs
 	prev = l.snap
-	if include.Health && !wantHealth {
-		// Between health cadences, carry the previous probe results forward so
-		// a port does not flicker between "checked" and "unknown".
-		carryHealth(prev.Ports, rows)
-	}
+	rows, groupRows := c.rows, c.groups
 
 	l.scans++
-	l.lastScanAt = l.now()
 	l.lastErr = nil
-	if wantHealth {
+	if l.haveSnap && c.startedAt.Before(l.lastScanFrom) {
+		// Superseded. This scan asked the OS what was listening before the
+		// snapshot on the wire was captured, so committing it would put back
+		// ports a newer scan has already seen go — the "no going backwards"
+		// half of contract §38, now enforced at the commit rather than by
+		// forbidding two scans to overlap at all (contract §44).
+		return prev, prev, false
+	}
+
+	// Carry forward every probe result this scan did not take: between health
+	// cadences, for a configured probe the round's budget cut short, and for a
+	// scan an RPC started that had no reason to pay for a subscriber's health
+	// (contract §44). Without it a port flickers between "checked" and
+	// "unknown" on the wire.
+	carryHealth(prev.Ports, rows, (c.collect.Health || c.carry.Health) && !c.health)
+
+	// Same for stats. A scan an RPC started collects none unless the caller
+	// asked, so it copies the subscribers' last readings across rather than
+	// publishing a snapshot with the numbers stripped out — and the 1 s stats
+	// tick refreshes them within the second anyway (contract §42).
+	if c.carry.Stats && !c.collect.Stats {
+		carryStats(prev.Ports, rows)
+	}
+	withStats := c.collect.Stats || c.carry.Stats
+
+	l.lastScanAt = l.now()
+	l.lastScanFrom = c.startedAt
+	l.lastPorts = c.pp
+	if c.health {
 		l.lastHealthAt = l.lastScanAt
 	}
 
+	host := c.host
 	host.Ports, host.Groups = len(rows), len(groupRows)
 	host.LastSeen = l.lastScanAt.Format(time.RFC3339)
 
@@ -560,7 +706,7 @@ func (l *Loop) commitScan(
 	local := state.Rows{
 		Ports:    rows,
 		Groups:   groupRows,
-		Sessions: sessionRows,
+		Sessions: c.sessions,
 		Hosts:    []state.Host{host},
 	}.Tag(state.LocalhostName).Normalize()
 	l.local = local
@@ -570,7 +716,7 @@ func (l *Loop) commitScan(
 		DaemonVersion: l.opts.DaemonVersion,
 	})
 
-	if l.haveSnap && !snapshotChanged(prev, next, include.Stats) {
+	if l.haveSnap && !snapshotChanged(prev, next, withStats) {
 		if !hostChanged(prev, next) {
 			// Nothing to publish: keep the previous seq and back the interval
 			// off.
@@ -616,8 +762,8 @@ func (l *Loop) commitScan(
 // nothing tells the subscriber a host appeared. It still wakes the loop, so
 // the local half follows.
 func (l *Loop) RemoteChanged() {
-	l.scanMu.Lock()
-	defer l.scanMu.Unlock()
+	lock(l.orderGate)
+	defer unlock(l.orderGate)
 	l.commitMu.Lock()
 	defer l.commitMu.Unlock()
 
@@ -691,6 +837,17 @@ func hostChanged(prev, next state.Snapshot) bool {
 	return len(d.Added) > 0 || len(d.Updated) > 0 || len(d.Removed) > 0
 }
 
+// dueIn is how long until the next scan is due: the current interval minus the
+// age of the last scan, whoever ran it. Zero or less means now.
+func (l *Loop) dueIn() time.Duration {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.lastScanAt.IsZero() {
+		return 0
+	}
+	return l.interval - l.now().Sub(l.lastScanAt)
+}
+
 // healthDue reports whether the health cadence has elapsed.
 func (l *Loop) healthDue() bool {
 	l.mu.Lock()
@@ -734,7 +891,13 @@ func snapshotChanged(prev, next state.Snapshot, withStats bool) bool {
 
 // carryHealth copies health results from the previous snapshot onto rows that
 // were not probed this tick.
-func carryHealth(prev []state.Port, next []state.Port) {
+//
+// all says whether to carry every result or only the configured ones. A
+// `.sonar.yaml` health path is state rather than an opt-in statistic
+// (contract §22), so its last verdict is always better than the "unknown" a
+// skipped probe would publish; an opt-in probe is only carried while somebody
+// is still asking for health.
+func carryHealth(prev []state.Port, next []state.Port, all bool) {
 	if len(prev) == 0 {
 		return
 	}
@@ -743,10 +906,37 @@ func carryHealth(prev []state.Port, next []state.Port) {
 		byKey[prev[i].Key()] = prev[i].Health
 	}
 	for i := range next {
-		if next[i].Health == nil {
-			if h, ok := byKey[next[i].Key()]; ok {
-				next[i].Health = h
-			}
+		if next[i].Health != nil {
+			continue
+		}
+		h, ok := byKey[next[i].Key()]
+		if !ok || h == nil {
+			continue
+		}
+		if all || h.Configured {
+			next[i].Health = h
+		}
+	}
+}
+
+// carryStats copies the previous snapshot's stats onto rows that were not
+// sampled this scan, keyed the same way health is. A port that appeared in
+// this scan and has no previous reading keeps a null `stats`; the 1 s stats
+// tick fills it in on its next pass.
+func carryStats(prev []state.Port, next []state.Port) {
+	if len(prev) == 0 {
+		return
+	}
+	byKey := make(map[string]*state.Stats, len(prev))
+	for i := range prev {
+		byKey[prev[i].Key()] = prev[i].Stats
+	}
+	for i := range next {
+		if next[i].Stats != nil {
+			continue
+		}
+		if st, ok := byKey[next[i].Key()]; ok {
+			next[i].Stats = st
 		}
 	}
 }
@@ -843,13 +1033,132 @@ func (l *Loop) Rescan(include Include) (state.Snapshot, error) {
 	return localOnly(snap), err
 }
 
-// scanNow is the uncached half of both: one scan under scanMu, published
-// before it returns.
-func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
-	l.scanMu.Lock()
-	defer l.scanMu.Unlock()
+// Republish makes a store or `.sonar.yaml` write visible on the wire without
+// scanning the machine (contract §44).
+//
+// The write changed how the ports the daemon already knows are *named and
+// grouped*, not which ports exist, so re-running attribution over the last
+// scan's own OS rows answers it exactly. It takes the scan lock, so it still
+// cannot interleave with a scan and §38's rule holds: a scan that started
+// before the write commits first and this publish supersedes it, a scan that
+// starts after it sees the write. What it no longer does is make a "Save"
+// button wait for `lsof`, `ps` and `docker stats`.
+//
+// It wakes the loop on the way out, so a real scan follows and picks up
+// anything that started or stopped meanwhile. Before the first scan, or if the
+// lock cannot be had inside ScanLockBudget, it falls back to Rescan and to
+// leaving the change for the next tick respectively; the second case means the
+// daemon is wedged and is reported as an error rather than a hung reply.
+func (l *Loop) Republish() error {
+	if !lockFor(l.orderGate, ScanLockBudget) {
+		l.Wake()
+		return fmt.Errorf("scanner busy for more than %s; the change is saved and the next scan will publish it", ScanLockBudget)
+	}
+	l.mu.Lock()
+	pp, have := l.lastPorts, l.haveSnap
+	l.mu.Unlock()
+	if !have || len(pp) == 0 {
+		// Nothing to re-attribute yet: fall back to a real scan, which is
+		// what this used to do unconditionally.
+		unlock(l.orderGate)
+		_, err := l.Rescan(Include{})
+		return err
+	}
+	defer unlock(l.orderGate)
+	defer l.Wake()
 
-	next, prev, _, err := l.scanLocked(l.withDemand(include))
+	subs, carry := l.opts.Demand()
+	rows, groupRows := l.attribute(pp)
+	sessionRows := l.sessions(rows)
+	probeConfigured(rows, groupRows, l.opts.Probe, ConfiguredHealthBudget)
+
+	l.commitMu.Lock()
+	defer l.commitMu.Unlock()
+
+	next, prev, changed := l.commitRepublish(subs, carry, rows, groupRows, sessionRows)
+	if changed {
+		l.publish(prev, next, deriveEvents(prev, next, l.nowRFC3339()))
+	}
+	return nil
+}
+
+// commitRepublish swaps a re-attributed snapshot into the cache. It is
+// commitScan minus everything that belongs to an OS scan: it does not touch
+// the scan counters, `lastScanAt`, the interval or the machine's load row, so
+// the RPC cache TTL and `daemon status` read exactly what they would have if
+// the write had never happened. Caller holds the ordering gate and commitMu.
+func (l *Loop) commitRepublish(
+	subs int, carry Include,
+	rows []state.Port, groupRows []state.Group, sessionRows []state.SessionRecord,
+) (next, prev state.Snapshot, changed bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.subs = subs
+	prev = l.snap
+
+	carryHealth(prev.Ports, rows, true)
+	carryStats(prev.Ports, rows)
+
+	host := l.localhostRow(prev.Hosts)
+	host.Ports, host.Groups = len(rows), len(groupRows)
+
+	local := state.Rows{
+		Ports:    rows,
+		Groups:   groupRows,
+		Sessions: sessionRows,
+		Hosts:    []state.Host{host},
+	}.Tag(state.LocalhostName).Normalize()
+
+	next = local.Append(l.remoteRows()).Into(state.Snapshot{
+		At:            l.now().Format(time.RFC3339),
+		DaemonVersion: l.opts.DaemonVersion,
+	})
+	if !snapshotChanged(prev, next, true) && !hostChanged(prev, next) {
+		// A write that changed nothing a client can see publishes nothing and
+		// burns no seq, the same rule the stats tick follows.
+		return prev, prev, false
+	}
+
+	l.local = local
+	l.seq++
+	next.Seq = l.seq
+	l.snap = next
+	return next, prev, true
+}
+
+// localhostRow is this machine's row as the last publisher left it, or the
+// identity row when there is none.
+func (l *Loop) localhostRow(hosts []state.Host) state.Host {
+	for i := range hosts {
+		if state.IsLocalhost(hosts[i].Name) {
+			return hosts[i]
+		}
+	}
+	return l.identityRow()
+}
+
+// scanNow is the uncached half of both: one scan under the run gate, published
+// before it returns.
+//
+// A scan that *started* after this call did is already the answer — it saw
+// everything this caller could have seen — so waiting for the one in flight
+// and then running a second is pure duplication. Coalescing onto it is what
+// keeps `ports.kill` to one scan's wait rather than two (contract §44).
+func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
+	asked := l.now()
+	if !lockFor(l.rpcGate, ScanLockBudget) {
+		// Wedged: the last good snapshot beats a reply that never comes.
+		l.opts.Logger.Warn("scanner busy, serving the last snapshot", "waited", ScanLockBudget)
+		return l.CachedAll(), nil
+	}
+	defer unlock(l.rpcGate)
+
+	if snap, ok := l.scannedSince(asked, include); ok {
+		return snap, nil
+	}
+
+	next, prev, _, err := l.scanLocked(include, l.demandInclude())
 	if err != nil {
 		if prev.Seq > 0 {
 			// A failed rescan still serves the last good state.
@@ -858,6 +1167,25 @@ func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
 		return state.Snapshot{}, err
 	}
 	return next, nil
+}
+
+// scannedSince reports the cached snapshot when a scan that began at or after
+// t has already committed one that carries what the caller asked for. Health
+// never coalesces: the probes run on their own cadence, so "a scan happened"
+// says nothing about whether it probed.
+func (l *Loop) scannedSince(t time.Time, include Include) (state.Snapshot, bool) {
+	if include.Health {
+		return state.Snapshot{}, false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.haveSnap || l.lastScanFrom.Before(t) {
+		return state.Snapshot{}, false
+	}
+	if include.Stats && !l.snapHasStats() {
+		return state.Snapshot{}, false
+	}
+	return l.snap, true
 }
 
 // cached returns the cached snapshot when it is younger than CacheTTL and
@@ -870,17 +1198,18 @@ func (l *Loop) cached(include Include) (state.Snapshot, bool) {
 	return l.snap, fresh && covers
 }
 
-// withDemand widens an RPC caller's include with what the subscribers want.
-// A scan started by a read is published like any other, so it has to collect
-// what a tick would: without this a `sonar list` in the middle of a subscribed
-// session would publish a snapshot with the stats stripped out, and every
-// subscriber that opted into them would see them blink away and back.
-func (l *Loop) withDemand(include Include) Include {
+// demandInclude is what the subscribers want a published snapshot to keep.
+//
+// A scan started by a read is published like any other, so it must not drop
+// what a tick would have carried: without this a `sonar list` in the middle of
+// a subscribed session would publish a snapshot with the stats stripped out,
+// and every subscriber that opted into them would see them blink away and
+// back. It used to be *collected* again, which put `docker stats` and a round
+// of health probes on the critical path of every kill and every write; it is
+// copied forward now instead (contract §44).
+func (l *Loop) demandInclude() Include {
 	_, want := l.opts.Demand()
-	return Include{
-		Stats:  include.Stats || want.Stats,
-		Health: include.Health || want.Health,
-	}
+	return want
 }
 
 // snapHasStats reports whether the cached snapshot carries stats. Caller holds

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -238,10 +238,22 @@ type Loop struct {
 	// re-attributes it instead of scanning the machine again, which is what
 	// makes a rename or a `.sonar.yaml` write cost microseconds rather than a
 	// full scan (contract §44).
-	lastPorts    []ports.ListeningPort
-	haveSnap     bool
+	lastPorts []ports.ListeningPort
+	haveSnap  bool
+
+	// scanSeq numbers scans in the order their OS half begins, and
+	// committedSeq is the number of the scan the published snapshot came
+	// from. Both are counters rather than timestamps on purpose: "did a scan
+	// begin after I asked" and "is this scan older than the one already
+	// published" are happens-before questions, and a clock cannot answer
+	// them. `time.Now` on Windows moves in steps of up to about 15 ms, so two
+	// events milliseconds apart read as simultaneous — which made a kill's
+	// rescan coalesce onto the scan that had *just* finished and resolve its
+	// targets against the very snapshot §17 says it must not use.
+	scanSeq      uint64
+	committedSeq uint64
+
 	lastScanAt   time.Time
-	lastScanFrom time.Time
 	lastHealthAt time.Time
 	interval     time.Duration
 	seq          uint64
@@ -502,6 +514,11 @@ func (l *Loop) Run(ctx context.Context) {
 		// every `sonar list` that missed the cache and every write woke the
 		// loop into a second full scan, which is one more scan for the next
 		// caller to be queued behind (contract §44).
+		//
+		// The floor is the *loop's* cadence and nothing else. A handler that
+		// asks for a scan gets one: Rescan is a forced scan (see scanMode)
+		// and never consults this, because a kill resolving its selectors
+		// against the previous tick is the bug §17 exists to prevent.
 		wait := l.dueIn()
 		if wait <= 0 {
 			l.scanAndPublish(include)
@@ -575,7 +592,7 @@ func (l *Loop) scanLocked(collect, carry Include) (next, prev state.Snapshot, ch
 	subs, _ := l.opts.Demand()
 	wantHealth := collect.Health && l.healthDue()
 
-	startedAt := l.now()
+	gen := l.beginScan()
 	pp, err := l.opts.Scan(collect)
 	if err != nil {
 		l.mu.Lock()
@@ -621,16 +638,16 @@ func (l *Loop) scanLocked(collect, carry Include) (next, prev state.Snapshot, ch
 	defer l.commitMu.Unlock()
 
 	next, prev, changed = l.commitScan(commit{
-		subs:      subs,
-		collect:   collect,
-		carry:     carry,
-		health:    wantHealth,
-		startedAt: startedAt,
-		pp:        pp,
-		rows:      rows,
-		groups:    groupRows,
-		sessions:  sessionRows,
-		host:      host,
+		subs:     subs,
+		collect:  collect,
+		carry:    carry,
+		health:   wantHealth,
+		seq:      gen,
+		pp:       pp,
+		rows:     rows,
+		groups:   groupRows,
+		sessions: sessionRows,
+		host:     host,
 	})
 	if changed {
 		l.publish(prev, next, deriveEvents(prev, next, l.nowRFC3339()))
@@ -640,16 +657,17 @@ func (l *Loop) scanLocked(collect, carry Include) (next, prev state.Snapshot, ch
 
 // commit is one finished scan on its way into the cache.
 type commit struct {
-	subs      int
-	collect   Include
-	carry     Include
-	health    bool
-	startedAt time.Time
-	pp        []ports.ListeningPort
-	rows      []state.Port
-	groups    []state.Group
-	sessions  []state.SessionRecord
-	host      state.Host
+	subs    int
+	collect Include
+	carry   Include
+	health  bool
+	// seq is the number this scan took when its OS half began.
+	seq      uint64
+	pp       []ports.ListeningPort
+	rows     []state.Port
+	groups   []state.Group
+	sessions []state.SessionRecord
+	host     state.Host
 }
 
 // commitScan swaps a finished scan into the cache and adapts the interval.
@@ -665,7 +683,7 @@ func (l *Loop) commitScan(c commit) (next, prev state.Snapshot, changed bool) {
 
 	l.scans++
 	l.lastErr = nil
-	if l.haveSnap && c.startedAt.Before(l.lastScanFrom) {
+	if l.haveSnap && c.seq < l.committedSeq {
 		// Superseded. This scan asked the OS what was listening before the
 		// snapshot on the wire was captured, so committing it would put back
 		// ports a newer scan has already seen go — the "no going backwards"
@@ -691,7 +709,7 @@ func (l *Loop) commitScan(c commit) (next, prev state.Snapshot, changed bool) {
 	withStats := c.collect.Stats || c.carry.Stats
 
 	l.lastScanAt = l.now()
-	l.lastScanFrom = c.startedAt
+	l.committedSeq = c.seq
 	l.lastPorts = c.pp
 	if c.health {
 		l.lastHealthAt = l.lastScanAt
@@ -1013,7 +1031,7 @@ func (l *Loop) SnapshotAll(include Include) (state.Snapshot, error) {
 	if snap, ok := l.cached(include); ok {
 		return snap, nil
 	}
-	return l.scanNow(include)
+	return l.scanNow(include, mayCoalesce)
 }
 
 // Rescan scans now whatever the cache says, publishes the change it finds and
@@ -1029,7 +1047,7 @@ func (l *Loop) SnapshotAll(include Include) (state.Snapshot, error) {
 // later. Rescan closes the window by holding scanMu across both halves.
 func (l *Loop) Rescan(include Include) (state.Snapshot, error) {
 	defer l.Wake()
-	snap, err := l.scanNow(include)
+	snap, err := l.scanNow(include, forceScan)
 	return localOnly(snap), err
 }
 
@@ -1138,15 +1156,29 @@ func (l *Loop) localhostRow(hosts []state.Host) state.Host {
 	return l.identityRow()
 }
 
+// scanMode says whether a caller may be given somebody else's scan.
+type scanMode bool
+
+const (
+	// mayCoalesce is the read path. A scan that *began* after this call did
+	// saw everything this caller could have seen, so waiting for the one in
+	// flight and then running a second is pure duplication.
+	mayCoalesce scanMode = false
+	// forceScan is the write and kill path. `ports.kill` and `groups.kill`
+	// resolve their selectors against the scan they ask for (contract §17,
+	// §25) and a write's fallback republish has to see its own change, so
+	// these always scan — never the one that happened to be in flight, and
+	// never the one that finished a moment ago.
+	forceScan scanMode = true
+)
+
 // scanNow is the uncached half of both: one scan under the run gate, published
 // before it returns.
-//
-// A scan that *started* after this call did is already the answer — it saw
-// everything this caller could have seen — so waiting for the one in flight
-// and then running a second is pure duplication. Coalescing onto it is what
-// keeps `ports.kill` to one scan's wait rather than two (contract §44).
-func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
-	asked := l.now()
+func (l *Loop) scanNow(include Include, mode scanMode) (state.Snapshot, error) {
+	// Sampled before the gate: any scan that begins while this call waits
+	// takes a higher number, which is what "began after I asked" means
+	// without consulting a clock.
+	asked := l.scanGeneration()
 	if !lockFor(l.rpcGate, ScanLockBudget) {
 		// Wedged: the last good snapshot beats a reply that never comes.
 		l.opts.Logger.Warn("scanner busy, serving the last snapshot", "waited", ScanLockBudget)
@@ -1154,8 +1186,10 @@ func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
 	}
 	defer unlock(l.rpcGate)
 
-	if snap, ok := l.scannedSince(asked, include); ok {
-		return snap, nil
+	if mode == mayCoalesce {
+		if snap, ok := l.scannedSince(asked, include); ok {
+			return snap, nil
+		}
 	}
 
 	next, prev, _, err := l.scanLocked(include, l.demandInclude())
@@ -1169,17 +1203,41 @@ func (l *Loop) scanNow(include Include) (state.Snapshot, error) {
 	return next, nil
 }
 
-// scannedSince reports the cached snapshot when a scan that began at or after
-// t has already committed one that carries what the caller asked for. Health
-// never coalesces: the probes run on their own cadence, so "a scan happened"
-// says nothing about whether it probed.
-func (l *Loop) scannedSince(t time.Time, include Include) (state.Snapshot, bool) {
+// beginScan numbers a scan as its OS half starts.
+func (l *Loop) beginScan() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.scanSeq++
+	return l.scanSeq
+}
+
+// scanGeneration is the number of the last scan to have begun.
+func (l *Loop) scanGeneration() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.scanSeq
+}
+
+// scannedSince reports the cached snapshot when a scan that began strictly
+// after generation gen has already committed one carrying what the caller
+// asked for.
+//
+// Strictly after, and counted rather than timed: a scan numbered gen is the
+// one that was already running (or had just finished) when the caller asked,
+// and serving its result would be serving state from before the call. That
+// distinction is invisible to `time.Now` on a platform whose clock moves in
+// milliseconds, which is how a kill's rescan came to be skipped on Windows and
+// nowhere else.
+//
+// Health never coalesces either way: the probes run on their own cadence, so
+// "a scan happened" says nothing about whether it probed.
+func (l *Loop) scannedSince(gen uint64, include Include) (state.Snapshot, bool) {
 	if include.Health {
 		return state.Snapshot{}, false
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if !l.haveSnap || l.lastScanFrom.Before(t) {
+	if !l.haveSnap || l.committedSeq <= gen {
 		return state.Snapshot{}, false
 	}
 	if include.Stats && !l.snapHasStats() {


### PR DESCRIPTION
Fixes the v0.6.1 latency regression introduced by 1A.15: the whole scan ran under the ordering lock and RPC scans collected subscriber demand. Now one gate serializes OS scans and another orders attribution, commit and publish; republish re-attributes without scanning; RPC scans carry subscriber stats and health forward; commits are monotonic; every handler-taken gate has a 15 s budget; health rounds and docker calls are bounded. Dry-run kill 5 s to 0.25 s, config.set 5 s to instant, real-daemon e2e 16/16.