### PR TITLE
feat: add a daemon.scan_interval config key and report both cadences in daemon.status

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ app, and editors.
 ```sh
 sonar serve                  # in the foreground
 sonar serve --detach         # in the background
-sonar daemon status          # pid, uptime, subscribers, scans, capabilities
+sonar daemon status          # pid, uptime, subscribers, scans, intervals
 sonar daemon path            # the socket it listens on
 sonar daemon log -n 50 -f    # what it is doing
 sonar daemon restart
@@ -571,6 +571,17 @@ The daemon stops on its own after 30 minutes with no clients and no
 subscribers. Set `daemon.idle_timeout` in the config file to change that, or
 `0` to keep it running.
 
+Ports are scanned every 2 seconds while something is changing; when nothing is,
+the scanner slows itself down to 5 seconds with a subscriber connected and 10
+seconds without one. `daemon.scan_interval` moves that base — minimum 1s — and
+both ceilings scale with it, so raising it to `5s` backs off to 12.5s and 25s
+rather than pinning the curve at the old caps. `daemon.stats_interval` is the
+separate cadence at which cpu, memory and the host load strip refresh while
+something is subscribed. Both are read when the daemon starts: edit the file,
+then `sonar daemon restart`. `sonar daemon status` prints the values in
+effect (`scan base`, `stats tick`) next to the adaptive interval the scanner is
+on right now.
+
 A subscriber that asks for `include: ["health"]` makes the daemon probe **every
 listening port** on a slower cadence, not only the services that declare a
 `health:` path — those are polled on every tick and reach every subscriber
@@ -599,6 +610,8 @@ list:
 daemon:
   idle_timeout: 30m     # 0 keeps the daemon running
   log_level: info       # debug | info | warn | error
+  scan_interval: 2s     # base port-scan cadence, minimum 1s
+  stats_interval: 1s    # cpu/memory refresh while subscribed, minimum 250ms
 color: true
 services:               # label custom/unknown ports
   9000: php-fpm

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -519,6 +519,12 @@
         "scan_interval_ms": {
           "type": "integer"
         },
+        "scan_base_interval_ms": {
+          "type": "integer"
+        },
+        "stats_interval_ms": {
+          "type": "integer"
+        },
         "scans": {
           "type": "integer"
         },
@@ -533,6 +539,8 @@
         "subscribers",
         "last_scan_at",
         "scan_interval_ms",
+        "scan_base_interval_ms",
+        "stats_interval_ms",
         "scans",
         "db_path"
       ]

--- a/internal/cmd/daemon_ctl.go
+++ b/internal/cmd/daemon_ctl.go
@@ -112,18 +112,20 @@ func daemonStatusRun(cmd *cobra.Command, _ []string) error {
 
 	if daemonJSONFlag {
 		out, err := json.MarshalIndent(map[string]any{
-			"running":          true,
-			"pid":              status.PID,
-			"uptime":           status.Uptime,
-			"subscribers":      status.Subscribers,
-			"last_scan_at":     status.LastScanAt,
-			"scan_interval_ms": status.ScanIntervalMs,
-			"scans":            status.Scans,
-			"db_path":          status.DBPath,
-			"socket":           hello.Socket,
-			"daemon_version":   hello.DaemonVersion,
-			"protocol_version": hello.ProtocolVersion,
-			"capabilities":     hello.Capabilities,
+			"running":               true,
+			"pid":                   status.PID,
+			"uptime":                status.Uptime,
+			"subscribers":           status.Subscribers,
+			"last_scan_at":          status.LastScanAt,
+			"scan_interval_ms":      status.ScanIntervalMs,
+			"scan_base_interval_ms": status.ScanBaseIntervalMs,
+			"stats_interval_ms":     status.StatsIntervalMs,
+			"scans":                 status.Scans,
+			"db_path":               status.DBPath,
+			"socket":                hello.Socket,
+			"daemon_version":        hello.DaemonVersion,
+			"protocol_version":      hello.ProtocolVersion,
+			"capabilities":          hello.Capabilities,
 		}, "", "  ")
 		if err != nil {
 			return err
@@ -138,6 +140,8 @@ func daemonStatusRun(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("uptime        %s\n", status.Uptime)
 	fmt.Printf("subscribers   %d\n", status.Subscribers)
 	fmt.Printf("scan interval %dms\n", status.ScanIntervalMs)
+	fmt.Printf("scan base     %dms\n", status.ScanBaseIntervalMs)
+	fmt.Printf("stats tick    %dms\n", status.StatsIntervalMs)
 	fmt.Printf("scans         %d\n", status.Scans)
 	if status.LastScanAt != "" {
 		fmt.Printf("last scan     %s\n", status.LastScanAt)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -67,6 +67,7 @@ func serveRun(cmd *cobra.Command, _ []string) error {
 		Version:       selfupdate.Version,
 		IdleTimeout:   loadedConfig.Daemon.ResolvedIdleTimeout(),
 		StatsInterval: loadedConfig.Daemon.ResolvedStatsInterval(),
+		ScanInterval:  loadedConfig.Daemon.ResolvedScanInterval(),
 		Logger:        logger,
 	})
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,13 +27,16 @@ type Config struct {
 const DefaultIdleTimeout = 30 * time.Minute
 
 // DefaultStatsInterval and MinStatsInterval bound `daemon.stats_interval`, the
-// cadence of the daemon's stats-only tick. They mirror scanner.StatsInterval
-// and scanner.MinStatsInterval; config does not import the scanner, which
-// would drag the whole port pipeline into every CLI command that reads a
-// config file.
+// cadence of the daemon's stats-only tick. DefaultScanInterval and
+// MinScanInterval do the same for `daemon.scan_interval`, the base of the
+// port-scan cadence. All four mirror the scanner's own constants;
+// config does not import the scanner, which would drag the whole port
+// pipeline into every CLI command that reads a config file.
 const (
 	DefaultStatsInterval = 1 * time.Second
 	MinStatsInterval     = 250 * time.Millisecond
+	DefaultScanInterval  = 2 * time.Second
+	MinScanInterval      = 1 * time.Second
 )
 
 // DaemonConfig holds `sonar serve` settings.
@@ -49,6 +52,13 @@ type DaemonConfig struct {
 	// below MinStatsInterval is clamped to it. It does not affect how often
 	// ports are scanned — that cadence is adaptive and owned by the scanner.
 	StatsInterval string `yaml:"stats_interval"`
+	// ScanInterval is the base cadence of the port scan, as a Go duration
+	// ("2s", "5s"). Empty means DefaultScanInterval; anything below
+	// MinScanInterval is clamped to it. It sets the *base*: the scanner still
+	// backs off on unchanged scans, and the two ceilings it backs off to
+	// scale with this value, so raising it makes the whole curve slower
+	// rather than only its fastest step.
+	ScanInterval string `yaml:"scan_interval"`
 }
 
 // ResolvedIdleTimeout returns the parsed idle timeout, falling back to
@@ -76,6 +86,21 @@ func (d DaemonConfig) ResolvedStatsInterval() time.Duration {
 	}
 	if v < MinStatsInterval {
 		return MinStatsInterval
+	}
+	return v
+}
+
+// ResolvedScanInterval returns the parsed base scan cadence, falling back to
+// DefaultScanInterval and never returning less than MinScanInterval.
+func (d DaemonConfig) ResolvedScanInterval() time.Duration {
+	v, err := time.ParseDuration(strings.TrimSpace(d.ScanInterval))
+	if err != nil || v <= 0 {
+		// Including the unset case. There is no "off": the loop already parks
+		// itself whenever nothing is subscribed and nothing is reading.
+		return DefaultScanInterval
+	}
+	if v < MinScanInterval {
+		return MinScanInterval
 	}
 	return v
 }
@@ -150,9 +175,14 @@ const template = `# sonar configuration
 #   # How much the daemon writes to ~/.config/sonar/daemon.log.
 #   log_level: info     # debug | info | warn | error
 #   # How often cpu, memory and the host load strip refresh while the app (or
