### PR TITLE
feat: add sonar doctor and daemon.doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,67 @@ other suggests `sonar start --` when a bare dev server is about to run (it
 advises, it never blocks). Both take `--scope project|user`, `--print` and
 `--uninstall`.
 
+### `sonar doctor`
+
+One command that checks everything sonar depends on and says what to do about
+whatever is wrong. It is what the desktop app runs during onboarding, and what
+to run yourself when something is off.
+
+```sh
+sonar doctor                       # the table, and a one-line verdict
+sonar doctor --json                # {ok, checks, version, daemon_version}
+sonar doctor --only db_ok,tray     # just these
+sonar doctor --only mcp_registered # a whole family
+sonar doctor --project ~/code/api  # a project other than the working directory
+sonar doctor --fix --yes           # apply the safe repairs, then check again
+```
+
+```sh
+# check
+sonar doctor --only daemon_reachable,daemon_protocol,socket_permissions,db_ok
+sonar doctor --json --only config_parses | grep -q '"status": "ok"'
+sonar doctor --only mcp_registered --project . > /dev/null
+```
+
+Every check reports `ok`, `warn`, `fail` or `skip`. `skip` means there was
+nothing to look at — Cursor is not installed, the machine has no docker, the
+socket is a named pipe on Windows — and never counts against you. The exit code
+is 0 unless something **failed**, so `sonar doctor` belongs in a setup script.
+
+| check | what it means |
+| --- | --- |
+| `cli_on_path` | the binary you ran is the one PATH resolves; names the shadowing install if not |
+| `cli_version_current` | compared with the newest release, or `skip` when GitHub is not reachable in 2s |
+| `config_parses` | your `config.yaml` loads; a syntax error is reported with a line, a column and a caret |
+| `config_dir_writable` | the daemon can write its log, lock and database |
+| `daemon_reachable` | something is listening on the socket |
+| `daemon_version_matches` | the running daemon is the version of the CLI you are using |
+| `daemon_protocol` | the daemon's protocol major matches this build's |
+| `socket_permissions` | the socket is yours and 0600, in a 0700 directory (`skip` on Windows) |
+| `db_ok` | the database opens, is at the newest schema, and how big it is |
+| `mcp_registered.{claude_code,cursor,codex}` | sonar's MCP server is in that client's config |
+| `skills_installed` | the bundled skill is installed and current |
+| `hooks_installed` | the optional Claude Code hooks are installed |
+| `project_config` | this project has a `.sonar.yaml` that loads |
+| `docker` | the docker CLI is there and its daemon answers |
+| `tray` | the superseded macOS `sonar-tray` binary is still around |
+
+`--fix` applies only the repairs that are safe to make unattended, and asks
+first unless you pass `--yes`: it moves an unparseable `config.yaml` to
+`config.yaml.broken-<timestamp>` and writes a fresh template (nothing is ever
+deleted), restarts a daemon that is not running, and runs the
+`sonar install mcp|skills|hooks` command the check names — from the working
+directory, the way you would type it, so run `--fix` inside the project you are
+repairing rather than pointing `--project` at it. Then it checks again.
+Anything it will not touch — a shadowing binary on PATH, a skill sonar did not
+write — is left to you with the exact command in the `fix` column.
+
+The desktop app calls the same checks over the daemon's `daemon.doctor` method
+instead of shelling out. The daemon runs everything it can from its own
+process; the three checks that are about the CLI binary you invoked
+(`cli_on_path`, `cli_version_current`, `daemon_version_matches`) come back as
+`skip` with a detail saying so.
+
 ### The desktop app
 
 The Sonar app is the same picture in a window and in the menu bar or system
@@ -740,12 +801,16 @@ daemon: check `docker ps`. A process that ignores SIGTERM needs `-f`, and one
 supervised by something else (systemd, Compose `restart: always`) comes back
 by design — stop the supervisor.
 
-**Reporting a bug.** Include these two, plus the last lines of
-`sonar daemon log`:
+**Nothing works and you are not sure why.** `sonar doctor` checks the binary,
+the config, the daemon, the database and every integration in one go, and
+prints the command that fixes each thing it finds.
+
+**Reporting a bug.** Include these, plus the last lines of `sonar daemon log`:
 
 ```sh
 sonar version
 sonar daemon status
+sonar doctor --json
 # check
 ```
 

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -390,6 +390,49 @@
         "remote_pid"
       ]
     },