-#   # any other subscriber) is watching. Ports are scanned on their own
-#   # adaptive cadence and are not affected. Minimum 250ms.
+#   # any other subscriber) is watching. Minimum 250ms.
 #   stats_interval: 1s
+#   # The base cadence of the port scan. The scanner still slows itself down
+#   # on unchanged scans — to 2.5x this while something is subscribed and 5x
+#   # when only RPC reads are served — so this moves the whole curve.
+#   # Minimum 1s. Both intervals are read at startup: restart the daemon to
+#   # apply a change, and 'sonar daemon status' shows what is in effect.
+#   scan_interval: 2s
 
 # color: true       # set false to disable colored output
 
@@ -246,6 +276,16 @@ func validate(cfg *Config) []string {
 		} else if d < MinStatsInterval {
 			warnings = append(warnings, fmt.Sprintf("config: daemon.stats_interval %q is below the %s minimum — using %s", v, MinStatsInterval, MinStatsInterval))
 			cfg.Daemon.StatsInterval = MinStatsInterval.String()
+		}
+	}
+
+	if v := strings.TrimSpace(cfg.Daemon.ScanInterval); v != "" {
+		if d, err := time.ParseDuration(v); err != nil || d <= 0 {
+			warnings = append(warnings, fmt.Sprintf("config: invalid daemon.scan_interval %q — using %s", v, DefaultScanInterval))
+			cfg.Daemon.ScanInterval = ""
+		} else if d < MinScanInterval {
+			warnings = append(warnings, fmt.Sprintf("config: daemon.scan_interval %q is below the %s minimum — using %s", v, MinScanInterval, MinScanInterval))
+			cfg.Daemon.ScanInterval = MinScanInterval.String()
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -201,6 +201,7 @@ func TestWriteTemplateRefusesOverwrite(t *testing.T) {
 func TestTemplateDocumentsTheDaemonAndItsEnvironment(t *testing.T) {
 	for _, want := range []string{
 		"# daemon:", "idle_timeout: 30m", "log_level: info", "stats_interval: 1s",
+		"scan_interval: 2s",
 		"SONAR_DB", "SONAR_SOCKET", "SONAR_NO_HINTS",
 	} {
 		if !strings.Contains(template, want) {
@@ -247,5 +248,62 @@ func TestValidateClampsStatsInterval(t *testing.T) {
 	}
 	if cfg.Daemon.LogLevel != "debug" {
 		t.Errorf("log_level = %q, a valid neighbour was dropped", cfg.Daemon.LogLevel)
+	}
+}
+
+// daemon.scan_interval defaults to the scanner's 2 s base, is clamped rather
+// than trusted, and never leaves the loop with a zero cadence.
+func TestResolvedScanInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		set  string
+		want time.Duration
+	}{
+		{"unset", "", DefaultScanInterval},
+		{"explicit", "5s", 5 * time.Second},
+		{"at the floor", "1s", MinScanInterval},
+		{"below the floor", "200ms", MinScanInterval},
+		{"zero", "0", DefaultScanInterval},
+		{"nonsense", "whenever", DefaultScanInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DaemonConfig{ScanInterval: tt.set}.ResolvedScanInterval()
+			if got != tt.want {
+				t.Errorf("ResolvedScanInterval(%q) = %s, want %s", tt.set, got, tt.want)
+			}
+		})
+	}
+}
+
+// An out-of-range scan_interval is repaired with a warning, the way
+// stats_interval is, and its neighbours survive.
+func TestValidateClampsScanInterval(t *testing.T) {
+	cfg := &Config{Daemon: DaemonConfig{ScanInterval: "50ms", StatsInterval: "1s"}}
+	warnings := validate(cfg)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "scan_interval") {
+		t.Fatalf("warnings = %v, want one about scan_interval", warnings)
+	}
+	if got := cfg.Daemon.ResolvedScanInterval(); got != MinScanInterval {
+		t.Errorf("scan_interval = %s, want the %s floor", got, MinScanInterval)
+	}
+	if cfg.Daemon.StatsInterval != "1s" {
+		t.Errorf("stats_interval = %q, a valid neighbour was dropped", cfg.Daemon.StatsInterval)
+	}
+}
+
+// A scan_interval that does not parse is dropped with a warning rather than
+// taken literally, and the daemon falls back to the default.
+func TestValidateDropsUnparseableScanInterval(t *testing.T) {
+	cfg := &Config{Daemon: DaemonConfig{ScanInterval: "every so often"}}
+	warnings := validate(cfg)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "scan_interval") {
+		t.Fatalf("warnings = %v, want one about scan_interval", warnings)
+	}
+	if cfg.Daemon.ScanInterval != "" {
+		t.Errorf("scan_interval = %q, want it dropped", cfg.Daemon.ScanInterval)
+	}
+	if got := cfg.Daemon.ResolvedScanInterval(); got != DefaultScanInterval {
+		t.Errorf("scan_interval = %s, want the %s default", got, DefaultScanInterval)
 	}
 }

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -80,13 +80,15 @@ func handleStatus(_ context.Context, req *Request) (any, error) {
 		lastScan = st.LastScanAt.Format(time.RFC3339)
 	}
 	return rpc.DaemonStatusResult{
-		PID:            rt.PID,
-		Uptime:         rt.Uptime().Round(time.Second).String(),
-		Subscribers:    rt.Subscribers(),
-		LastScanAt:     lastScan,
-		ScanIntervalMs: st.IntervalMs,
-		Scans:          st.Scans,
-		DBPath:         rt.DBPath(),
+		PID:                rt.PID,
+		Uptime:             rt.Uptime().Round(time.Second).String(),
+		Subscribers:        rt.Subscribers(),
+		LastScanAt:         lastScan,
+		ScanIntervalMs:     st.IntervalMs,
+		ScanBaseIntervalMs: st.BaseIntervalMs,
+		StatsIntervalMs:    st.StatsIntervalMs,
+		Scans:              st.Scans,
+		DBPath:             rt.DBPath(),
 	}, nil
 }
 

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -97,11 +97,19 @@ type DaemonHelloResult struct {
 }
 
 type DaemonStatusResult struct {
-	PID            int    `json:"pid"`
-	Uptime         string `json:"uptime"`
-	Subscribers    int    `json:"subscribers"`
-	LastScanAt     string `json:"last_scan_at"`
-	ScanIntervalMs int    `json:"scan_interval_ms"`
+	PID         int    `json:"pid"`
+	Uptime      string `json:"uptime"`
+	Subscribers int    `json:"subscribers"`
+	LastScanAt  string `json:"last_scan_at"`
+	// ScanIntervalMs is the adaptive port-scan cadence right now; it moves
+	// between the base and a ceiling as scans come back unchanged.
+	ScanIntervalMs int `json:"scan_interval_ms"`
+	// ScanBaseIntervalMs and StatsIntervalMs are the effective settings
+	// behind it: `daemon.scan_interval` and `daemon.stats_interval` as this
+	// daemon resolved them at startup. Both are read once, so a config edit
+	// needs a daemon restart and these are how you check that it took.
+	ScanBaseIntervalMs int `json:"scan_base_interval_ms"`
+	StatsIntervalMs    int `json:"stats_interval_ms"`
 	// Scans counts the port scans this daemon has run. Two clients reading
 	// through the daemon must not make it grow faster than one does.
 	Scans  int64  `json:"scans"`

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -47,6 +47,10 @@ type Options struct {
 	// (`daemon.stats_interval`). Zero means scanner.StatsInterval. Ignored
 	// when Scanner is set, since the caller built the loop itself.
 	StatsInterval time.Duration
+	// ScanInterval is the base cadence of the scanner's port scan
+	// (`daemon.scan_interval`). Zero means scanner.BaseInterval. Ignored when
+	// Scanner is set, for the same reason StatsInterval is.
+	ScanInterval time.Duration
 	// Logger receives the daemon's structured log. Required in production;
 	// tests may leave it nil for a discard logger.
 	Logger *slog.Logger
@@ -119,6 +123,7 @@ func New(opts Options) *Server {
 			ProtocolVersion: rpc.ProtocolVersion,
 			Logger:          opts.Logger,
 			StatsInterval:   opts.StatsInterval,
+			ScanInterval:    opts.ScanInterval,
 		})
 	}
 	s.loop.SetDemand(s.demand)

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -678,3 +678,35 @@ func (c *testClient) subscribeAndSettle(p rpc.StateSubscribeParams) state.Delta 
 	}
 	return c.nextDelta()
 }