+    "DaemonDoctorParams": {
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "only": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "project": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DaemonDoctorResult": {
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/definitions/DoctorCheck"
+          },
+          "type": "array"
+        },
+        "version": {
+          "type": "string"
+        },
+        "daemon_version": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "ok",
+        "checks",
+        "version",
+        "daemon_version"
+      ]
+    },
     "DaemonHelloParams": {
       "properties": {
         "client": {
@@ -562,6 +605,35 @@
         "compose_service",
         "compose_project",
         "container_port"
+      ]
+    },
+    "DoctorCheck": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "fix": {
+          "type": "string"
+        },
+        "fixable": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [
+        "id",
+        "status",
+        "summary",
+        "fixable"
       ]
     },
     "Empty": {
@@ -3789,6 +3861,14 @@
       },
       "result": {
         "$ref": "#/definitions/ConfigSetResult"
+      }
+    },
+    "daemon.doctor": {
+      "params": {
+        "$ref": "#/definitions/DaemonDoctorParams"
+      },
+      "result": {
+        "$ref": "#/definitions/DaemonDoctorResult"
       }
     },
     "daemon.hello": {

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -1,0 +1,380 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/doctor"
+	"github.com/raskrebs/sonar/internal/selfupdate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	doctorJSONFlag    bool
+	doctorFixFlag     bool
+	doctorYesFlag     bool
+	doctorOnlyFlag    []string
+	doctorProjectFlag string
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check that this sonar installation is healthy",
+	Long: "Run every self-check sonar has: the binary on PATH, the config file, the\n" +
+		"daemon and its socket, the database, the MCP/skill/hook integrations, this\n" +
+		"project's " + ".sonar.yaml" + ", docker and the menu bar.\n\n" +
+		"Each check is ok, warn, fail or skip. The exit code is 0 unless something\n" +
+		"failed, so `sonar doctor` works in a script. `--fix` applies the repairs\n" +
+		"that are safe to make unattended and runs the checks again.",
+	Args: cobra.NoArgs,
+	// The report is the output; a failing check must not also print a bare
+	// "Error:" line under the table. Execute() still prints a real error.
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          doctorRun,
+}
+
+func init() {
+	doctorCmd.Flags().BoolVar(&doctorJSONFlag, "json", false, "Output as JSON")
+	doctorCmd.Flags().BoolVar(&doctorFixFlag, "fix", false,
+		"Apply the safe fixes from the working directory, then check again")
+	doctorCmd.Flags().BoolVar(&doctorYesFlag, "yes", false, "Do not ask before applying a fix")
+	doctorCmd.Flags().StringSliceVar(&doctorOnlyFlag, "only", nil,
+		"Run only these checks (comma separated; `mcp_registered` means all of them)")
+	doctorCmd.Flags().StringVar(&doctorProjectFlag, "project", "",
+		"Directory the project checks look at (default: the working directory)")
+	rootCmd.AddCommand(doctorCmd)
+}
+
+func doctorRun(cmd *cobra.Command, _ []string) error {
+	if bad := doctor.UnknownSelectors(doctorOnlyFlag); len(bad) > 0 {
+		return fmt.Errorf("unknown check %s\nknown checks: %s",
+			strings.Join(bad, ", "), strings.Join(doctor.IDs(), ", "))
+	}
+	project, err := doctorProject()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	env := doctorEnv(project)
+	report := doctor.Run(ctx, env, doctorOnlyFlag)
+
+	if doctorFixFlag {
+		applied, err := applyDoctorFixes(ctx, cmd, report)
+		if err != nil {
+			return err
+		}
+		if applied > 0 {
+			report = doctor.Run(ctx, doctorEnv(project), doctorOnlyFlag)
+		}
+	}
+
+	if doctorJSONFlag {
+		out, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+	} else {
+		renderDoctor(os.Stdout, report)
+	}
+	if !report.OK {
+		return errSilent
+	}
+	return nil
+}
+
+func doctorProject() (string, error) {
+	if doctorProjectFlag == "" {
+		return os.Getwd()
+	}
+	abs, err := filepath.Abs(doctorProjectFlag)
+	if err != nil {
+		return "", err
+	}
+	if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+		return "", fmt.Errorf("--project %s is not a directory", doctorProjectFlag)
+	}
+	return abs, nil
+}
+
+// doctorEnv is the CLI's view of the world: the running binary, the network,
+// docker, and a daemon dialled once without ever autostarting one — a
+// diagnosis must report the machine as it found it, not as it left it.
+func doctorEnv(project string) doctor.Env {
+	return doctor.Env{
+		Mode:          doctor.ModeCLI,
+		Version:       selfupdate.Version,
+		Project:       project,
+		Daemon:        doctorDaemonProbe,
+		LatestRelease: doctor.ReleaseProbe,
+		Docker:        doctor.DockerProbe,
+	}
+}
+
+func doctorDaemonProbe(ctx context.Context) doctor.DaemonInfo {
+	socket := daemon.SocketPath()
+	c, err := client.Dial(ctx, client.ClientInfo{Name: "cli", Version: selfupdate.Version})
+	if err != nil {
+		// A daemon speaking another protocol major is running, not absent:
+		// reporting it as unreachable would hide the one check that explains
+		// what is actually wrong.
+		var mismatch *client.ProtocolMismatchError
+		if errors.As(err, &mismatch) {
+			return doctor.DaemonInfo{Reachable: true, ProtocolVersion: mismatch.Daemon, Socket: socket}
+		}
+		return doctor.DaemonInfo{Err: err, Socket: socket}
+	}
+	defer c.Close()
+
+	hello := c.Hello()
+	var status rpc.DaemonStatusResult
+	_ = c.Call(ctx, "daemon.status", rpc.Empty{}, &status)
+	return doctor.DaemonInfo{
+		Reachable:       true,
+		Version:         hello.DaemonVersion,
+		ProtocolVersion: hello.ProtocolVersion,
+		Socket:          hello.Socket,
+		PID:             hello.PID,
+		DBPath:          status.DBPath,
+	}
+}
+
+// ---------------------------------------------------------------- render ---
+
+func renderDoctor(w io.Writer, report rpc.DaemonDoctorResult) {
+	idWidth, summaryWidth := 0, 0
+	for _, c := range report.Checks {
+		if len(c.ID) > idWidth {
+			idWidth = len(c.ID)
+		}
+		if len(c.Summary) > summaryWidth {
+			summaryWidth = len(c.Summary)
+		}
+	}
+
+	counts := map[string]int{}
+	for _, c := range report.Checks {
+		counts[c.Status]++
+		row := fmt.Sprintf("%s  %s  %s", doctorGlyph(c.Status),
+			padRight(c.ID, idWidth), padRight(c.Summary, summaryWidth))
+		if c.Fix != "" && c.Status != doctor.StatusOK && c.Status != doctor.StatusSkip {
+			row += "  " + display.Dim("→ "+c.Fix)
+		}
+		fmt.Fprintln(w, strings.TrimRight(row, " "))
+		// Only a failure earns its evidence in the table: it is the row a
+		// reader has to act on, and config_parses' caret is useless folded
+		// into one line.
+		if c.Status == doctor.StatusFail && c.Detail != "" {
+			for _, line := range strings.Split(c.Detail, "\n") {
+				fmt.Fprintln(w, "   "+display.Dim(line))
+			}
+		}
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, doctorVerdict(report, counts))
+}
+
+func doctorVerdict(report rpc.DaemonDoctorResult, counts map[string]int) string {
+	var parts []string
+	for _, status := range []string{doctor.StatusFail, doctor.StatusWarn, doctor.StatusOK, doctor.StatusSkip} {
+		if n := counts[status]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, status))
+		}
+	}
+	summary := strings.Join(parts, ", ")
+
+	fixable := 0
+	for _, c := range report.Checks {
+		if c.Fixable && (c.Status == doctor.StatusFail || c.Status == doctor.StatusWarn) {
+			fixable++
+		}
+	}
+	hint := ""
+	if fixable > 0 && !doctorFixFlag {
+		hint = display.Dim(fmt.Sprintf("  (`sonar doctor --fix` repairs %d of them)", fixable))
+	}
+
+	switch {
+	case !report.OK:
+		return display.Red("something is wrong: ") + summary + hint
+	case counts[doctor.StatusWarn] > 0:
+		return display.Yellow("mostly healthy: ") + summary + hint
+	default:
+		return display.Green("all good: ") + summary
+	}
+}
+
+// doctorGlyph is a symbol and a word, not one or the other: the symbol is what
+// the eye finds when the terminal has colour, and the word is what survives
+// NO_COLOR, a pipe and a screenshot.
+func doctorGlyph(status string) string {
+	switch status {
+	case doctor.StatusOK:
+		return display.Green("\u2714 ok  ")
+	case doctor.StatusWarn:
+		return display.Yellow("! warn")
+	case doctor.StatusFail:
+		return display.Red("\u2716 FAIL")
+	default:
+		return display.Dim("\u00b7 skip")
+	}
+}
+
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+// ------------------------------------------------------------------- fix ---
+
+// doctorFix is one repair `--fix` may apply. Every one of them is a call the
+// user could have made themselves from the check's own fix hint; nothing here
+// deletes anything, and the broken config is moved aside rather than replaced.
+//
+// The install commands resolve project scope from the working directory, the
+// way they do when a user types them, so `--fix` repairs the project you run it
+// in — not the one `--project` pointed the checks at.
+type doctorFix struct {
+	// id is the check it repairs; a dotted id matches by prefix too.
+	id  string
+	run func(ctx context.Context, cmd *cobra.Command) (string, error)
+}
+
+func doctorFixes() []doctorFix {
+	fixes := []doctorFix{
+		{id: "config_parses", run: fixBrokenConfig},
+		{id: "daemon_reachable", run: func(ctx context.Context, cmd *cobra.Command) (string, error) {
+			if err := daemonRestartRun(cmd, nil); err != nil {
+				return "", err
+			}
+			return "restarted the daemon", nil
+		}},
+		{id: "skills_installed", run: func(ctx context.Context, cmd *cobra.Command) (string, error) {
+			return runInstallSubcommand(cmd, "install", "skills", "--claude-code")
+		}},
+		{id: "hooks_installed", run: func(ctx context.Context, cmd *cobra.Command) (string, error) {
+			return runInstallSubcommand(cmd, "install", "hooks", "--claude-code")
+		}},
+	}
+	for _, client := range []string{"claude-code", "cursor", "codex"} {
+		client := client
+		id := "mcp_registered." + strings.ReplaceAll(client, "-", "_")
+		fixes = append(fixes, doctorFix{id: id, run: func(ctx context.Context, cmd *cobra.Command) (string, error) {
+			return runInstallSubcommand(cmd, "install", "mcp", "--"+client)
+		}})
+	}
+	sort.Slice(fixes, func(i, j int) bool { return fixes[i].id < fixes[j].id })
+	return fixes
+}
+
+// runInstallSubcommand drives the real `sonar install …` command in this
+// process, so a fix is exactly the documented command and never a second
+// implementation of it.
+func runInstallSubcommand(parent *cobra.Command, args ...string) (string, error) {
+	root := parent.Root()
+	target, rest, err := root.Find(args)
+	if err != nil {
+		return "", err
+	}
+	if err := target.ParseFlags(rest); err != nil {
+		return "", err
+	}
+	if err := target.RunE(target, target.Flags().Args()); err != nil {
+		return "", err
+	}
+	return "ran `sonar " + strings.Join(args, " ") + "`", nil
+}
+
+// fixBrokenConfig moves an unparseable config.yaml aside and writes a fresh
+// commented template in its place. The old file is kept: it is the only copy of
+// whatever the user meant to write.
+func fixBrokenConfig(context.Context, *cobra.Command) (string, error) {
+	path := config.Path()
+	stamp := time.Now().UTC().Format("20060102T150405Z")
+	moved := path + doctor.BrokenSuffix + stamp
+	if err := os.Rename(path, moved); err != nil {
+		return "", fmt.Errorf("could not move %s aside: %w", path, err)
+	}
+	if err := config.WriteTemplate(true); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("moved the broken config to %s and wrote a fresh one", moved), nil
+}
+
+// applyDoctorFixes runs every safe fix for a check that is not ok, after
+// confirmation. It returns how many it applied.
+func applyDoctorFixes(ctx context.Context, cmd *cobra.Command, report rpc.DaemonDoctorResult) (int, error) {
+	var todo []doctorFix
+	for _, c := range report.Checks {
+		if !c.Fixable || c.Status == doctor.StatusOK || c.Status == doctor.StatusSkip {
+			continue
+		}
+		for _, f := range doctorFixes() {
+			if f.id == c.ID {
+				todo = append(todo, f)
+			}
+		}
+	}
+	if len(todo) == 0 {
+		fmt.Fprintln(os.Stderr, "nothing to fix automatically")
+		return 0, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "sonar doctor --fix will:\n")
+	for _, f := range todo {
+		fmt.Fprintf(os.Stderr, "  repair %s\n", f.id)
+	}
+	if !doctorYesFlag && !confirmDoctorFix() {
+		fmt.Fprintln(os.Stderr, "nothing was changed")
+		return 0, nil
+	}
+
+	applied := 0
+	for _, f := range todo {
+		what, err := f.run(ctx, cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not repair %s: %v\n", f.id, err)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "%s: %s\n", f.id, what)
+		applied++
+	}
+	fmt.Fprintln(os.Stderr)
+	return applied, nil
+}
+
+// confirmDoctorFix asks once on the terminal. A non-interactive run (a pipe, a
+// CI job) answers no rather than blocking, which is why `--yes` exists.
+func confirmDoctorFix() bool {
+	info, err := os.Stdin.Stat()
+	if err != nil || info.Mode()&os.ModeCharDevice == 0 {
+		fmt.Fprintln(os.Stderr, "stdin is not a terminal; pass --yes to apply these")
+		return false
+	}
+	fmt.Fprint(os.Stderr, "apply? [y/N] ")
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/doctor"
+	"github.com/spf13/cobra"
+)
+
+func sampleReport() rpc.DaemonDoctorResult {
+	return rpc.DaemonDoctorResult{
+		OK:            false,
+		Version:       "v1.2.3",
+		DaemonVersion: "v1.2.3",
+		Checks: []rpc.DoctorCheck{
+			{ID: "cli_on_path", Status: doctor.StatusOK, Summary: "sonar resolves from PATH", Detail: "/usr/local/bin/sonar"},
+			{ID: "cli_version_current", Status: doctor.StatusSkip, Summary: "development build"},
+			{
+				ID: "config_parses", Status: doctor.StatusFail,
+				Summary: "config.yaml does not parse",
+				Detail:  "/home/dev/.config/sonar/config.yaml:1:7: did not find expected ','\n  list: [broken\n        ^",
+				Fix:     "sonar doctor --fix", Fixable: true,
+			},
+			{
+				ID: "hooks_installed", Status: doctor.StatusWarn,
+				Summary: "the sonar hooks are not installed",
+				Fix:     "sonar install hooks --claude-code", Fixable: true,
+			},
+		},
+	}
+}
+
+func TestRenderDoctorTable(t *testing.T) {
+	restore := display.NoColor
+	display.NoColor = true
+	t.Cleanup(func() { display.NoColor = restore })
+
+	var buf bytes.Buffer
+	renderDoctor(&buf, sampleReport())
+	out := buf.String()
+
+	for _, want := range []string{
+		"ok    cli_on_path",
+		"skip  cli_version_current",
+		"FAIL  config_parses",
+		"warn  hooks_installed",
+		// The fix hint rides on the rows that need acting on...
+		"→ sonar install hooks --claude-code",
+		// ...and the evidence is spelled out under a failure.
+		"list: [broken",
+		"^",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table is missing %q:\n%s", want, out)
+		}
+	}
+	// A healthy row must not carry a fix hint or its detail.
+	if strings.Contains(out, "/usr/local/bin/sonar") {
+		t.Errorf("an ok row should not print its detail:\n%s", out)
+	}
+	if !strings.Contains(out, "something is wrong: 1 fail, 1 warn, 1 ok, 1 skip") {
+		t.Errorf("verdict is missing or wrong:\n%s", out)
+	}
+}
+
+func TestRenderDoctorVerdicts(t *testing.T) {
+	restore := display.NoColor
+	display.NoColor = true
+	t.Cleanup(func() { display.NoColor = restore })
+
+	cases := []struct {
+		name   string
+		report rpc.DaemonDoctorResult
+		want   string
+	}{
+		{
+			name: "all ok",
+			report: rpc.DaemonDoctorResult{OK: true, Checks: []rpc.DoctorCheck{
+				{ID: "a", Status: doctor.StatusOK, Summary: "fine"},
+			}},
+			want: "all good: 1 ok",
+		},
+		{
+			name: "warnings only",
+			report: rpc.DaemonDoctorResult{OK: true, Checks: []rpc.DoctorCheck{
+				{ID: "a", Status: doctor.StatusWarn, Summary: "hmm"},
+			}},
+			want: "mostly healthy: 1 warn",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderDoctor(&buf, tc.report)
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("verdict = %q, want it to contain %q", buf.String(), tc.want)
+			}
+		})
+	}
+}
+
+// TestDoctorJSON drives the command itself, so the JSON a script parses is the
+// JSON this test asserts on.
+func TestDoctorJSON(t *testing.T) {
+	withDoctorFlags(t, func() {
+		doctorJSONFlag = true
+		doctorOnlyFlag = []string{"tray", "db_ok"}
+	})
+
+	out := captureStdout(t, func() {
+		if err := doctorRun(testCommand(), nil); err != nil && !errors.Is(err, errSilent) {
+			t.Fatalf("sonar doctor --json: %v", err)
+		}
+	})
+
+	var got rpc.DaemonDoctorResult
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out)
+	}
+	if len(got.Checks) != 2 {
+		t.Fatalf("got %d checks, want the 2 that were selected: %+v", len(got.Checks), got.Checks)
+	}
+	ids := []string{got.Checks[0].ID, got.Checks[1].ID}
+	if ids[0] != "db_ok" || ids[1] != "tray" {
+		t.Errorf("ids = %v, want [db_ok tray] in table order", ids)
+	}
+	for _, c := range got.Checks {
+		switch c.Status {
+		case doctor.StatusOK, doctor.StatusWarn, doctor.StatusFail, doctor.StatusSkip:
+		default:
+			t.Errorf("%s has status %q", c.ID, c.Status)
+		}
+	}
+	if got.Version == "" {
+		t.Error("version is empty")
+	}
+}
+
+// TestDoctorExitsNonZeroOnAFailure pins the contract a script depends on: the
+// command returns errSilent, which Execute turns into exit 1 without printing
+// anything more.
+func TestDoctorExitsNonZeroOnAFailure(t *testing.T) {
+	withDoctorFlags(t, func() {
+		// No daemon runs in an isolated test binary, so this one fails.
+		doctorOnlyFlag = []string{"daemon_reachable"}
+	})
+	err := errors.New("")
+	captureStdout(t, func() { err = doctorRun(testCommand(), nil) })
+	if !errors.Is(err, errSilent) {
+		t.Fatalf("error = %v, want errSilent", err)
+	}
+}
+
+func TestDoctorRejectsAnUnknownCheck(t *testing.T) {
+	withDoctorFlags(t, func() { doctorOnlyFlag = []string{"not_a_check"} })
+	err := doctorRun(testCommand(), nil)
+	if err == nil || !strings.Contains(err.Error(), "not_a_check") {
+		t.Fatalf("error = %v, want it to name the unknown check", err)
+	}
+}
+
+func TestDoctorProjectMustBeADirectory(t *testing.T) {
+	withDoctorFlags(t, func() { doctorProjectFlag = os.DevNull })
+	if _, err := doctorProject(); err == nil {
+		t.Fatal("a --project that is not a directory should be refused")
+	}
+}
+
+// TestEveryFixableCheckHasAFix keeps the two lists in step: a check that
+// advertises Fixable with no entry in doctorFixes would print an offer
+// `--fix` cannot keep.
+func TestEveryFixableCheckHasAFix(t *testing.T) {
+	have := map[string]bool{}
+	for _, f := range doctorFixes() {
+		have[f.id] = true
+	}
+	// The ids the doctor package marks fixable, spelled out here so a new one
+	// has to be considered rather than silently unhandled.
+	for _, id := range []string{
+		"config_parses", "daemon_reachable", "skills_installed", "hooks_installed",
+		"mcp_registered.claude_code", "mcp_registered.cursor", "mcp_registered.codex",
+	} {
+		if !have[id] {
+			t.Errorf("no fix registered for %s", id)
+		}
+	}
+	for _, f := range doctorFixes() {
+		if !contains(doctor.IDs(), f.id) {
+			t.Errorf("fix %s repairs a check that does not exist", f.id)
+		}
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------- helpers ---
+
+// withDoctorFlags sets the command's package-level flags for one test and puts
+// them back afterwards.
+func withDoctorFlags(t *testing.T, set func()) {
+	t.Helper()
+	oldJSON, oldFix, oldYes := doctorJSONFlag, doctorFixFlag, doctorYesFlag
+	oldOnly, oldProject := doctorOnlyFlag, doctorProjectFlag
+	t.Cleanup(func() {
+		doctorJSONFlag, doctorFixFlag, doctorYesFlag = oldJSON, oldFix, oldYes
+		doctorOnlyFlag, doctorProjectFlag = oldOnly, oldProject
+	})
+	doctorJSONFlag, doctorFixFlag, doctorYesFlag = false, false, false
+	doctorOnlyFlag, doctorProjectFlag = nil, ""
+	set()
+}
+
+func testCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}

--- a/internal/daemon/doctor_integration_test.go
+++ b/internal/daemon/doctor_integration_test.go
@@ -1,0 +1,148 @@
+//go:build integration
+
+package daemon_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+)
+
+// doctorEnvironmentChecks are the rows that must come back clean on a machine
+// where sonar itself is set up correctly: the daemon, its socket, its database
+// and the user's config. The integration checks — MCP clients, the skill, the
+// hooks, a project's .sonar.yaml, docker — describe the *user's* machine and
+// are warnings on a fresh temp HOME by design, so they are not asserted here.
+var doctorEnvironmentChecks = []string{
+	"config_parses", "config_dir_writable",
+	"daemon_reachable", "daemon_version_matches", "daemon_protocol",
+	"socket_permissions", "db_ok",
+}
+
+// TestDoctorAgainstARunningDaemon is the step's acceptance demo: `sonar doctor`
+// against a daemon this test started reports every environment check ok and
+// exits 0.
+func TestDoctorAgainstARunningDaemon(t *testing.T) {
+	e := newEnv(t)
+	e.serve()
+
+	out, err := e.command("doctor", "--json",
+		"--only", strings.Join(doctorEnvironmentChecks, ",")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("sonar doctor exited non-zero: %v\n%s", err, out)
+	}
+
+	var report rpc.DaemonDoctorResult
+	if err := json.Unmarshal(out, &report); err != nil {
+		t.Fatalf("sonar doctor --json did not print JSON: %v\n%s", err, out)
+	}
+	if !report.OK {
+		t.Errorf("report is not ok:\n%s", out)
+	}
+	assertHealthy(t, report, doctorEnvironmentChecks)
+	if report.DaemonVersion == "" {
+		t.Error("the report did not name the daemon's version")
+	}
+}
+
+// TestDoctorExitsNonZeroWithNoDaemon is the other half of the exit-code
+// contract: a script can branch on it.
+func TestDoctorExitsNonZeroWithNoDaemon(t *testing.T) {
+	e := newEnv(t)
+	out, err := e.command("doctor", "--only", "daemon_reachable").CombinedOutput()
+	if err == nil {
+		t.Fatalf("sonar doctor exited 0 with no daemon running:\n%s", out)
+	}
+	if !strings.Contains(string(out), "no daemon is listening") {
+		t.Errorf("output does not say what is wrong:\n%s", out)
+	}
+}
+
+// TestDaemonDoctorRPC is what the desktop app calls: the same rows, without
+// shelling out, with the CLI-only ones marked as such.
+func TestDaemonDoctorRPC(t *testing.T) {
+	e := newEnv(t)
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	var report rpc.DaemonDoctorResult
+	if err := c.Call(ctx, "daemon.doctor", rpc.DaemonDoctorParams{
+		Only: append([]string{"cli_on_path"}, doctorEnvironmentChecks...),
+	}, &report); err != nil {
+		t.Fatalf("daemon.doctor: %v", err)
+	}
+	if !report.OK {
+		t.Errorf("daemon.doctor is not ok: %+v", report.Checks)
+	}
+
+	byID := map[string]rpc.DoctorCheck{}
+	for _, c := range report.Checks {
+		byID[c.ID] = c
+	}
+	cli, ok := byID["cli_on_path"]
+	if !ok {
+		t.Fatal("daemon.doctor dropped the cli_on_path row instead of skipping it")
+	}
+	if cli.Status != "skip" || !strings.Contains(cli.Detail, "CLI-only") {
+		t.Errorf("cli_on_path = %+v, want a skip whose detail says it is CLI-only", cli)
+	}
+	// The daemon answers for itself rather than dialling its own socket.
+	if d := byID["daemon_reachable"]; d.Status != "ok" || !strings.Contains(d.Detail, "from the daemon itself") {
+		t.Errorf("daemon_reachable = %+v", d)
+	}
+	assertHealthy(t, report, doctorEnvironmentChecks)
+
+	// Same daemon, because a second one costs a whole process: an unknown id
+	// must be refused rather than silently answered with an empty report.
+	t.Run("an unknown check is refused", func(t *testing.T) {
+		var out rpc.DaemonDoctorResult
+		err := c.Call(ctx, "daemon.doctor", rpc.DaemonDoctorParams{Only: []string{"nope"}}, &out)
+		if err == nil {
+			t.Fatal("an unknown check id was accepted")
+		}
+		if !strings.Contains(err.Error(), "nope") {
+			t.Errorf("error = %v, want it to name the unknown check", err)
+		}
+	})
+
+	// A relative --project would mean the daemon's own working directory,
+	// which is never what the caller meant.
+	t.Run("a relative project is refused", func(t *testing.T) {
+		var out rpc.DaemonDoctorResult
+		if err := c.Call(ctx, "daemon.doctor", rpc.DaemonDoctorParams{Project: "."}, &out); err == nil {
+			t.Fatal("a relative project path was accepted")
+		}
+	})
+}
+
+// assertHealthy fails the test for any of ids that is not ok. A skip is allowed
+// only where the platform genuinely has nothing to look at — Windows has no
+// socket file — and never silently: the check has to say so.
+func assertHealthy(t *testing.T, report rpc.DaemonDoctorResult, ids []string) {
+	t.Helper()
+	byID := map[string]rpc.DoctorCheck{}
+	for _, c := range report.Checks {
+		byID[c.ID] = c
+	}
+	for _, id := range ids {
+		got, ok := byID[id]
+		if !ok {
+			t.Errorf("%s is missing from the report", id)
+			continue
+		}
+		if got.Status == "ok" {
+			continue
+		}
+		if got.Status == "skip" && (id == "socket_permissions" || id == "daemon_version_matches") {
+			continue // no socket file on Windows; no CLI to compare over RPC
+		}
+		t.Errorf("%s = %s (%s / %s), want ok", id, got.Status, got.Summary, got.Detail)
+	}
+}

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -113,6 +113,49 @@ type DaemonSchemaResult struct {
 	Schema json.RawMessage `json:"schema"`
 }
 