+
+// TestStatusReportsConfiguredIntervals: both `daemon.scan_interval` and
+// `daemon.stats_interval` are read once when the daemon starts, so
+// `daemon.status` is what tells a client — and the person who just edited the
+// config file and restarted — which values a running daemon is actually on.
+func TestStatusReportsConfiguredIntervals(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newHarness(t, ctx, func(o *scanner.Options) {
+		o.ScanInterval = 4 * time.Second
+		o.StatsInterval = 300 * time.Millisecond
+	})
+	c := h.dial(ctx)
+
+	var status rpc.DaemonStatusResult
+	if e := c.call("daemon.status", rpc.Empty{}, &status); e != nil {
+		t.Fatalf("daemon.status: %v", e)
+	}
+	if status.ScanBaseIntervalMs != 4000 {
+		t.Errorf("scan_base_interval_ms = %d, want 4000", status.ScanBaseIntervalMs)
+	}
+	if status.StatsIntervalMs != 300 {
+		t.Errorf("stats_interval_ms = %d, want 300", status.StatsIntervalMs)
+	}
+	// The adaptive interval is a separate number and still starts at the base
+	// rather than at the 2 s constant.
+	if status.ScanIntervalMs < status.ScanBaseIntervalMs {
+		t.Errorf("scan_interval_ms = %d, want at least the %dms base",
+			status.ScanIntervalMs, status.ScanBaseIntervalMs)
+	}
+}