+// DoctorCheck is one diagnostic `sonar doctor` and `daemon.doctor` report. It
+// is the single Go type behind the table, the CLI's `--json` and the wire
+// result (contract §17), so a client that renders one renders the other.
+type DoctorCheck struct {
+	// ID names the check. Checks that exist once per external tool are
+	// dotted: `mcp_registered.claude_code`.
+	ID string `json:"id"`
+	// Status is ok, warn, fail or skip. Only `fail` makes the run not ok.
+	Status string `json:"status"`
+	// Summary is the one line a table row shows.
+	Summary string `json:"summary"`
+	// Detail is the evidence: paths, versions, the parse error. It is also
+	// where a check the daemon cannot run from its own process says so.
+	Detail string `json:"detail,omitempty"`
+	// Fix is the human hint: what to run, or what to edit.
+	Fix string `json:"fix,omitempty"`
+	// Fixable says `sonar doctor --fix` can repair this one unattended.
+	Fixable bool `json:"fixable"`
+}
+
+type DaemonDoctorParams struct {
+	HostParams
+	// Only keeps just these checks. An entry matches a check id exactly, or
+	// every check under it when the id is dotted (`mcp_registered`).
+	Only []string `json:"only,omitempty"`
+	// Project is the directory the project-scoped checks look at. Empty means
+	// the process's own working directory, which for the daemon is wherever it
+	// was started, so a client that cares always sends it.
+	Project string `json:"project,omitempty"`
+}
+
+// DaemonDoctorResult is what both `sonar doctor --json` and `daemon.doctor`
+// return. OK is false when any check failed.
+type DaemonDoctorResult struct {
+	OK     bool          `json:"ok"`
+	Checks []DoctorCheck `json:"checks"`
+	// Version is the version of the process that ran the checks: the CLI for
+	// `sonar doctor`, the daemon for `daemon.doctor`.
+	Version string `json:"version"`
+	// DaemonVersion is the daemon's version, empty when it is not reachable.
+	DaemonVersion string `json:"daemon_version"`
+}
+
 // ----------------------------------------------------------------- state ---
 
 type StateSnapshotParams struct {

--- a/internal/daemon/rpc/schema.go
+++ b/internal/daemon/rpc/schema.go
@@ -134,7 +134,7 @@ func namedTypes() []any {
 		state.Snapshot{}, state.Delta{}, state.Event{}, state.Service{},
 		state.Stats{}, state.Health{}, state.Docker{}, state.Run{},
 		state.KillResult{},
-		Error{}, MutationResult{}, KillEnvelope{},
+		Error{}, MutationResult{}, KillEnvelope{}, DoctorCheck{},
 		// The streaming envelopes (contract §1). A client needs the shape of
 		// {id, data} to read any stream at all, so it is a named definition
 		// rather than something every generator re-invents.
@@ -272,6 +272,7 @@ func init() {
 	Describe("daemon.shutdown", Empty{}, OKResult{}, nil, nil)
 	Describe("daemon.status", HostParams{}, DaemonStatusResult{}, nil, nil)
 	Describe("daemon.schema", Empty{}, DaemonSchemaResult{}, nil, nil)
+	Describe("daemon.doctor", DaemonDoctorParams{}, DaemonDoctorResult{}, nil, nil)
 
 	// State.
 	Describe("state.snapshot", StateSnapshotParams{}, state.Snapshot{}, nil, nil)

--- a/internal/doctor/checks_agents.go
+++ b/internal/doctor/checks_agents.go
@@ -1,0 +1,274 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/install"
+)
+
+// The agent integrations are checked by reading exactly the files
+// `sonar install` writes — never by running a client's CLI, which would be slow
+// and, for a tool mid-login, interactive. A tool that is not installed at all
+// is a `skip`: not having Cursor is not a problem with sonar.
+
+// agentConfig is one file that may carry sonar's entry, and how to tell.
+type agentConfig struct {
+	scope string
+	path  string
+	has   func([]byte) bool
+}
+
+// tool is one coding agent sonar can register with.
+type tool struct {
+	id      string
+	label   string
+	client  string // the `sonar install mcp` flag, without the dashes
+	scope   string // the scope that flag defaults to
+	present func(*Env) bool
+	configs func(*Env) []agentConfig
+}
+
+// mcpTools is the table behind the mcp_registered.* checks.
+func mcpTools() []check {
+	var out []check
+	for _, t := range agentTools() {
+		t := t
+		out = append(out, check{
+			id:  "mcp_registered." + t.id,
+			run: func(_ context.Context, env *Env) rpc.DoctorCheck { return checkMCPRegistered(env, t) },
+		})
+	}
+	return out
+}
+
+func agentTools() []tool {
+	return []tool{
+		{
+			id: "claude_code", label: "Claude Code", client: "claude-code", scope: "project",
+			present: func(env *Env) bool {
+				return onPATH(env, "claude") ||
+					exists(env.homePath(".claude")) ||
+					exists(env.homePath(".claude.json"))
+			},
+			configs: func(env *Env) []agentConfig {
+				var cc []agentConfig
+				if root := gitRootOf(env.Project); root != "" {
+					cc = append(cc, agentConfig{scope: "project", path: filepath.Join(root, ".mcp.json"), has: hasJSONServer})
+				}
+				// `sonar install mcp --claude-code --scope user` drives
+				// `claude mcp add`, which writes this file. Sonar never edits
+				// it, but reading it is how doctor sees a user-scope install.
+				if p := env.homePath(".claude.json"); p != "" {
+					cc = append(cc, agentConfig{scope: "user", path: p, has: hasJSONServer})
+				}
+				return cc
+			},
+		},
+		{
+			id: "cursor", label: "Cursor", client: "cursor", scope: "project",
+			present: func(env *Env) bool {
+				return onPATH(env, "cursor") || exists(env.homePath(".cursor"))
+			},
+			configs: func(env *Env) []agentConfig {
+				var cc []agentConfig
+				if root := gitRootOf(env.Project); root != "" {
+					cc = append(cc, agentConfig{scope: "project", path: filepath.Join(root, ".cursor", "mcp.json"), has: hasJSONServer})
+				}
+				if p := env.homePath(".cursor", "mcp.json"); p != "" {
+					cc = append(cc, agentConfig{scope: "user", path: p, has: hasJSONServer})
+				}
+				return cc
+			},
+		},
+		{
+			id: "codex", label: "Codex", client: "codex", scope: "user",
+			present: func(env *Env) bool {
+				return onPATH(env, "codex") || exists(env.homePath(".codex"))
+			},
+			configs: func(env *Env) []agentConfig {
+				p := env.homePath(".codex", "config.toml")
+				if p == "" {
+					return nil
+				}
+				return []agentConfig{{scope: "user", path: p, has: hasTOMLServer}}
+			},
+		},
+	}
+}
+
+func checkMCPRegistered(env *Env, t tool) rpc.DoctorCheck {
+	if !t.present(env) {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: t.label + " is not installed",
+			Detail:  "nothing to register sonar with on this machine",
+		}
+	}
+	var looked []string
+	for _, cfg := range t.configs(env) {
+		looked = append(looked, cfg.path)
+		data, err := os.ReadFile(cfg.path)
+		if err != nil {
+			continue
+		}
+		if cfg.has(data) {
+			return rpc.DoctorCheck{
+				Status:  StatusOK,
+				Summary: fmt.Sprintf("registered with %s (%s scope)", t.label, cfg.scope),
+				Detail:  cfg.path,
+			}
+		}
+	}
+	fix := fmt.Sprintf("sonar install mcp --%s", t.client)
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: "not registered with " + t.label,
+		Detail:  "no sonar entry in " + strings.Join(looked, " or "),
+		Fix:     fix,
+		Fixable: true,
+	}
+}
+
+// hasJSONServer reports whether an MCP client config carries sonar's server
+// entry. Only the key matters: a user who edited the command or added args
+// still has a working registration.
+func hasJSONServer(data []byte) bool {
+	var root struct {
+		Servers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false
+	}
+	_, ok := root.Servers["sonar"]
+	return ok
+}
+
+// hasTOMLServer looks for codex's `[mcp_servers.sonar]` table header. Sonar has
+// no TOML parser and needs none: the header is the whole question, and
+// `codex mcp add` writes it on a line of its own.
+var codexTable = regexp.MustCompile(`(?m)^\s*\[mcp_servers\.(sonar|"sonar")\]\s*$`)
+
+func hasTOMLServer(data []byte) bool { return codexTable.Match(data) }
+
+func onPATH(env *Env, name string) bool {
+	_, err := env.LookPath(name)
+	return err == nil
+}
+
+// claudeCode is the tool the skill and the hooks belong to; both `sonar install
+// skills` and `sonar install hooks` support Claude Code only.
+func claudeCode() tool { return agentTools()[0] }
+
+func checkSkillsInstalled(_ context.Context, env *Env) rpc.DoctorCheck {
+	cc := claudeCode()
+	if !cc.present(env) {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: cc.label + " is not installed",
+			Detail:  "the bundled skill has nowhere to go",
+		}
+	}
+	root := gitRootOf(env.Project)
+	want := install.SkillContent()
+
+	var looked []string
+	for _, scope := range []struct {
+		name string
+		s    install.Scope
+	}{{"user", install.ScopeUser}, {"project", install.ScopeProject}} {
+		if scope.s == install.ScopeProject && root == "" {
+			continue
+		}
+		path := install.SkillPath(scope.s, env.Home, root)
+		looked = append(looked, path)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		switch {
+		case string(data) == want:
+			return rpc.DoctorCheck{
+				Status:  StatusOK,
+				Summary: fmt.Sprintf("skill installed (%s scope)", scope.name),
+				Detail:  path,
+			}
+		case install.IsManaged(string(data)):
+			return rpc.DoctorCheck{
+				Status:  StatusWarn,
+				Summary: "the installed skill is out of date",
+				Detail:  path + " was written by an older sonar",
+				Fix:     "sonar install skills --claude-code",
+				Fixable: true,
+			}
+		default:
+			return rpc.DoctorCheck{
+				Status:  StatusWarn,
+				Summary: "a skill sonar did not write is in the way",
+				Detail:  path + " exists and carries no sonar marker",
+				Fix:     "sonar install skills --claude-code --force (this overwrites it)",
+			}
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: "the sonar skill is not installed",
+		Detail:  "no skill at " + strings.Join(looked, " or "),
+		Fix:     "sonar install skills --claude-code",
+		Fixable: true,
+	}
+}
+
+func checkHooksInstalled(_ context.Context, env *Env) rpc.DoctorCheck {
+	cc := claudeCode()
+	if !cc.present(env) {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: cc.label + " is not installed",
+			Detail:  "there are no settings to add hooks to",
+		}
+	}
+	root := gitRootOf(env.Project)
+
+	var looked []string
+	for _, scope := range []struct {
+		name string
+		s    install.Scope
+	}{{"project", install.ScopeProject}, {"user", install.ScopeUser}} {
+		if scope.s == install.ScopeProject && root == "" {
+			continue
+		}
+		path := install.SettingsPath(scope.s, env.Home, root)
+		looked = append(looked, path)
+		n, err := install.InstalledHooks(path)
+		if err != nil {
+			return rpc.DoctorCheck{
+				Status:  StatusWarn,
+				Summary: "cannot read the Claude Code settings",
+				Detail:  err.Error(),
+				Fix:     "fix the JSON in " + path,
+			}
+		}
+		if n > 0 {
+			return rpc.DoctorCheck{
+				Status:  StatusOK,
+				Summary: fmt.Sprintf("%d sonar %s installed (%s scope)", n, plural(n, "hook"), scope.name),
+				Detail:  path,
+			}
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: "the sonar hooks are not installed",
+		Detail: "no _sonar entries in " + strings.Join(looked, " or ") +
+			"; the hooks are optional — they attribute a session's processes and suggest `sonar start --`",
+		Fix:     "sonar install hooks --claude-code",
+		Fixable: true,
+	}
+}

--- a/internal/doctor/checks_cli.go
+++ b/internal/doctor/checks_cli.go
@@ -1,0 +1,112 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/selfupdate"
+)
+
+// checkCLIOnPath answers "is the sonar I just ran the sonar PATH would find?".
+// A second install earlier on PATH is the single most confusing thing a user
+// can have: every hint the CLI prints then names a binary they are not running.
+func checkCLIOnPath(_ context.Context, env *Env) rpc.DoctorCheck {
+	exe, err := env.Executable()
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: "could not resolve the running binary",
+			Detail:  err.Error(),
+		}
+	}
+	exe = resolveLinks(exe)
+
+	onPath, err := env.LookPath(binaryName(env.GOOS))
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "sonar is not on PATH",
+			Detail:  fmt.Sprintf("running %s, but PATH has no sonar: %v", exe, err),
+			Fix: fmt.Sprintf("put %s on PATH (add %s to it, or reinstall with the script in the README)",
+				binaryName(env.GOOS), filepath.Dir(exe)),
+		}
+	}
+	onPath = resolveLinks(onPath)
+
+	if samePath(env.GOOS, exe, onPath) {
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: "sonar resolves from PATH",
+			Detail:  onPath,
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: "another sonar is first on PATH",
+		Detail:  fmt.Sprintf("PATH resolves sonar to %s; you are running %s", onPath, exe),
+		Fix: fmt.Sprintf("remove %s, or put %s earlier on PATH",
+			onPath, filepath.Dir(exe)),
+	}
+}
+
+// checkCLIVersionCurrent compares this build with the newest published release.
+// It never fails: a pinned old version and a machine with no network are both
+// deliberate states, so the worst it reports is a warning.
+func checkCLIVersionCurrent(ctx context.Context, env *Env) rpc.DoctorCheck {
+	if v := strings.TrimSpace(env.Version); v == "" || v == "dev" {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "development build",
+			Detail:  "a binary built from source has no release to compare against",
+		}
+	}
+	latest, err := env.LatestRelease(ctx)
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "could not reach the release feed",
+			Detail:  err.Error(),
+		}
+	}
+	if selfupdate.IsNewer(env.Version, latest) {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: fmt.Sprintf("%s is behind %s", env.Version, latest),
+			Detail:  fmt.Sprintf("the newest published release is %s", latest),
+			Fix:     "sonar update",
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusOK,
+		Summary: fmt.Sprintf("%s is current", env.Version),
+		Detail:  fmt.Sprintf("newest published release: %s", latest),
+	}
+}
+
+func binaryName(goos string) string {
+	if goos == "windows" {
+		return "sonar.exe"
+	}
+	return "sonar"
+}
+
+// resolveLinks follows symlinks when it can and returns the input otherwise:
+// two spellings of one file must compare equal, but a path that cannot be
+// resolved is still worth printing.
+func resolveLinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}
+
+// samePath compares two resolved paths with the platform's case rules.
+func samePath(goos, a, b string) bool {
+	if goos == "windows" || goos == "darwin" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}

--- a/internal/doctor/checks_config.go
+++ b/internal/doctor/checks_config.go
@@ -1,0 +1,192 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"gopkg.in/yaml.v3"
+)
+
+// BrokenSuffix is how `sonar doctor --fix` names the file it moves aside:
+// config.yaml.broken-20260906T121314Z. Nothing is ever deleted.
+const BrokenSuffix = ".broken-"
+
+// checkConfigParses reads the user's own config.yaml. A file that does not
+// parse is the one failure here that silently changes what every other command
+// does — config.Load drops the whole file on a syntax error and carries on with
+// defaults — so it fails loudly and points at the exact bracket.
+func checkConfigParses(_ context.Context, env *Env) rpc.DoctorCheck {
+	path := env.ConfigPath
+	if path == "" {
+		return rpc.DoctorCheck{Status: StatusSkip, Summary: "no config path resolved"}
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: "no config file, defaults apply",
+			Detail:  path + " does not exist, which is a valid state",
+			Fix:     "sonar config init writes a commented starter file",
+		}
+	}
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "cannot read the config file",
+			Detail:  err.Error(),
+		}
+	}
+
+	src := string(data)
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		pos := parsePosition(src, err)
+		where := path
+		if pos.Line > 0 {
+			where = fmt.Sprintf("%s:%d:%d", path, pos.Line, pos.Col)
+		}
+		detail := fmt.Sprintf("%s: %s", where, yamlMessage(err))
+		if marked := caret(src, pos); marked != "" {
+			detail += "\n" + marked
+		}
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "config.yaml does not parse",
+			Detail:  detail,
+			Fix: fmt.Sprintf("fix %s, or run `sonar doctor --fix` to move it to %s%s<timestamp> and write a fresh template",
+				path, filepath.Base(path), BrokenSuffix),
+			Fixable: true,
+		}
+	}
+
+	var cfg config.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: "config.yaml parses but some settings have the wrong type",
+			Detail:  fmt.Sprintf("%s: %v", path, err),
+			Fix:     "sonar config edit",
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusOK,
+		Summary: "config.yaml parses",
+		Detail:  path,
+	}
+}
+
+func checkConfigDirWritable(_ context.Context, env *Env) rpc.DoctorCheck {
+	dir := env.ConfigDir
+	if dir == "" {
+		return rpc.DoctorCheck{Status: StatusSkip, Summary: "no config directory resolved"}
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "cannot create the config directory",
+			Detail:  fmt.Sprintf("%s: %v", dir, err),
+			Fix:     "create it yourself, or point HOME somewhere writable",
+		}
+	}
+	probe, err := os.CreateTemp(dir, ".doctor-*")
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "config directory is not writable",
+			Detail:  fmt.Sprintf("%s: %v", dir, err),
+			Fix:     fmt.Sprintf("chmod u+w %s (the daemon writes its log, lock and database here)", dir),
+		}
+	}
+	name := probe.Name()
+	probe.Close()
+	os.Remove(name)
+	return rpc.DoctorCheck{
+		Status:  StatusOK,
+		Summary: "config directory is writable",
+		Detail:  dir,
+	}
+}
+
+// checkProjectConfig looks for this project's `.sonar.yaml`, in the directory
+// the caller named and then at the git root above it — the two places every
+// other command looks.
+func checkProjectConfig(_ context.Context, env *Env) rpc.DoctorCheck {
+	dir := env.Project
+	if dir == "" {
+		return rpc.DoctorCheck{Status: StatusSkip, Summary: "no project directory"}
+	}
+	root := gitRootOf(dir)
+
+	var looked []string
+	for _, base := range []string{dir, root} {
+		if base == "" {
+			continue
+		}
+		for _, name := range []string{groups.ConfigName, ".sonar.yml"} {
+			candidate := filepath.Join(base, name)
+			looked = append(looked, candidate)
+			if !exists(candidate) {
+				continue
+			}
+			return projectConfigResult(candidate)
+		}
+		if root == dir {
+			break
+		}
+	}
+
+	detail := "looked at " + strings.Join(dedupe(looked), ", ")
+	if root == "" {
+		detail += fmt.Sprintf("\n%s is not inside a git repository, so there is no repository root to look at either", dir)
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: "no " + groups.ConfigName + " for this project",
+		Detail:  detail,
+		Fix:     "sonar init writes one from what is listening right now",
+	}
+}
+
+func projectConfigResult(path string) rpc.DoctorCheck {
+	cfg, err := groups.Load(path)
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: filepath.Base(path) + " does not load",
+			Detail:  err.Error(),
+			Fix:     "edit " + path,
+		}
+	}
+	return rpc.DoctorCheck{
+		Status: StatusOK,
+		Summary: fmt.Sprintf("group %q, %d %s", cfg.Name, len(cfg.Services),
+			plural(len(cfg.Services), "service")),
+		Detail: path,
+	}
+}
+
+func plural(n int, word string) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/doctor/checks_daemon.go
+++ b/internal/doctor/checks_daemon.go
@@ -1,0 +1,179 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+func checkDaemonReachable(ctx context.Context, env *Env) rpc.DoctorCheck {
+	info := env.Daemon(ctx)
+	switch {
+	case info.Local:
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: "the daemon is running",
+			Detail:  fmt.Sprintf("this answer came from the daemon itself (pid %d, %s)", info.PID, info.Socket),
+		}
+	case info.Reachable:
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: "the daemon is listening",
+			Detail:  fmt.Sprintf("pid %d on %s", info.PID, info.Socket),
+		}
+	}
+	detail := env.SocketPath
+	if info.Err != nil {
+		detail = fmt.Sprintf("%s: %v", env.SocketPath, info.Err)
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusFail,
+		Summary: "no daemon is listening",
+		Detail:  detail,
+		Fix:     "sonar serve --detach",
+		Fixable: true,
+	}
+}
+
+func checkDaemonVersionMatches(ctx context.Context, env *Env) rpc.DoctorCheck {
+	info := env.Daemon(ctx)
+	if !info.Reachable {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "no daemon to compare against",
+			Detail:  "start the daemon and run doctor again",
+		}
+	}
+	if info.Version == env.Version {
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: fmt.Sprintf("daemon and CLI are both %s", env.Version),
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: fmt.Sprintf("daemon is %s, CLI is %s", info.Version, env.Version),
+		Detail: "an old daemon keeps serving whoever started it; restarting it " +
+			"adopts the version of the binary you are running now",
+		Fix: "sonar daemon restart",
+	}
+}
+
+func checkDaemonProtocol(ctx context.Context, env *Env) rpc.DoctorCheck {
+	info := env.Daemon(ctx)
+	if !info.Reachable {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "no daemon to handshake with",
+			Detail:  "start the daemon and run doctor again",
+		}
+	}
+	got, gotErr := protocolMajor(info.ProtocolVersion)
+	want, wantErr := protocolMajor(rpc.ProtocolVersion)
+	if gotErr != nil || wantErr != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "unreadable protocol version",
+			Detail:  fmt.Sprintf("daemon reported %q, this build speaks %q", info.ProtocolVersion, rpc.ProtocolVersion),
+			Fix:     "sonar daemon restart",
+		}
+	}
+	if got != want {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: fmt.Sprintf("protocol major %d, this build speaks %d", got, want),
+			Detail: fmt.Sprintf("daemon protocol %s, client protocol %s; only the major has to match",
+				info.ProtocolVersion, rpc.ProtocolVersion),
+			Fix: "sonar daemon restart",
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusOK,
+		Summary: fmt.Sprintf("protocol %s", info.ProtocolVersion),
+		Detail:  fmt.Sprintf("this build speaks %s; majors match", rpc.ProtocolVersion),
+	}
+}
+
+func protocolMajor(v string) (int, error) {
+	head, _, _ := strings.Cut(strings.TrimPrefix(strings.TrimSpace(v), "v"), ".")
+	return strconv.Atoi(head)
+}
+
+// checkDBOK opens the database the daemon uses and reports its schema version
+// and size. It does not create one: a machine whose daemon has never run has
+// no database yet, which is normal rather than broken.
+func checkDBOK(_ context.Context, env *Env) rpc.DoctorCheck {
+	path := env.DBPath
+	if path == "" {
+		return rpc.DoctorCheck{Status: StatusSkip, Summary: "no database path resolved"}
+	}
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: "no database yet",
+			Detail:  path + " is created the first time the daemon runs",
+			Fix:     "sonar serve --detach",
+		}
+	}
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "cannot stat the database",
+			Detail:  err.Error(),
+		}
+	}
+
+	db, err := store.Open(path)
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "cannot open the database",
+			Detail:  fmt.Sprintf("%s: %v", path, err),
+			Fix:     "move it aside and let the daemon recreate it: mv " + path + " " + path + ".bad",
+		}
+	}
+	defer db.Close()
+
+	version, err := db.Version()
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "cannot read the schema version",
+			Detail:  fmt.Sprintf("%s: %v", path, err),
+		}
+	}
+	latest := store.LatestVersion()
+	size := humanBytes(info.Size())
+	if version != latest {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: fmt.Sprintf("schema v%d, this build expects v%d", version, latest),
+			Detail:  fmt.Sprintf("%s (%s)", path, size),
+			Fix:     "sonar daemon restart — the daemon migrates on open",
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusOK,
+		Summary: fmt.Sprintf("schema v%d, %s", version, size),
+		Detail:  path,
+	}
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit && exp < 3; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/internal/doctor/checks_extras.go
+++ b/internal/doctor/checks_extras.go
@@ -1,0 +1,65 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/tray"
+)
+
+// checkDocker is about enrichment, never about health: sonar works fine with no
+// docker on the machine. The one thing worth reporting is the confusing case —
+// the CLI is installed but its daemon is not answering, so container names and
+// images are silently missing from every listing.
+func checkDocker(ctx context.Context, env *Env) rpc.DoctorCheck {
+	path, err := env.LookPath("docker")
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "docker is not installed",
+			Detail:  "container names, images and compose projects are not enriched",
+		}
+	}
+	version, err := env.Docker(ctx)
+	if err != nil {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: "docker is installed but not responding",
+			Detail:  fmt.Sprintf("%s: %v", path, err),
+			Fix:     "start Docker Desktop (or the docker service); until then container rows are unenriched",
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusOK,
+		Summary: "docker is responding",
+		Detail:  fmt.Sprintf("%s, server %s", path, version),
+	}
+}
+
+// checkTray looks for the legacy macOS menu bar binary. It is not broken, but
+// it is superseded: `sonar tray` prefers the desktop app wherever both are
+// installed, so a leftover sonar-tray is a thing to remove, not to launch.
+func checkTray(_ context.Context, env *Env) rpc.DoctorCheck {
+	if env.GOOS != "darwin" {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "macOS only",
+			Detail:  "the legacy Swift menu bar binary only ever shipped for macOS",
+		}
+	}
+	path, ok := tray.LegacyTray()
+	if !ok {
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: "no legacy menu bar binary",
+			Detail:  "`sonar tray` launches the desktop app",
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: "the legacy sonar-tray is still installed",
+		Detail:  path + " predates the desktop app, which replaces it",
+		Fix:     "rm " + path + " — `sonar tray` then launches the desktop app",
+	}
+}