--- a/internal/mcpserver/fakedaemon/handlers.go
+++ b/internal/mcpserver/fakedaemon/handlers.go
@@ -46,12 +46,14 @@ func (f *Fake) handleHello(raw json.RawMessage) (any, error) {
 
 func (f *Fake) handleStatus(json.RawMessage) (any, error) {
 	return rpc.DaemonStatusResult{
-		PID:            os.Getpid(),
-		Uptime:         "1m0s",
-		Subscribers:    f.Subscribers(),
-		LastScanAt:     f.Fixture().StartedAt,
-		ScanIntervalMs: 2000,
-		Scans:          1,
+		PID:                os.Getpid(),
+		Uptime:             "1m0s",
+		Subscribers:        f.Subscribers(),
+		LastScanAt:         f.Fixture().StartedAt,
+		ScanIntervalMs:     2000,
+		ScanBaseIntervalMs: 2000,
+		StatsIntervalMs:    1000,
+		Scans:              1,
 	}, nil
 }
 

--- a/internal/scanner/attribute.go
+++ b/internal/scanner/attribute.go
@@ -88,7 +88,7 @@ func (l *Loop) sessions(rows []state.Port) []state.SessionRecord {
 func (l *Loop) Invalidate() {
 	l.mu.Lock()
 	l.lastScanAt = time.Time{}
-	l.interval = BaseInterval
+	l.interval = l.base
 	l.mu.Unlock()
 	l.Wake()
 }

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -21,14 +21,28 @@ import (
 
 // Timing constants from the spec's "Scanner loop" section.
 const (
-	// BaseInterval is the interval while anything is changing.
+	// BaseInterval is the interval while anything is changing, and the
+	// default `daemon.scan_interval` sets.
 	BaseInterval = 2 * time.Second
+	// MinScanInterval is the floor `daemon.scan_interval` may be set to. One
+	// scan is an `lsof`/`ss`/`netstat` plus a docker round trip; below a
+	// second a machine spends more of itself being measured than run.
+	MinScanInterval = 1 * time.Second
 	// MaxInterval caps the backoff on unchanged scans while the daemon is
-	// serving RPC reads only.
+	// serving RPC reads only. The constant is the ceiling at the default
+	// base; a configured base scales it by IdleMaxFactor.
 	MaxInterval = 10 * time.Second
 	// SubscribedMaxInterval caps the backoff while at least one subscriber is
-	// connected, so a live view never lags a change by more than this.
+	// connected, so a live view never lags a change by more than this. Like
+	// MaxInterval it is the ceiling at the default base, scaled by
+	// SubscribedMaxFactor.
 	SubscribedMaxInterval = 5 * time.Second
+	// SubscribedMaxFactor and IdleMaxFactor scale the two ceilings with the
+	// base interval, so `daemon.scan_interval` moves the whole adaptive curve
+	// rather than only its floor. At the 2 s default they reproduce
+	// SubscribedMaxInterval and MaxInterval exactly.
+	SubscribedMaxFactor = 2.5
+	IdleMaxFactor       = 5
 	// BackoffFactor multiplies the interval after an unchanged scan.
 	BackoffFactor = 1.5
 	// CacheTTL is how long an RPC read may reuse the last scan.
@@ -147,6 +161,13 @@ type Options struct {
 	// inject a fake; production leaves it nil and gets ports.SampleProcStats.
 	SampleStats func(pids []int) map[int]ports.ProcSample
 
+	// ScanInterval overrides the base port-scan cadence
+	// (`daemon.scan_interval`): the interval used while something is changing
+	// and the floor the backoff returns to. Zero means BaseInterval; anything
+	// below MinScanInterval is clamped to it. Both backoff ceilings scale
+	// with it, so the adaptive shape is the same whatever the base.
+	ScanInterval time.Duration
+
 	// StatsInterval overrides the stats-only tick's cadence
 	// (`daemon.stats_interval`). Zero means StatsInterval; anything below
 	// MinStatsInterval is clamped to it.
@@ -160,6 +181,10 @@ type Options struct {
 type Loop struct {
 	opts Options
 	now  func() time.Time
+	// base is the resolved `daemon.scan_interval`: the cadence while
+	// something is changing and the floor the backoff returns to. It is fixed
+	// at construction, so nothing locks to read it.
+	base time.Duration
 
 	wake chan struct{}
 	// statsWake unparks the stats-only tick when a subscriber connects. It is
@@ -291,16 +316,31 @@ func New(opts Options) *Loop {
 	if now == nil {
 		now = time.Now
 	}
+	base := resolveScanInterval(opts.ScanInterval)
 	return &Loop{
 		opts:      opts,
 		now:       now,
+		base:      base,
 		wake:      make(chan struct{}, 1),
 		statsWake: make(chan struct{}, 1),
 		runGate:   make(chan struct{}, 1),
 		rpcGate:   make(chan struct{}, 1),
 		orderGate: make(chan struct{}, 1),
-		interval:  BaseInterval,
+		interval:  base,
 	}
+}
+
+// resolveScanInterval clamps a configured base scan interval. Zero (the unset
+// case) means BaseInterval; there is no "off", because the loop already parks
+// itself whenever nothing is subscribed.
+func resolveScanInterval(d time.Duration) time.Duration {
+	if d <= 0 {
+		return BaseInterval
+	}
+	if d < MinScanInterval {
+		return MinScanInterval
+	}
+	return d
 }
 
 // lock takes one of the loop's channel mutexes and waits as long as it takes.
@@ -525,7 +565,7 @@ func (l *Loop) Run(ctx context.Context) {
 			wait = l.dueIn()
 		}
 		if wait <= 0 {
-			wait = BaseInterval
+			wait = l.base
 		}
 
 		if !timer.Stop() {
@@ -542,7 +582,7 @@ func (l *Loop) Run(ctx context.Context) {
 		case <-l.wake:
 			// A read or a new subscriber: back to the base interval.
 			l.mu.Lock()
-			l.interval = BaseInterval
+			l.interval = l.base
 			l.mu.Unlock()
 		}
 	}
@@ -740,7 +780,7 @@ func (l *Loop) commitScan(c commit) (next, prev state.Snapshot, changed bool) {
 			// off.
 			next.Seq = prev.Seq
 			l.snap = next
-			l.interval = backoff(l.interval, l.maxIntervalLocked())
+			l.interval = backoff(l.interval, l.base, l.maxIntervalLocked())
 			return next, prev, false
 		}
 		// Only the machine's own load moved. It is published — host load is
@@ -753,7 +793,7 @@ func (l *Loop) commitScan(c commit) (next, prev state.Snapshot, changed bool) {
 		l.seq++
 		next.Seq = l.seq
 		l.snap = next
-		l.interval = backoff(l.interval, l.maxIntervalLocked())
+		l.interval = backoff(l.interval, l.base, l.maxIntervalLocked())
 		return next, prev, true
 	}
 
@@ -761,7 +801,7 @@ func (l *Loop) commitScan(c commit) (next, prev state.Snapshot, changed bool) {
 	next.Seq = l.seq
 	l.snap = next
 	l.haveSnap = true
-	l.interval = BaseInterval
+	l.interval = l.base
 	return next, prev, true
 }
 
@@ -873,25 +913,26 @@ func (l *Loop) healthDue() bool {
 	return l.lastHealthAt.IsZero() || l.now().Sub(l.lastHealthAt) >= HealthCadence
 }
 
-// maxIntervalLocked is the ceiling the backoff may reach right now: 5 s while
-// anyone is subscribed, so a live view never lags a change by more than that,
-// and the full 10 s when the daemon only answers RPC reads. Caller holds the
-// mutex.
+// maxIntervalLocked is the ceiling the backoff may reach right now: 2.5x the
+// base while anyone is subscribed, so a live view never lags a change by more
+// than that, and 5x when the daemon only answers RPC reads. At the default 2 s
+// base those are the 5 s and 10 s of the spec. Caller holds the mutex.
 func (l *Loop) maxIntervalLocked() time.Duration {
+	factor := float64(IdleMaxFactor)
 	if l.subs > 0 {
-		return SubscribedMaxInterval
+		factor = SubscribedMaxFactor
 	}
-	return MaxInterval
+	return time.Duration(float64(l.base) * factor)
 }
 
-// backoff multiplies the interval by 1.5, capped at max.
-func backoff(d, max time.Duration) time.Duration {
+// backoff multiplies the interval by 1.5, floored at base and capped at max.
+func backoff(d, base, max time.Duration) time.Duration {
 	next := time.Duration(float64(d) * BackoffFactor)
 	if next > max {
 		return max
 	}
-	if next < BaseInterval {
-		return BaseInterval
+	if next < base {
+		return base
 	}
 	return next
 }
@@ -1284,10 +1325,18 @@ func (l *Loop) snapHasStats() bool {
 // Status is what `daemon.status` reports about the scanner.
 type Status struct {
 	LastScanAt time.Time
+	// IntervalMs is the adaptive cadence right now: somewhere between the
+	// base and whichever ceiling currently applies.
 	IntervalMs int
-	Scans      int64
-	Seq        uint64
-	LastError  error
+	// BaseIntervalMs and StatsIntervalMs are the effective settings behind
+	// it: `daemon.scan_interval` and `daemon.stats_interval` after clamping.
+	// Both are fixed for the life of the daemon, so `daemon.status` is where
+	// you check that an edit to the config file took.
+	BaseIntervalMs  int
+	StatsIntervalMs int
+	Scans           int64
+	Seq             uint64
+	LastError       error
 }
 
 // Status returns the scanner's current counters.
@@ -1295,10 +1344,12 @@ func (l *Loop) Status() Status {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return Status{
-		LastScanAt: l.lastScanAt,
-		IntervalMs: int(l.interval / time.Millisecond),
-		Scans:      l.scans,
-		Seq:        l.seq,
-		LastError:  l.lastErr,
+		LastScanAt:      l.lastScanAt,
+		IntervalMs:      int(l.interval / time.Millisecond),
+		BaseIntervalMs:  int(l.base / time.Millisecond),
+		StatsIntervalMs: int(l.statsInterval() / time.Millisecond),
+		Scans:           l.scans,
+		Seq:             l.seq,
+		LastError:       l.lastErr,
 	}
 }

--- a/internal/scanner/loop_test.go
+++ b/internal/scanner/loop_test.go
@@ -47,7 +47,7 @@ func TestBackoffSequence(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := BaseInterval
 			for i, w := range tt.want {
-				got = backoff(got, tt.max)
+				got = backoff(got, BaseInterval, tt.max)
 				if got != w {
 					t.Fatalf("backoff step %d = %s, want %s", i+1, got, w)
 				}
@@ -57,7 +57,7 @@ func TestBackoffSequence(t *testing.T) {
 }
 
 func TestBackoffNeverDropsBelowBase(t *testing.T) {
-	if got := backoff(time.Millisecond, MaxInterval); got != BaseInterval {
+	if got := backoff(time.Millisecond, BaseInterval, MaxInterval); got != BaseInterval {
 		t.Errorf("backoff(1ms) = %s, want the base interval %s", got, BaseInterval)
 	}
 }
@@ -337,4 +337,106 @@ func TestLoopParksWithNoSubscribers(t *testing.T) {
 // collector reports live cpu, which changes on nearly every tick.
 func fixedHost(context.Context) (state.Host, error) {
 	return state.Host{Kernel: "test-kernel", OS: "testos", Arch: "testarch"}, nil
+}
+
+// TestConfiguredScanIntervalMovesTheWholeCurve is `daemon.scan_interval`: the
+// value sets the base, and the two ceilings scale with it, so a daemon told to
+// scan every 5 s backs off to 12.5 s with a subscriber and 25 s without one
+// rather than to the constants that belong to the 2 s default.
+func TestConfiguredScanIntervalMovesTheWholeCurve(t *testing.T) {
+	subs := 1
+	l := New(Options{
+		HostStats:    fixedHost,
+		ScanInterval: 5 * time.Second,
+		Demand:       func() (int, Include) { return subs, Include{} },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 1}}, nil
+		},
+	})
+
+	l.scanAndPublish(Include{})
+	if got, want := l.Status().IntervalMs, 5000; got != want {
+		t.Fatalf("after the first scan interval = %dms, want the configured base %dms", got, want)
+	}
+
+	for i := 0; i < 20; i++ {
+		l.scanAndPublish(Include{})
+	}
+	if got, want := l.Status().IntervalMs, 12500; got != want {
+		t.Errorf("subscribed cap = %dms, want %dms (%v x the base)", got, want, SubscribedMaxFactor)
+	}
+
+	subs = 0
+	for i := 0; i < 20; i++ {
+		l.scanAndPublish(Include{})
+	}
+	if got, want := l.Status().IntervalMs, 25000; got != want {
+		t.Errorf("idle cap = %dms, want %dms (%d x the base)", got, want, IdleMaxFactor)
+	}
+}
+
+// TestConfiguredScanIntervalPacesTheTick: the interval the loop waits out
+// between ticks is the configured base, not the 2 s constant. The clock is
+// injected so the assertion is about the cadence rather than about how long
+// the test was willing to sleep.
+func TestConfiguredScanIntervalPacesTheTick(t *testing.T) {
+	frozen := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	now := frozen
+	l := New(Options{
+		HostStats:    fixedHost,
+		ScanInterval: 6 * time.Second,
+		Now:          func() time.Time { return now },
+		Demand:       func() (int, Include) { return 1, Include{} },
+		Scan: func(Include) ([]ports.ListeningPort, error) {
+			return []ports.ListeningPort{{Port: 3000, BindAddress: "127.0.0.1", PID: 1}}, nil
+		},
+	})
+
+	l.scanAndPublish(Include{})
+	if got := l.dueIn(); got != 6*time.Second {
+		t.Fatalf("dueIn right after a scan = %s, want the configured base 6s", got)
+	}
+	now = frozen.Add(5 * time.Second)
+	if got := l.dueIn(); got != time.Second {
+		t.Errorf("dueIn 5s into a 6s base = %s, want 1s", got)
+	}
+	now = frozen.Add(6 * time.Second)
+	if got := l.dueIn(); got > 0 {
+		t.Errorf("dueIn once the base has elapsed = %s, want a scan to be due", got)
+	}
+}
+
+// A scan_interval below the floor is clamped rather than honoured: a daemon
+// asked to scan every 10ms would spend the machine on `lsof`.
+func TestScanIntervalIsClampedToTheFloor(t *testing.T) {
+	l := New(Options{HostStats: fixedHost, ScanInterval: 10 * time.Millisecond})
+	if got, want := l.Status().BaseIntervalMs, int(MinScanInterval/time.Millisecond); got != want {
+		t.Errorf("base = %dms, want the %dms floor", got, want)
+	}
+}
+
+// TestStatusReportsTheEffectiveIntervals: both cadences are read once at
+// startup, so `daemon.status` is the only way to tell what a running daemon
+// actually settled on.
+func TestStatusReportsTheEffectiveIntervals(t *testing.T) {
+	l := New(Options{
+		HostStats:     fixedHost,
+		ScanInterval:  3 * time.Second,
+		StatsInterval: 500 * time.Millisecond,
+	})
+	st := l.Status()
+	if st.BaseIntervalMs != 3000 {
+		t.Errorf("BaseIntervalMs = %d, want 3000", st.BaseIntervalMs)
+	}
+	if st.StatsIntervalMs != 500 {
+		t.Errorf("StatsIntervalMs = %d, want 500", st.StatsIntervalMs)
+	}
+
+	def := New(Options{HostStats: fixedHost}).Status()
+	if def.BaseIntervalMs != int(BaseInterval/time.Millisecond) {
+		t.Errorf("default BaseIntervalMs = %d, want %d", def.BaseIntervalMs, BaseInterval/time.Millisecond)
+	}
+	if def.StatsIntervalMs != int(StatsInterval/time.Millisecond) {
+		t.Errorf("default StatsIntervalMs = %d, want %d", def.StatsIntervalMs, StatsInterval/time.Millisecond)
+	}
 }


### PR DESCRIPTION
Adds `daemon.scan_interval` (base cadence, default 2 s, floor 1 s) next to `stats_interval`; the adaptive backoff caps scale with it (2.5× subscribed, 5× idle). `daemon.status` gains `scan_base_interval_ms` and `stats_interval_ms`. Applied on restart, like the other daemon keys. Contract §47.