--- a/internal/doctor/checks_socket.go
+++ b/internal/doctor/checks_socket.go
@@ -1,0 +1,86 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+)
+
+// checkSocketPermissions is contract §21 read back off the disk: the socket
+// must be a same-user-only file, and the directory sonar makes for it must be
+// 0700. Windows has neither — the pipe's ACL is applied at bind time and there
+// is no file to stat — so the check skips rather than inventing an equivalent.
+func checkSocketPermissions(ctx context.Context, env *Env) rpc.DoctorCheck {
+	socket := env.SocketPath
+	if env.GOOS == "windows" || strings.HasPrefix(socket, `\\`) {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "named pipe, not a file",
+			Detail: "on Windows the daemon listens on " + daemon.WindowsPipe +
+				", whose DACL grants only this user and SYSTEM when it is bound; there are no file modes to check",
+		}
+	}
+	if socket == "" {
+		return rpc.DoctorCheck{Status: StatusSkip, Summary: "no socket path resolved"}
+	}
+
+	info, err := os.Stat(socket)
+	if os.IsNotExist(err) {
+		if env.Daemon(ctx).Reachable {
+			return rpc.DoctorCheck{
+				Status:  StatusFail,
+				Summary: "the daemon answers but its socket is gone",
+				Detail:  socket + " does not exist",
+				Fix:     "sonar daemon restart",
+			}
+		}
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "no socket to check",
+			Detail:  socket + " appears when the daemon starts",
+		}
+	}
+	if err != nil {
+		return rpc.DoctorCheck{Status: StatusFail, Summary: "cannot stat the socket", Detail: err.Error()}
+	}
+
+	var problems []string
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		problems = append(problems, fmt.Sprintf("mode is %04o, want 0600", mode))
+	}
+	if uid, ok := fileOwner(info); ok && env.UID >= 0 && uid != env.UID {
+		problems = append(problems, fmt.Sprintf("owned by uid %d, you are uid %d", uid, env.UID))
+	}
+
+	dir := filepath.Dir(socket)
+	dirNote := ""
+	if daemon.OwnsSocketDir(socket) {
+		if dirInfo, err := os.Stat(dir); err == nil {
+			if dirMode := dirInfo.Mode().Perm(); dirMode&0o077 != 0 {
+				problems = append(problems, fmt.Sprintf("%s is %04o, want 0700", dir, dirMode))
+			} else {
+				dirNote = fmt.Sprintf(", %s is %04o", dir, dirMode)
+			}
+		}
+	}
+
+	if len(problems) > 0 {
+		return rpc.DoctorCheck{
+			Status:  StatusFail,
+			Summary: "the socket is reachable by other users",
+			Detail:  fmt.Sprintf("%s: %s", socket, strings.Join(problems, "; ")),
+			Fix:     fmt.Sprintf("chmod 700 %s && chmod 600 %s", dir, socket),
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusOK,
+		Summary: fmt.Sprintf("socket is %04o and yours", mode),
+		Detail:  socket + dirNote,
+	}
+}

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1,0 +1,518 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/install"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// --------------------------------------------------------------- the CLI ---
+
+func TestCLIOnPath(t *testing.T) {
+	t.Run("resolves to the running binary", func(t *testing.T) {
+		env := fakeEnv(t)
+		self := write(t, filepath.Join(t.TempDir(), "sonar"), "#!/bin/sh\n")
+		env.Executable = func() (string, error) { return self, nil }
+		env.LookPath = func(string) (string, error) { return self, nil }
+		got := run(t, env, checkCLIOnPath)
+		wantStatus(t, got, StatusOK)
+	})
+
+	t.Run("another sonar shadows this one", func(t *testing.T) {
+		env := fakeEnv(t)
+		dir := t.TempDir()
+		self := write(t, filepath.Join(dir, "mine", "sonar"), "#!/bin/sh\n")
+		other := write(t, filepath.Join(dir, "theirs", "sonar"), "#!/bin/sh\n")
+		env.Executable = func() (string, error) { return self, nil }
+		env.LookPath = func(string) (string, error) { return other, nil }
+
+		got := run(t, env, checkCLIOnPath)
+		wantStatus(t, got, StatusWarn)
+		if !strings.Contains(got.Detail, other) || !strings.Contains(got.Detail, self) {
+			t.Errorf("detail = %q, want it to name both binaries", got.Detail)
+		}
+	})
+
+	t.Run("nothing on PATH at all", func(t *testing.T) {
+		env := fakeEnv(t)
+		got := run(t, env, checkCLIOnPath)
+		wantStatus(t, got, StatusFail)
+	})
+}
+
+func TestCLIVersionCurrent(t *testing.T) {
+	t.Run("a dev build has nothing to compare", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Version = "dev"
+		wantStatus(t, run(t, env, checkCLIVersionCurrent), StatusSkip)
+	})
+
+	t.Run("an unreachable feed skips rather than fails", func(t *testing.T) {
+		env := fakeEnv(t)
+		wantStatus(t, run(t, env, checkCLIVersionCurrent), StatusSkip)
+	})
+
+	t.Run("behind the latest release", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.LatestRelease = func(context.Context) (string, error) { return "v9.0.0", nil }
+		got := run(t, env, checkCLIVersionCurrent)
+		wantStatus(t, got, StatusWarn)
+		if got.Fix != "sonar update" {
+			t.Errorf("fix = %q", got.Fix)
+		}
+	})
+
+	t.Run("current", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.LatestRelease = func(context.Context) (string, error) { return "v1.2.3", nil }
+		wantStatus(t, run(t, env, checkCLIVersionCurrent), StatusOK)
+	})
+}
+
+// ---------------------------------------------------------------- config ---
+
+func TestConfigParses(t *testing.T) {
+	t.Run("no file is a valid state", func(t *testing.T) {
+		wantStatus(t, run(t, fakeEnv(t), checkConfigParses), StatusOK)
+	})
+
+	t.Run("a broken file fails with a position and a caret", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, env.ConfigPath, "list: [broken")
+		got := run(t, env, checkConfigParses)
+		wantStatus(t, got, StatusFail)
+		if !got.Fixable {
+			t.Error("a broken config is the fix --fix exists for")
+		}
+		if !strings.Contains(got.Detail, env.ConfigPath+":1:7") {
+			t.Errorf("detail = %q, want it to carry <path>:1:7", got.Detail)
+		}
+		if !strings.Contains(got.Detail, "^") {
+			t.Errorf("detail = %q, want a caret under the column", got.Detail)
+		}
+	})
+
+	t.Run("a valid file parses", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, env.ConfigPath, "list:\n  sort: port\n")
+		wantStatus(t, run(t, env, checkConfigParses), StatusOK)
+	})
+
+	t.Run("a well-formed file with the wrong types only warns", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, env.ConfigPath, "list:\n  columns: 3\n")
+		wantStatus(t, run(t, env, checkConfigParses), StatusWarn)
+	})
+}
+
+func TestConfigDirWritable(t *testing.T) {
+	t.Run("a writable directory", func(t *testing.T) {
+		env := fakeEnv(t)
+		got := run(t, env, checkConfigDirWritable)
+		wantStatus(t, got, StatusOK)
+		if _, err := os.Stat(env.ConfigDir); err != nil {
+			t.Errorf("the check should have created %s: %v", env.ConfigDir, err)
+		}
+	})
+
+	t.Run("a read-only directory fails", func(t *testing.T) {
+		if runtime.GOOS == "windows" || os.Getuid() == 0 {
+			t.Skip("file modes do not stop this user from writing")
+		}
+		env := fakeEnv(t)
+		if err := os.MkdirAll(env.ConfigDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(env.ConfigDir, 0o500); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(env.ConfigDir, 0o700) })
+		wantStatus(t, run(t, env, checkConfigDirWritable), StatusFail)
+	})
+}
+
+func TestProjectConfig(t *testing.T) {
+	t.Run("absent warns and points at sonar init", func(t *testing.T) {
+		env := fakeEnv(t)
+		got := run(t, env, checkProjectConfig)
+		wantStatus(t, got, StatusWarn)
+		if !strings.Contains(got.Fix, "sonar init") {
+			t.Errorf("fix = %q", got.Fix)
+		}
+	})
+
+	t.Run("present and valid", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, filepath.Join(env.Project, ".sonar.yaml"),
+			"name: demo\nservices:\n  - name: api\n    port: 3000\n")
+		got := run(t, env, checkProjectConfig)
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Summary, "demo") || !strings.Contains(got.Summary, "1 service") {
+			t.Errorf("summary = %q, want the group name and the service count", got.Summary)
+		}
+	})
+
+	t.Run("present and invalid fails", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, filepath.Join(env.Project, ".sonar.yaml"), "name: demo\nservices: [broken")
+		wantStatus(t, run(t, env, checkProjectConfig), StatusFail)
+	})
+}
+
+// ---------------------------------------------------------------- daemon ---
+
+func aliveDaemon() DaemonInfo {
+	return DaemonInfo{
+		Reachable:       true,
+		Version:         "v1.2.3",
+		ProtocolVersion: rpc.ProtocolVersion,
+		Socket:          "/tmp/sonar.sock",
+		PID:             4242,
+	}
+}
+
+func TestDaemonReachable(t *testing.T) {
+	t.Run("no daemon fails and is fixable", func(t *testing.T) {
+		got := run(t, fakeEnv(t), checkDaemonReachable)
+		wantStatus(t, got, StatusFail)
+		if !got.Fixable {
+			t.Error("a stopped daemon is exactly what --fix restarts")
+		}
+	})
+
+	t.Run("a listening daemon", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo { return aliveDaemon() }
+		got := run(t, env, checkDaemonReachable)
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Detail, "4242") {
+			t.Errorf("detail = %q, want the pid", got.Detail)
+		}
+	})
+
+	t.Run("answered from inside the daemon", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo {
+			d := aliveDaemon()
+			d.Local = true
+			return d
+		}
+		wantStatus(t, run(t, env, checkDaemonReachable), StatusOK)
+	})
+}
+
+func TestDaemonVersionMatches(t *testing.T) {
+	t.Run("no daemon skips", func(t *testing.T) {
+		wantStatus(t, run(t, fakeEnv(t), checkDaemonVersionMatches), StatusSkip)
+	})
+
+	t.Run("same version", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo { return aliveDaemon() }
+		wantStatus(t, run(t, env, checkDaemonVersionMatches), StatusOK)
+	})
+
+	t.Run("a stale daemon warns and names the restart", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo {
+			d := aliveDaemon()
+			d.Version = "v0.9.0"
+			return d
+		}
+		got := run(t, env, checkDaemonVersionMatches)
+		wantStatus(t, got, StatusWarn)
+		if !strings.Contains(got.Summary, "v0.9.0") || !strings.Contains(got.Summary, "v1.2.3") {
+			t.Errorf("summary = %q, want both versions", got.Summary)
+		}
+		if got.Fix != "sonar daemon restart" {
+			t.Errorf("fix = %q", got.Fix)
+		}
+	})
+}
+
+func TestDaemonProtocol(t *testing.T) {
+	t.Run("matching majors", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo { return aliveDaemon() }
+		wantStatus(t, run(t, env, checkDaemonProtocol), StatusOK)
+	})
+
+	t.Run("a newer minor still matches", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo {
+			d := aliveDaemon()
+			major, _ := protocolMajor(rpc.ProtocolVersion)
+			d.ProtocolVersion = fmt.Sprintf("%d.99.0", major)
+			return d
+		}
+		wantStatus(t, run(t, env, checkDaemonProtocol), StatusOK)
+	})
+
+	t.Run("a different major fails", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo {
+			d := aliveDaemon()
+			major, _ := protocolMajor(rpc.ProtocolVersion)
+			d.ProtocolVersion = fmt.Sprintf("%d.0.0", major+1)
+			return d
+		}
+		got := run(t, env, checkDaemonProtocol)
+		wantStatus(t, got, StatusFail)
+		if got.Fix != "sonar daemon restart" {
+			t.Errorf("fix = %q", got.Fix)
+		}
+	})
+}
+
+func TestSocketPermissions(t *testing.T) {
+	t.Run("windows is a skip, not a failure", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.GOOS = "windows"
+		env.SocketPath = `\\.\pipe\sonar`
+		wantStatus(t, run(t, env, checkSocketPermissions), StatusSkip)
+	})
+
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	t.Run("no socket and no daemon skips", func(t *testing.T) {
+		wantStatus(t, run(t, fakeEnv(t), checkSocketPermissions), StatusSkip)
+	})
+
+	t.Run("a daemon whose socket vanished fails", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.Daemon = func(context.Context) DaemonInfo { return aliveDaemon() }
+		wantStatus(t, run(t, env, checkSocketPermissions), StatusFail)
+	})
+
+	t.Run("0600 is fine, 0666 is not", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, env.SocketPath, "")
+		if err := os.Chmod(env.SocketPath, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		wantStatus(t, run(t, env, checkSocketPermissions), StatusOK)
+
+		if err := os.Chmod(env.SocketPath, 0o666); err != nil {
+			t.Fatal(err)
+		}
+		got := run(t, env, checkSocketPermissions)
+		wantStatus(t, got, StatusFail)
+		if !strings.Contains(got.Detail, "0666") {
+			t.Errorf("detail = %q, want the mode it found", got.Detail)
+		}
+	})
+}
+
+func TestDBOK(t *testing.T) {
+	t.Run("no database yet warns", func(t *testing.T) {
+		got := run(t, fakeEnv(t), checkDBOK)
+		wantStatus(t, got, StatusWarn)
+	})
+
+	t.Run("a real database reports its schema version", func(t *testing.T) {
+		env := fakeEnv(t)
+		db, err := store.Open(env.DBPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		db.Close()
+
+		got := run(t, env, checkDBOK)
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Summary, fmt.Sprintf("v%d", store.LatestVersion())) {
+			t.Errorf("summary = %q, want schema v%d", got.Summary, store.LatestVersion())
+		}
+	})
+}
+
+// ------------------------------------------------------------ agent tools ---
+
+func TestMCPRegistered(t *testing.T) {
+	t.Run("a tool that is not installed skips", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.fill()
+		got := checkMCPRegistered(env, agentTools()[1]) // cursor
+		wantStatus(t, got, StatusSkip)
+	})
+
+	t.Run("installed but not registered warns and is fixable", func(t *testing.T) {
+		env := fakeEnv(t)
+		if err := os.MkdirAll(filepath.Join(env.Home, ".cursor"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		env.fill()
+		got := checkMCPRegistered(env, agentTools()[1])
+		wantStatus(t, got, StatusWarn)
+		if !got.Fixable || got.Fix != "sonar install mcp --cursor" {
+			t.Errorf("fix = %q fixable = %v", got.Fix, got.Fixable)
+		}
+	})
+
+	t.Run("registered in the user config", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, filepath.Join(env.Home, ".cursor", "mcp.json"),
+			`{"mcpServers":{"sonar":{"command":"sonar","args":["mcp"]}}}`)
+		env.fill()
+		got := checkMCPRegistered(env, agentTools()[1])
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Summary, "user scope") {
+			t.Errorf("summary = %q, want the scope it found", got.Summary)
+		}
+	})
+
+	t.Run("another server registered is not sonar", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, filepath.Join(env.Home, ".cursor", "mcp.json"),
+			`{"mcpServers":{"something-else":{"command":"x"}}}`)
+		env.fill()
+		wantStatus(t, checkMCPRegistered(env, agentTools()[1]), StatusWarn)
+	})
+
+	t.Run("codex is read out of its TOML", func(t *testing.T) {
+		env := fakeEnv(t)
+		codex := agentTools()[2]
+		write(t, filepath.Join(env.Home, ".codex", "config.toml"),
+			"model = \"gpt\"\n\n[mcp_servers.sonar]\ncommand = \"sonar\"\nargs = [\"mcp\"]\n")
+		env.fill()
+		wantStatus(t, checkMCPRegistered(env, codex), StatusOK)
+	})
+
+	t.Run("codex without an entry", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, filepath.Join(env.Home, ".codex", "config.toml"), "model = \"gpt\"\n")
+		env.fill()
+		wantStatus(t, checkMCPRegistered(env, agentTools()[2]), StatusWarn)
+	})
+}
+
+func TestSkillsInstalled(t *testing.T) {
+	t.Run("no Claude Code skips", func(t *testing.T) {
+		wantStatus(t, run(t, fakeEnv(t), checkSkillsInstalled), StatusSkip)
+	})
+
+	t.Run("installed but missing warns", func(t *testing.T) {
+		env := fakeEnv(t)
+		if err := os.MkdirAll(filepath.Join(env.Home, ".claude"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got := run(t, env, checkSkillsInstalled)
+		wantStatus(t, got, StatusWarn)
+		if !got.Fixable {
+			t.Error("installing the skill is a safe fix")
+		}
+	})
+
+	t.Run("the bundled skill is installed", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, install.SkillPath(install.ScopeUser, env.Home, ""), install.SkillContent())
+		wantStatus(t, run(t, env, checkSkillsInstalled), StatusOK)
+	})
+
+	t.Run("a foreign skill is not overwritten silently", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, install.SkillPath(install.ScopeUser, env.Home, ""), "---\nname: sonar\n---\nmine\n")
+		got := run(t, env, checkSkillsInstalled)
+		wantStatus(t, got, StatusWarn)
+		if got.Fixable {
+			t.Error("overwriting a file sonar did not write is not a safe fix")
+		}
+	})
+}
+
+func TestHooksInstalled(t *testing.T) {
+	t.Run("no Claude Code skips", func(t *testing.T) {
+		wantStatus(t, run(t, fakeEnv(t), checkHooksInstalled), StatusSkip)
+	})
+
+	t.Run("settings without sonar hooks warns", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, install.SettingsPath(install.ScopeUser, env.Home, ""), `{"hooks":{}}`)
+		got := run(t, env, checkHooksInstalled)
+		wantStatus(t, got, StatusWarn)
+		if !got.Fixable {
+			t.Error("installing the hooks is a safe fix")
+		}
+	})
+
+	t.Run("hooks sonar wrote are found", func(t *testing.T) {
+		env := fakeEnv(t)
+		path := install.SettingsPath(install.ScopeUser, env.Home, "")
+		write(t, path, "{}")
+		if _, _, err := install.InstallHooks(path, "sonar", install.ModeAdvise); err != nil {
+			t.Fatal(err)
+		}
+		got := run(t, env, checkHooksInstalled)
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Summary, "2 sonar hooks") {
+			t.Errorf("summary = %q, want the two hooks install writes", got.Summary)
+		}
+	})
+
+	t.Run("unreadable settings warn rather than fail the run", func(t *testing.T) {
+		env := fakeEnv(t)
+		write(t, install.SettingsPath(install.ScopeUser, env.Home, ""), "{not json")
+		wantStatus(t, run(t, env, checkHooksInstalled), StatusWarn)
+	})
+}
+
+// ---------------------------------------------------------------- extras ---
+
+func TestDocker(t *testing.T) {
+	t.Run("not installed skips", func(t *testing.T) {
+		wantStatus(t, run(t, fakeEnv(t), checkDocker), StatusSkip)
+	})
+
+	t.Run("installed but not responding warns", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.LookPath = func(name string) (string, error) {
+			if name == "docker" {
+				return "/usr/local/bin/docker", nil
+			}
+			return "", exec.ErrNotFound
+		}
+		wantStatus(t, run(t, env, checkDocker), StatusWarn)
+	})
+
+	t.Run("responding is ok", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.LookPath = func(string) (string, error) { return "/usr/local/bin/docker", nil }
+		env.Docker = func(context.Context) (string, error) { return "27.0.1", nil }
+		got := run(t, env, checkDocker)
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Detail, "27.0.1") {
+			t.Errorf("detail = %q", got.Detail)
+		}
+	})
+}
+
+func TestTraySkipsOffMacOS(t *testing.T) {
+	env := fakeEnv(t)
+	env.GOOS = "linux"
+	got := run(t, env, checkTray)
+	wantStatus(t, got, StatusSkip)
+	if !strings.Contains(got.Summary, "macOS") {
+		t.Errorf("summary = %q", got.Summary)
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	for _, tc := range []struct {
+		in   int64
+		want string
+	}{{0, "0 B"}, {999, "999 B"}, {2048, "2.0 KiB"}, {5 << 20, "5.0 MiB"}} {
+		if got := humanBytes(tc.in); got != tc.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,360 @@
+// Package doctor runs sonar's self-diagnosis: one list of independent checks
+// that say whether the CLI, the daemon, the database, the agent integrations
+// and this project's config are in the state sonar expects.
+//
+// The same list backs `sonar doctor` and the `daemon.doctor` RPC the desktop
+// app calls, so the app never has to shell out to learn what is wrong. A few
+// checks are about the CLI process itself (which binary PATH resolves, how it
+// compares with the daemon and with the latest release); those the daemon
+// cannot answer from its own process and reports as `skip`, saying so in the
+// check's detail.
+package doctor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/store"
+)
+
+// Status values, in the order a reader should worry about them.
+const (
+	StatusOK   = "ok"
+	StatusWarn = "warn"
+	StatusFail = "fail"
+	StatusSkip = "skip"
+)
+
+// Mode says which process is running the checks. It only changes what the
+// CLI-only checks report, never the list of checks: a caller that asked for
+// `cli_on_path` gets a row for it either way, so a client's table does not
+// change shape depending on who answered.
+type Mode string
+
+const (
+	// ModeCLI is a `sonar doctor` run in the CLI process.
+	ModeCLI Mode = "cli"
+	// ModeDaemon is a `daemon.doctor` call answered inside the daemon.
+	ModeDaemon Mode = "daemon"
+)
+
+// cliOnlyDetail is what a CLI-only check says when the daemon answered.
+const cliOnlyDetail = "CLI-only: this check is about the sonar binary you invoked, " +
+	"which the daemon cannot see from its own process. Run `sonar doctor` for it."
+
+// DaemonInfo is what the doctor knows about the daemon. The CLI fills it in by
+// dialling; the daemon fills it in from its own runtime, which is also why
+// this is a plain struct rather than a client handle.
+type DaemonInfo struct {
+	// Reachable is false when nothing answered on the socket.
+	Reachable bool
+	// Err is why it was not reachable.
+	Err error
+	// Local is true when the answer came from inside the daemon process.
+	Local bool
+
+	Version         string
+	ProtocolVersion string
+	Socket          string
+	PID             int
+	DBPath          string
+}
+
+// Env is the slice of the world the checks read. Everything that a test would
+// otherwise have to fake on the real machine — the executable's own path, what
+// PATH resolves, the network, docker — is a field here; plain files are not,
+// because every test binary already runs with an isolated HOME (internal/testenv)
+// and reading a real temp file is more honest than faking os.ReadFile.
+type Env struct {
+	// Mode is who is running the checks.
+	Mode Mode
+	// GOOS overrides runtime.GOOS, so the Windows skips can be exercised on
+	// any host.
+	GOOS string
+	// Version is the running process's own version string.
+	Version string
+	// Project is the directory the project-scoped checks look at. Empty means
+	// the process's working directory.
+	Project string
+
+	// Home is the user's home directory.
+	Home string
+	// ConfigPath is the user's config.yaml.
+	ConfigPath string
+	// ConfigDir is ~/.config/sonar.
+	ConfigDir string
+	// SocketPath is the address the daemon listens on.
+	SocketPath string
+	// DBPath is the SQLite database file.
+	DBPath string
+
+	// Executable is the running binary's path.
+	Executable func() (string, error)
+	// LookPath resolves a name against PATH.
+	LookPath func(string) (string, error)
+	// UID is the current user's numeric id on unix; -1 when unknown.
+	UID int
+
+	// Daemon reports the daemon's identity, or why it could not be reached.
+	Daemon func(context.Context) DaemonInfo
+	// LatestRelease returns the newest published release tag. An error means
+	// GitHub was unreachable within the budget, which is a `skip`, never a
+	// failure: a machine offline on purpose is not broken.
+	LatestRelease func(context.Context) (string, error)
+	// Docker reports the docker daemon's server version, or an error when the
+	// CLI is there but the daemon is not answering.
+	Docker func(context.Context) (string, error)
+}
+
+// check is one diagnostic: its id, whether only the CLI can answer it, and the
+// function that looks.
+type check struct {
+	id      string
+	cliOnly bool
+	run     func(context.Context, *Env) rpc.DoctorCheck
+}
+
+// checks is the whole list, in the order the table prints them: the binary,
+// then the daemon, then its storage, then the integrations, then the project,
+// then the optional extras.
+func checks() []check {
+	list := []check{
+		{id: "cli_on_path", cliOnly: true, run: checkCLIOnPath},
+		{id: "cli_version_current", cliOnly: true, run: checkCLIVersionCurrent},
+		{id: "config_parses", run: checkConfigParses},
+		{id: "config_dir_writable", run: checkConfigDirWritable},
+		{id: "daemon_reachable", run: checkDaemonReachable},
+		{id: "daemon_version_matches", cliOnly: true, run: checkDaemonVersionMatches},
+		{id: "daemon_protocol", run: checkDaemonProtocol},
+		{id: "socket_permissions", run: checkSocketPermissions},
+		{id: "db_ok", run: checkDBOK},
+	}
+	for _, tool := range mcpTools() {
+		list = append(list, check{id: tool.id, run: tool.run})
+	}
+	return append(list,
+		check{id: "skills_installed", run: checkSkillsInstalled},
+		check{id: "hooks_installed", run: checkHooksInstalled},
+		check{id: "project_config", run: checkProjectConfig},
+		check{id: "docker", run: checkDocker},
+		check{id: "tray", run: checkTray},
+	)
+}
+
+// IDs lists every check id, in table order. `sonar doctor --only` validates
+// against it.
+func IDs() []string {
+	all := checks()
+	out := make([]string, 0, len(all))
+	for _, c := range all {
+		out = append(out, c.id)
+	}
+	return out
+}
+
+// Prefixes lists the selectors `--only` accepts that are not check ids: the
+// part before the dot of every dotted id, so `--only mcp_registered` means all
+// three MCP checks.
+func Prefixes() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, id := range IDs() {
+		prefix, _, ok := strings.Cut(id, ".")
+		if !ok || seen[prefix] {
+			continue
+		}
+		seen[prefix] = true
+		out = append(out, prefix)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// UnknownSelectors returns the entries of only that name no check.
+func UnknownSelectors(only []string) []string {
+	var bad []string
+	for _, sel := range normalize(only) {
+		if !selects([]string{sel}, IDs()) {
+			bad = append(bad, sel)
+		}
+	}
+	return bad
+}
+
+// selects reports whether any of ids is picked by only.
+func selects(only, ids []string) bool {
+	for _, id := range ids {
+		if picked(only, id) {
+			return true
+		}
+	}
+	return false
+}
+
+// picked reports whether only selects id. An empty only selects everything.
+func picked(only []string, id string) bool {
+	if len(only) == 0 {
+		return true
+	}
+	for _, sel := range only {
+		if sel == id || strings.HasPrefix(id, sel+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalize(only []string) []string {
+	out := make([]string, 0, len(only))
+	for _, sel := range only {
+		for _, part := range strings.Split(sel, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
+
+// Run executes the selected checks and assembles the reply both `sonar doctor`
+// and `daemon.doctor` return.
+func Run(ctx context.Context, env Env, only []string) rpc.DaemonDoctorResult {
+	env.fill()
+	sel := normalize(only)
+
+	// The daemon is dialled at most once per run, however many checks ask
+	// about it, and once more at the end for daemon_version — a doctor run
+	// must not open a connection per check.
+	var info DaemonInfo
+	var haveInfo bool
+	probe := env.Daemon
+	daemonOnce := func(ctx context.Context) DaemonInfo {
+		if !haveInfo {
+			info = probe(ctx)
+			haveInfo = true
+		}
+		return info
+	}
+	env.Daemon = daemonOnce
+
+	result := rpc.DaemonDoctorResult{OK: true, Checks: []rpc.DoctorCheck{}, Version: env.Version}
+	for _, c := range checks() {
+		if !picked(sel, c.id) {
+			continue
+		}
+		var got rpc.DoctorCheck
+		if c.cliOnly && env.Mode == ModeDaemon {
+			got = rpc.DoctorCheck{
+				ID:      c.id,
+				Status:  StatusSkip,
+				Summary: "not checked from the daemon",
+				Detail:  cliOnlyDetail,
+			}
+		} else {
+			got = c.run(ctx, &env)
+			got.ID = c.id
+		}
+		if got.Status == StatusFail {
+			result.OK = false
+		}
+		result.Checks = append(result.Checks, got)
+	}
+	if d := daemonOnce(ctx); d.Reachable {
+		result.DaemonVersion = d.Version
+	}
+	return result
+}
+
+// fill installs the real world behind every seam the caller left empty.
+func (e *Env) fill() {
+	if e.Mode == "" {
+		e.Mode = ModeCLI
+	}
+	if e.GOOS == "" {
+		e.GOOS = runtime.GOOS
+	}
+	if e.Executable == nil {
+		e.Executable = os.Executable
+	}
+	if e.LookPath == nil {
+		e.LookPath = exec.LookPath
+	}
+	if e.UID == 0 {
+		e.UID = os.Getuid()
+	}
+	if e.Home == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			e.Home = home
+		}
+	}
+	if e.Project == "" {
+		if wd, err := os.Getwd(); err == nil {
+			e.Project = wd
+		}
+	}
+	// The four paths default to what every other command resolves, so a
+	// caller that only wants the standard run passes none of them and a test
+	// that wants a fixture passes exactly the one it cares about.
+	if e.ConfigPath == "" {
+		e.ConfigPath = config.Path()
+	}
+	if e.ConfigDir == "" {
+		e.ConfigDir = daemon.ConfigDir()
+	}
+	if e.SocketPath == "" {
+		e.SocketPath = daemon.SocketPath()
+	}
+	if e.DBPath == "" {
+		e.DBPath = store.Path()
+	}
+	if e.Daemon == nil {
+		e.Daemon = func(context.Context) DaemonInfo {
+			return DaemonInfo{Err: errNoProbe}
+		}
+	}
+	if e.LatestRelease == nil {
+		e.LatestRelease = func(context.Context) (string, error) { return "", errNoProbe }
+	}
+	if e.Docker == nil {
+		e.Docker = func(context.Context) (string, error) { return "", errNoProbe }
+	}
+}
+
+// errNoProbe is what an unwired seam reports: the caller did not give the
+// doctor a way to look, so the check that needs it skips.
+var errNoProbe = errors.New("not available in this process")
+
+// gitRootOf is the repository root above dir, or "" when dir is not in one.
+func gitRootOf(dir string) string {
+	root, _, ok := groups.Find(dir)
+	if !ok {
+		return ""
+	}
+	return root
+}
+
+// home joins a path under the user's home directory, or "" without one.
+func (e *Env) homePath(parts ...string) string {
+	if e.Home == "" {
+		return ""
+	}
+	return filepath.Join(append([]string{e.Home}, parts...)...)
+}
+
+func exists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,156 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+)
+
+// fakeEnv is an Env whose every seam answers without touching the machine: no
+// PATH lookup escapes it, no socket is dialled, no release is fetched. Paths
+// point into t.TempDir(), so a check that reads a file reads a real one the
+// test wrote.
+func fakeEnv(t *testing.T) *Env {
+	t.Helper()
+	home := t.TempDir()
+	return &Env{
+		Mode:       ModeCLI,
+		GOOS:       runtime.GOOS,
+		Version:    "v1.2.3",
+		Home:       home,
+		Project:    home,
+		ConfigPath: filepath.Join(home, ".config", "sonar", "config.yaml"),
+		ConfigDir:  filepath.Join(home, ".config", "sonar"),
+		SocketPath: filepath.Join(home, ".config", "sonar", "daemon.sock"),
+		DBPath:     filepath.Join(home, ".config", "sonar", "sonar.db"),
+		UID:        os.Getuid(),
+		Executable: func() (string, error) { return filepath.Join(home, "bin", "sonar"), nil },
+		LookPath:   func(string) (string, error) { return "", exec.ErrNotFound },
+		Daemon:     func(context.Context) DaemonInfo { return DaemonInfo{Err: errors.New("no daemon")} },
+		LatestRelease: func(context.Context) (string, error) {
+			return "", errors.New("no network in tests")
+		},
+		Docker: func(context.Context) (string, error) { return "", errors.New("no docker in tests") },
+	}
+}
+
+// write puts content at path, creating parents.
+func write(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func run(t *testing.T, env *Env, fn func(context.Context, *Env) rpc.DoctorCheck) rpc.DoctorCheck {
+	t.Helper()
+	env.fill()
+	return fn(context.Background(), env)
+}
+
+func wantStatus(t *testing.T, got rpc.DoctorCheck, status string) {
+	t.Helper()
+	if got.Status != status {
+		t.Fatalf("status = %q (%s / %s), want %q", got.Status, got.Summary, got.Detail, status)
+	}
+}
+
+// -------------------------------------------------------------- selectors ---
+
+func TestOnlySelectsExactIDsAndDottedFamilies(t *testing.T) {
+	ids := IDs()
+	if len(ids) < 10 {
+		t.Fatalf("only %d checks: %v", len(ids), ids)
+	}
+	if !picked(nil, "db_ok") {
+		t.Error("an empty --only should select everything")
+	}
+	if !picked([]string{"mcp_registered"}, "mcp_registered.cursor") {
+		t.Error("--only mcp_registered should select the whole family")
+	}
+	if picked([]string{"mcp_registered"}, "db_ok") {
+		t.Error("--only mcp_registered should not select db_ok")
+	}
+	if got := UnknownSelectors([]string{"db_ok", "mcp_registered", "nope"}); len(got) != 1 || got[0] != "nope" {
+		t.Errorf("unknown selectors = %v, want [nope]", got)
+	}
+	if got := Prefixes(); len(got) != 1 || got[0] != "mcp_registered" {
+		t.Errorf("prefixes = %v, want [mcp_registered]", got)
+	}
+}
+
+func TestRunKeepsOnlyTheSelectedChecks(t *testing.T) {
+	env := *fakeEnv(t)
+	got := Run(context.Background(), env, []string{"db_ok,tray"})
+	if len(got.Checks) != 2 {
+		t.Fatalf("ran %d checks, want 2: %v", len(got.Checks), got.Checks)
+	}
+	if got.Checks[0].ID != "db_ok" || got.Checks[1].ID != "tray" {
+		t.Errorf("ids = %s, %s", got.Checks[0].ID, got.Checks[1].ID)
+	}
+	if got.Version != "v1.2.3" {
+		t.Errorf("version = %q", got.Version)
+	}
+}
+
+func TestRunDialsTheDaemonOnce(t *testing.T) {
+	env := *fakeEnv(t)
+	calls := 0
+	env.Daemon = func(context.Context) DaemonInfo {
+		calls++
+		return DaemonInfo{Reachable: true, Version: "v1.2.3", ProtocolVersion: rpc.ProtocolVersion}
+	}
+	Run(context.Background(), env, nil)
+	if calls != 1 {
+		t.Errorf("dialled the daemon %d times, want 1", calls)
+	}
+}
+
+func TestDaemonModeSkipsTheCLIOnlyChecks(t *testing.T) {
+	env := *fakeEnv(t)
+	env.Mode = ModeDaemon
+	got := Run(context.Background(), env, nil)
+
+	cliOnly := map[string]bool{"cli_on_path": true, "cli_version_current": true, "daemon_version_matches": true}
+	seen := 0
+	for _, c := range got.Checks {
+		if !cliOnly[c.ID] {
+			continue
+		}
+		seen++
+		wantStatus(t, c, StatusSkip)
+		if !strings.Contains(c.Detail, "CLI-only") {
+			t.Errorf("%s detail = %q, want it to say the check is CLI-only", c.ID, c.Detail)
+		}
+	}
+	if seen != len(cliOnly) {
+		t.Errorf("saw %d CLI-only checks, want %d", seen, len(cliOnly))
+	}
+	// The list of rows must not change shape with the answering process.
+	if len(got.Checks) != len(IDs()) {
+		t.Errorf("daemon mode ran %d checks, want all %d", len(got.Checks), len(IDs()))
+	}
+}
+
+func TestRunIsNotOKOnlyWhenSomethingFailed(t *testing.T) {
+	env := *fakeEnv(t)
+	// No daemon is a fail.
+	if got := Run(context.Background(), env, []string{"daemon_reachable"}); got.OK {
+		t.Error("a failing check must make the run not ok")
+	}
+	// A missing .sonar.yaml is only a warning.
+	if got := Run(context.Background(), env, []string{"project_config"}); !got.OK {
+		t.Error("a warning must leave the run ok")
+	}
+}

--- a/internal/doctor/handlers.go
+++ b/internal/doctor/handlers.go
@@ -1,0 +1,58 @@
+package doctor
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+)
+
+// `daemon.doctor` exists so the desktop app can diagnose an installation
+// without shelling out to a CLI it may not have found yet. It runs the same
+// list `sonar doctor` runs and returns the same rows; the checks that are about
+// the CLI process come back as `skip` with a detail saying so (contract §8: the
+// handler lives here, and the daemon package never imports this one).
+func init() {
+	daemon.RegisterHandler("daemon.doctor", handleDoctor)
+	daemon.RegisterCapability("doctor")
+}
+
+func handleDoctor(ctx context.Context, req *daemon.Request) (any, error) {
+	var p rpc.DaemonDoctorParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	if bad := UnknownSelectors(p.Only); len(bad) > 0 {
+		return nil, rpc.NewError(rpc.CodeInvalidParams,
+			"unknown check "+strings.Join(bad, ", "),
+			"known checks: "+strings.Join(append(IDs(), Prefixes()...), ", "))
+	}
+	if p.Project != "" && !filepath.IsAbs(p.Project) {
+		return nil, rpc.NewError(rpc.CodeInvalidParams,
+			"project must be an absolute path",
+			"the daemon has its own working directory, so a relative path would mean something else here")
+	}
+
+	rt := req.Runtime
+	self := DaemonInfo{
+		Reachable:       true,
+		Local:           true,
+		Version:         rt.Version,
+		ProtocolVersion: rpc.ProtocolVersion,
+		Socket:          rt.Socket,
+		PID:             rt.PID,
+		DBPath:          rt.DBPath(),
+	}
+	env := Env{
+		Mode:       ModeDaemon,
+		Version:    rt.Version,
+		Project:    p.Project,
+		SocketPath: rt.Socket,
+		DBPath:     rt.DBPath(),
+		Daemon:     func(context.Context) DaemonInfo { return self },
+		Docker:     DockerProbe,
+	}
+	return Run(ctx, env, p.Only), nil
+}

--- a/internal/doctor/main_test.go
+++ b/internal/doctor/main_test.go
@@ -1,0 +1,13 @@
+package doctor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// Every path sonar resolves from the environment points at a private temp
+// directory for the whole of this test binary, daemon autostart is off, and
+// the run fails if a test leaves a daemon behind (step 1A.20).
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/doctor/owner_unix.go
+++ b/internal/doctor/owner_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package doctor
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileOwner reports the numeric owner of a file. The second result is false
+// when the platform does not expose one.
+func fileOwner(info os.FileInfo) (int, bool) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(st.Uid), true
+}

--- a/internal/doctor/owner_windows.go
+++ b/internal/doctor/owner_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package doctor
+
+import "os"
+
+// fileOwner has no answer on Windows: the socket is a named pipe there and the
+// permission check skips before it is ever called.
+func fileOwner(os.FileInfo) (int, bool) { return 0, false }

--- a/internal/doctor/probes.go
+++ b/internal/doctor/probes.go
@@ -1,0 +1,59 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/selfupdate"
+)
+
+// NetworkBudget is how long the doctor waits on anything off this machine.
+// A check that runs out of budget is a `skip`: an offline machine is not a
+// broken one, and a diagnosis must not itself hang.
+const NetworkBudget = 2 * time.Second
+
+// ReleaseProbe asks GitHub for the newest published release tag, within
+// NetworkBudget.
+func ReleaseProbe(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, NetworkBudget)
+	defer cancel()
+	tag, err := selfupdate.LatestTag(ctx)
+	if err != nil {
+		return "", fmt.Errorf("github.com did not answer within %s: %w", NetworkBudget, err)
+	}
+	return tag, nil
+}
+
+// DockerProbe asks the local docker daemon for its server version, within
+// NetworkBudget. An error means the CLI is installed but its daemon is not
+// answering — the state that quietly strips container names off every listing.
+func DockerProbe(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, NetworkBudget)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
+	out, err := cmd.Output()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("`docker info` did not answer within %s", NetworkBudget)
+		}
+		var exit *exec.ExitError
+		if errors.As(err, &exit) && len(exit.Stderr) > 0 {
+			return "", errors.New(firstLine(string(exit.Stderr)))
+		}
+		return "", err
+	}
+	version := strings.TrimSpace(string(out))
+	if version == "" {
+		return "", errors.New("`docker info` reported no server version")
+	}
+	return version, nil
+}
+
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(s), "\n")
+	return line
+}

--- a/internal/doctor/yamlpos.go
+++ b/internal/doctor/yamlpos.go
@@ -1,0 +1,142 @@
+package doctor
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// go-yaml reports a syntax error as "yaml: line N: <what>" and nothing else:
+// no column, and N is where the parser gave up rather than where the mistake
+// is. `list: [broken` is reported at line 1 whichever line the bracket was
+// opened on, so a user with a long config is told the file is broken and left
+// to find the spot.
+//
+// So the doctor finds the spot itself. A flow collection that is still open at
+// the end of the document is the mistake, and its opening bracket is both the
+// line and the column worth pointing at; anything else falls back to the
+// parser's own line. Either way the caller gets a position it can print with a
+// caret under it, which is what makes `config_parses` actionable.
+
+var yamlLinePattern = regexp.MustCompile(`line (\d+):`)
+
+// Position is a 1-based location in a source file.
+type Position struct {
+	Line int
+	Col  int
+}
+
+// parsePosition locates a YAML parse failure in src. A zero Line means the
+// error carried no position at all.
+func parsePosition(src string, err error) Position {
+	if line, col, ok := unclosedFlow(src); ok {
+		return Position{Line: line, Col: col}
+	}
+	if err == nil {
+		return Position{}
+	}
+	m := yamlLinePattern.FindStringSubmatch(err.Error())
+	if m == nil {
+		return Position{}
+	}
+	line, convErr := strconv.Atoi(m[1])
+	if convErr != nil {
+		return Position{}
+	}
+	return Position{Line: line, Col: 1}
+}
+
+// yamlMessage is a go-yaml error without the "yaml:" prefix and without the
+// "line N:" it repeats: the position is printed separately, and more precisely.
+func yamlMessage(err error) string {
+	msg := strings.TrimPrefix(err.Error(), "yaml: ")
+	return strings.TrimSpace(yamlLinePattern.ReplaceAllString(msg, ""))
+}
+
+// unclosedFlow returns the position of the innermost `[` or `{` that is never
+// closed, skipping comments and quoted scalars.
+func unclosedFlow(src string) (int, int, bool) {
+	type mark struct {
+		line, col int
+		open      byte
+	}
+	var stack []mark
+
+	line, col := 1, 1
+	var inSingle, inDouble, inComment bool
+	for i := 0; i < len(src); i++ {
+		ch := src[i]
+		switch {
+		case ch == '\n':
+			line, col = line+1, 0 // col is incremented at the bottom
+			inComment, inSingle, inDouble = false, false, false
+		case inComment:
+		case inSingle:
+			if ch == '\'' {
+				if i+1 < len(src) && src[i+1] == '\'' {
+					i, col = i+1, col+1 // an escaped quote, still inside
+					break
+				}
+				inSingle = false
+			}
+		case inDouble:
+			if ch == '\\' && i+1 < len(src) {
+				i, col = i+1, col+1
+				break
+			}
+			if ch == '"' {
+				inDouble = false
+			}
+		case ch == '#' && (i == 0 || src[i-1] == ' ' || src[i-1] == '\t' || src[i-1] == '\n'):
+			inComment = true
+		case ch == '\'':
+			inSingle = true
+		case ch == '"':
+			inDouble = true
+		case ch == '[' || ch == '{':
+			stack = append(stack, mark{line: line, col: col, open: ch})
+		case ch == ']' || ch == '}':
+			want := byte('[')
+			if ch == '}' {
+				want = '{'
+			}
+			if n := len(stack); n > 0 && stack[n-1].open == want {
+				stack = stack[:n-1]
+			}
+		}
+		col++
+	}
+	if len(stack) == 0 {
+		return 0, 0, false
+	}
+	top := stack[len(stack)-1]
+	return top.line, top.col, true
+}
+
+// caret renders the offending line with a marker under the column, so the
+// detail of a failing config_parses check reads like a compiler error.
+func caret(src string, pos Position) string {
+	if pos.Line <= 0 {
+		return ""
+	}
+	lines := strings.Split(src, "\n")
+	if pos.Line > len(lines) {
+		return ""
+	}
+	text := strings.TrimRight(lines[pos.Line-1], "\r")
+	if pos.Col <= 0 || pos.Col > len(text)+1 {
+		return fmt.Sprintf("  %s", text)
+	}
+	// Tabs are copied through so the marker lands under the right glyph in a
+	// terminal that renders them the same way.
+	pad := make([]byte, 0, pos.Col-1)
+	for i := 0; i < pos.Col-1; i++ {
+		if text[i] == '\t' {
+			pad = append(pad, '\t')
+			continue
+		}
+		pad = append(pad, ' ')
+	}
+	return fmt.Sprintf("  %s\n  %s^", text, pad)
+}

--- a/internal/doctor/yamlpos_test.go
+++ b/internal/doctor/yamlpos_test.go
@@ -1,0 +1,94 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestParsePositionPointsAtTheUnclosedBracket(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		wantLine int
+		wantCol  int
+	}{
+		{
+			// The config the step was written for.
+			name: "flow sequence never closed", src: "list: [broken",
+			wantLine: 1, wantCol: 7,
+		},
+		{
+			// go-yaml blames line 1 here; the bracket is on line 2.
+			name: "unclosed bracket below the reported line",
+			src:  "a: 1\nb: [1,\nc: 2\n", wantLine: 2, wantCol: 4,
+		},
+		{
+			name: "unclosed mapping", src: "a: {x: 1\n", wantLine: 1, wantCol: 4,
+		},
+		{
+			name:     "the innermost one wins",
+			src:      "a: [1, {b: 2\n",
+			wantLine: 1, wantCol: 8,
+		},
+		{
+			name:     "a bracket inside a quoted scalar is not an opener",
+			src:      "a: \"[\"\nb: [1\n",
+			wantLine: 2, wantCol: 4,
+		},
+		{
+			name:     "a bracket in a comment is not an opener",
+			src:      "a: 1 # [\nb: [1\n",
+			wantLine: 2, wantCol: 4,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var node yaml.Node
+			err := yaml.Unmarshal([]byte(tc.src), &node)
+			if err == nil {
+				t.Fatalf("%q parsed cleanly; the fixture is not a syntax error", tc.src)
+			}
+			pos := parsePosition(tc.src, err)
+			if pos.Line != tc.wantLine || pos.Col != tc.wantCol {
+				t.Errorf("position = %d:%d, want %d:%d (yaml said %v)",
+					pos.Line, pos.Col, tc.wantLine, tc.wantCol, err)
+			}
+		})
+	}
+}
+
+func TestParsePositionFallsBackToTheParsersLine(t *testing.T) {
+	const src = "a: *nope\n"
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(src), &node)
+	if err == nil {
+		t.Fatal("an unknown anchor should not parse")
+	}
+	// go-yaml reports this one without a line at all, so there is nothing to
+	// point at and the check falls back to naming the file.
+	if pos := parsePosition(src, err); pos.Line != 0 {
+		t.Errorf("position = %d:%d, want no position", pos.Line, pos.Col)
+	}
+}
+
+func TestCaretMarksTheColumn(t *testing.T) {
+	got := caret("list: [broken", Position{Line: 1, Col: 7})
+	want := "  list: [broken\n        ^"
+	if got != want {
+		t.Errorf("caret =\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestYamlMessageDropsTheRedundantPrefixes(t *testing.T) {
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte("list: [broken"), &node)
+	got := yamlMessage(err)
+	if strings.Contains(got, "yaml:") || strings.Contains(got, "line 1") {
+		t.Errorf("message = %q, want it without the yaml: and line prefixes", got)
+	}
+	if !strings.Contains(got, "','") {
+		t.Errorf("message = %q, want it to keep what the parser said", got)
+	}
+}

--- a/internal/install/hooks.go
+++ b/internal/install/hooks.go
@@ -122,6 +122,64 @@ func UninstallHooks(path string) (Action, error) {
 	return ActionRemoved, nil
 }
 
+// InstalledHooks counts the hook entries sonar wrote into the settings file at
+// path: the same `_sonar`-tagged entries InstallHooks writes and UninstallHooks
+// strips. A missing file is zero hooks, not an error, so `sonar doctor` can ask
+// about a settings file that was never created.
+func InstalledHooks(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("could not read %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return 0, nil
+	}
+	root := map[string]any{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return 0, fmt.Errorf("could not parse %s as JSON: %w", path, err)
+	}
+	return countSonarHooks(root), nil
+}
+
+// countSonarHooks walks the same shape stripSonarHooks walks, counting instead
+// of removing.
+func countSonarHooks(root map[string]any) int {
+	hooksVal, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	n := 0
+	for _, groupsVal := range hooksVal {
+		groups, ok := groupsVal.([]any)
+		if !ok {
+			continue
+		}
+		for _, gv := range groups {
+			g, ok := gv.(map[string]any)
+			if !ok {
+				continue
+			}
+			if tagged(g) {
+				n++
+				continue
+			}
+			entries, ok := g["hooks"].([]any)
+			if !ok {
+				continue
+			}
+			for _, ev := range entries {
+				if e, ok := ev.(map[string]any); ok && tagged(e) {
+					n++
+				}
+			}
+		}
+	}
+	return n
+}
+
 // loadSettings returns the canonical bytes of the existing file (nil when the
 // file does not exist) and its decoded form.
 func loadSettings(path string) ([]byte, map[string]any, []string, error) {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,6 +1,7 @@
 package selfupdate
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -35,10 +36,27 @@ func VersionString() string {
 	return fmt.Sprintf("sonar %s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 }
 
+// LatestTag is the tag of the newest published release, fetched under the
+// caller's context so a diagnosis with a deadline (`sonar doctor`) can give up
+// rather than hang on a network that is not there.
+func LatestTag(ctx context.Context) (string, error) {
+	release, err := fetchLatestRelease(ctx)
+	if err != nil {
+		return "", err
+	}
+	return release.TagName, nil
+}
+
 // FetchLatestRelease queries GitHub for the latest release.
-func FetchLatestRelease() (*githubRelease, error) {
+func FetchLatestRelease() (*githubRelease, error) { return fetchLatestRelease(context.Background()) }
+
+func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check for updates: %w", err)
 	}

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -160,6 +160,20 @@ func desktopBinaryNames(goos string) []string {
 
 // findSwiftTray keeps the pre-app behaviour: the binary shipped next to sonar,
 // or one on PATH.
+// LegacyTray reports whether the legacy macOS menu bar binary is installed on
+// this machine, whatever else is. Decide prefers the desktop app and so never
+// mentions a sonar-tray that sits beside it; `sonar doctor` wants to see the
+// leftover exactly then, which is why this is its own lookup.
+func LegacyTray() (string, bool) { return LegacyTrayIn(osEnv()) }
+
+// LegacyTrayIn is LegacyTray against an injected environment.
+func LegacyTrayIn(env Env) (string, bool) {
+	if env.GOOS != "darwin" {
+		return "", false
+	}
+	return findSwiftTray(env)
+}
+
 func findSwiftTray(env Env) (string, bool) {
 	if env.SelfDir != "" {
 		candidate := filepath.Join(env.SelfDir, "sonar-tray")


### PR DESCRIPTION
Adds `sonar doctor` (table, `--json`, `--only`, `--project`, `--fix`) and the read-only `daemon.doctor` method with the same `{ok, checks}` shape, covering the CLI on PATH, config parsing with computed positions, daemon reachability and version, socket permissions, the database, MCP registration per tool, skills, hooks, the project config, docker and the legacy tray. Contract §45.