### PR TITLE
fix: scope the test leak gate to this runs own temp root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,15 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # A runner has one checkout and one suite, so the leak gate takes the wide
+      # net: any `sonar serve` from anywhere under the temp directory, not only
+      # the ones this run built. A developer's machine runs several worktrees
+      # at once and must not have it.
       - name: Test
         if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
         run: go test ./...
+        env:
+          SONAR_TESTENV_GATE_ALL: "1"
 
       - name: Build
         run: go build ./...
@@ -67,13 +73,19 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # See the note on the build job's test step: on a runner the leak gate
+      # may match every daemon under the temp directory, not only this run's.
       - name: Integration tests
         run: go test -tags integration -timeout 10m ./internal/daemon/...
+        env:
+          SONAR_TESTENV_GATE_ALL: "1"
 
       # The relay ships in the same binary, so a change that breaks
       # `sonar relay serve` has to fail here rather than at tag time.
       - name: Relay integration tests
         run: go test -tags integration -timeout 10m ./internal/relay/...
+        env:
+          SONAR_TESTENV_GATE_ALL: "1"
 
   schema:
     name: Protocol schema up to date

--- a/README.md
+++ b/README.md
@@ -624,6 +624,14 @@ Environment overrides that have no config key: `SONAR_DB`, `SONAR_SOCKET`,
 `SONAR_NO_AUTOSTART=1` to stop any sonar client from starting a daemon it did
 not find — useful in CI, where a build should never leave a process behind.
 
+sonar's own test suite sets `SONAR_NO_AUTOSTART=1` for every test binary and,
+after the run, looks for a daemon that outlived it. That gate only claims a
+`serve` started from the run's private temp root, so two suites running side by
+side on one machine leave each other's daemons alone;
+`SONAR_TESTENV_GATE_ALL=1` widens it back to every `sonar serve` anywhere under
+the temp directory, which is what a CI runner that owns the whole machine
+wants.
+
 ### Agents: MCP, skills and hooks
 
 ```sh

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -35,8 +35,12 @@ import (
 )
 
 // buildBinary compiles the sonar CLI once per test run.
+// The binary goes under testenv.Root(): the leak gate only claims a `serve`
+// whose executable lives inside this run's own temp root, so a daemon this
+// harness starts has to be built there to be recognised — and one another run
+// built has to be somewhere else to be left alone.
 var buildBinary = sync.OnceValues(func() (string, error) {
-	dir, err := os.MkdirTemp("", "sonar-itest-bin")
+	dir, err := os.MkdirTemp(testenv.Root(), "sonar-itest-bin")
 	if err != nil {
 		return "", err
 	}

--- a/internal/mcpserver/integration_test.go
+++ b/internal/mcpserver/integration_test.go
@@ -408,8 +408,12 @@ func (s *stderrSink) Write(p []byte) (int, error) {
 
 var pipeSeq atomic.Int64
 
+// The binary goes under testenv.Root(): the leak gate only claims a `serve`
+// whose executable lives inside this run's own temp root, so a daemon this
+// harness starts has to be built there to be recognised — and one another run
+// built has to be somewhere else to be left alone.
 var buildSonar = sync.OnceValues(func() (string, error) {
-	dir, err := os.MkdirTemp("", "sonar-mcp-itest-bin")
+	dir, err := os.MkdirTemp(testenv.Root(), "sonar-mcp-itest-bin")
 	if err != nil {
 		return "", err
 	}

--- a/internal/remote/ssh_integration_test.go
+++ b/internal/remote/ssh_integration_test.go
@@ -31,8 +31,12 @@ import (
 )
 
 // buildBinary compiles the sonar CLI once per test run.
+// The binary goes under testenv.Root(): the leak gate only claims a `serve`
+// whose executable lives inside this run's own temp root, so a daemon this
+// harness starts has to be built there to be recognised — and one another run
+// built has to be somewhere else to be left alone.
 var buildBinary = sync.OnceValues(func() (string, error) {
-	dir, err := os.MkdirTemp("", "sonar-remote-itest-bin")
+	dir, err := os.MkdirTemp(testenv.Root(), "sonar-remote-itest-bin")
 	if err != nil {
 		return "", err
 	}

--- a/internal/remoteinstall/install_integration_test.go
+++ b/internal/remoteinstall/install_integration_test.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/raskrebs/sonar/internal/testenv"
 )
 
 // testVersion is the release the fake host installs. It is injected into the
@@ -381,8 +383,12 @@ func (h *fakeHost) runScript(t *testing.T, script string) (string, error) {
 
 // buildSonar compiles the CLI once per test run, with the release version this
 // test pretends to be installing baked in.
+// The binary goes under testenv.Root(): the leak gate only claims a `serve`
+// whose executable lives inside this run's own temp root, so a daemon this
+// harness starts has to be built there to be recognised — and one another run
+// built has to be somewhere else to be left alone.
 var buildSonar = sync.OnceValues(func() (string, error) {
-	dir, err := os.MkdirTemp("", "sonar-ri-bin")
+	dir, err := os.MkdirTemp(testenv.Root(), "sonar-ri-bin")
 	if err != nil {
 		return "", err
 	}

--- a/internal/testenv/leaks.go
+++ b/internal/testenv/leaks.go
@@ -21,6 +21,14 @@ import (
 // leak is silent: the parent test passes and the stray process lives on. So
 // every isolated package also *looks*, after its tests have run, and fails the
 // run if anything is still there.
+//
+// What it may look at is bounded by ownership. The gate kills what it finds,
+// so a rule that matched more than this run started would make one suite kill
+// another's daemon and fail that run for a leak it did not cause — which is
+// what "any sonar serve under the temp directory" did on a machine running
+// several worktrees at once. Everything this run starts is under its own temp
+// root (see testenv.Root), and that is the whole of the search space unless
+// SONAR_TESTENV_GATE_ALL=1 says the machine belongs to one suite.
 
 // Daemon is one stray process left behind by this test binary.
 type Daemon struct {
@@ -72,10 +80,17 @@ func RequireNoLeakedDaemons(t testing.TB) {
 }
 
 // LeakedDaemons lists running processes that this test run should have
-// stopped: this test binary running as `serve`, and any `sonar serve` started
-// from a binary the tests built into a temp directory. Nothing installed on
-// the machine matches either shape, so a developer's own daemon is never
-// mistaken for a leak.
+// stopped: this test binary running as `serve`, and anything running `serve`
+// from an executable under this run's own temp root (Root) — which is where
+// the integration harnesses build the real binary they drive. Nothing else is
+// ever a candidate, so neither a developer's installed daemon nor another
+// `go test` sharing the machine can be mistaken for this run's leak.
+//
+// SONAR_TESTENV_GATE_ALL=1 widens the second rule back to any `sonar serve`
+// running from anywhere under the machine's temp directory. That is right on a
+// CI runner, which has one checkout and one suite and would rather over-match
+// than miss a stray daemon, and wrong on a developer's machine, where several
+// worktrees run their suites at once.
 func LeakedDaemons() []Daemon {
 	if runtime.GOOS == "windows" {
 		return nil
@@ -92,13 +107,14 @@ func LeakedDaemons() []Daemon {
 	}
 
 	self := os.Getpid()
+	gateAll := os.Getenv(gateAllEnv) == "1"
 	var leaked []Daemon
 	for _, line := range strings.Split(string(out), "\n") {
 		pid, cmdline, ok := splitPS(line)
 		if !ok || pid == self {
 			continue
 		}
-		if isDaemonOf(exe, cmdline) || isTempBuiltDaemon(cmdline) {
+		if isDaemonOf(exe, cmdline) || isRunRootDaemon(cmdline) || (gateAll && isTempBuiltDaemon(cmdline)) {
 			leaked = append(leaked, Daemon{PID: pid, Command: cmdline})
 		}
 	}
@@ -129,22 +145,61 @@ func splitPS(line string) (int, string, bool) {
 // the file name would let one package's gate fail on another package's
 // process — which is a flaky gate, and a flaky gate gets deleted.
 func isDaemonOf(exe, cmdline string) bool {
-	rest, ok := strings.CutPrefix(cmdline, exe+" ")
-	if !ok {
-		return false
-	}
-	fields := strings.Fields(rest)
-	return len(fields) > 0 && fields[0] == "serve"
+	path, ok := splitServe(cmdline)
+	return ok && path == exe
+}
+
+// isRunRootDaemon reports whether cmdline is a `serve` whose executable lives
+// under this run's temp root. Only this run puts anything there, so the name
+// of the binary does not have to be checked and another run's daemon can never
+// match.
+func isRunRootDaemon(cmdline string) bool {
+	path, ok := splitServe(cmdline)
+	return ok && runRoot != "" && under(path, runRoot)
 }
 
 // isTempBuiltDaemon reports whether cmdline is a `sonar serve` running from a
-// binary under the temp directory — which only the integration harnesses, who
-// build one there, ever produce.
+// binary anywhere under the machine's temp directory. It is the opt-in
+// machine-wide net, and it deliberately catches other runs' daemons too.
 func isTempBuiltDaemon(cmdline string) bool {
-	fields := strings.Fields(cmdline)
-	if len(fields) < 2 || fields[1] != "serve" {
+	path, ok := splitServe(cmdline)
+	if !ok {
 		return false
 	}
-	name := strings.TrimSuffix(strings.ToLower(filepath.Base(fields[0])), ".exe")
-	return name == "sonar" && under(fields[0], os.TempDir())
+	name := strings.TrimSuffix(strings.ToLower(filepath.Base(path)), ".exe")
+	return name == "sonar" && under(path, machineTempDir())
+}
+
+// machineTempDir is the temp directory the machine had before Isolate pointed
+// TMPDIR at this run's root.
+func machineTempDir() string {
+	if realTemp != "" {
+		return realTemp
+	}
+	return os.TempDir()
+}
+
+// splitServe returns the executable path of a `ps` command line whose first
+// argument is `serve`, and reports whether it had that shape.
+//
+// `ps -axo command=` joins argv with single spaces and quotes nothing, so a
+// path containing spaces cannot be recovered by splitting on whitespace: an
+// executable at "/tmp/my dir/sonar" would look like the two arguments
+// "/tmp/my" and "dir/sonar". What can be recovered is the boundary — the
+// executable is everything before the first " serve" that stands as a whole
+// argument rather than as part of a longer one.
+func splitServe(cmdline string) (string, bool) {
+	const arg = " serve"
+	for i := 0; i < len(cmdline); {
+		j := strings.Index(cmdline[i:], arg)
+		if j < 0 {
+			return "", false
+		}
+		j += i
+		if end := j + len(arg); end == len(cmdline) || cmdline[end] == ' ' {
+			return cmdline[:j], true
+		}
+		i = j + 1
+	}
+	return "", false
 }

--- a/internal/testenv/leaks_test.go
+++ b/internal/testenv/leaks_test.go
@@ -1,0 +1,144 @@
+package testenv
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The bug this pins: the gate used to match any `sonar serve` running from
+// anywhere under the machine's temp directory, so a run killed the daemons of
+// every other worktree that was building into a temp directory of its own at
+// the same moment, and failed those runs with a leak they had not caused.
+func TestGateMatchesOnlyThisRunsRoot(t *testing.T) {
+	skipWithoutPS(t)
+
+	// The space in the directory name is the `ps` parsing case: ps quotes
+	// nothing, so a gate that split the command line on whitespace would read
+	// this process as the two arguments "<root>/gate" and "inside/sonar".
+	inside := startFakeDaemon(t, filepath.Join(Root(), "gate inside"))
+	outsideRoot, err := os.MkdirTemp(machineTempDir(), "sonar-gate-outside")
+	if err != nil {
+		t.Fatalf("creating a directory outside this run's root: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(outsideRoot) })
+	outside := startFakeDaemon(t, outsideRoot)
+
+	t.Setenv(gateAllEnv, "")
+	leaked := LeakedDaemons()
+	if !hasPID(leaked, inside) {
+		t.Errorf("the gate missed pid %d, a `serve` under this run's root %s: %v", inside, Root(), leaked)
+	}
+	if hasPID(leaked, outside) {
+		t.Errorf("the gate claimed pid %d, a `sonar serve` outside this run's root %s: %v", outside, Root(), leaked)
+	}
+
+	// CI is one runner with one suite, so it opts back into the wide net.
+	t.Setenv(gateAllEnv, "1")
+	if leaked := LeakedDaemons(); !hasPID(leaked, outside) {
+		t.Errorf("%s=1 did not restore the machine-wide match for pid %d: %v", gateAllEnv, outside, leaked)
+	}
+}
+
+// Every child of the test process writes its temp files into this run's root,
+// which is what makes the gate's ownership rule true of the binaries the
+// integration harnesses build with `go build -o`.
+func TestChildrenInheritTheRunRootAsTMPDIR(t *testing.T) {
+	if !sameDir(os.TempDir(), Root()) {
+		t.Fatalf("os.TempDir() = %s, want this run's root %s", os.TempDir(), Root())
+	}
+	RequireIsolated(t, t.TempDir())
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("finding this test binary: %v", err)
+	}
+	cmd := exec.Command(self)
+	cmd.Env = append(os.Environ(), helperEnv+"="+helperTempDir)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("asking a child process for its temp directory: %v", err)
+	}
+	if !sameDir(string(out), Root()) {
+		t.Errorf("a child process resolved its temp directory to %s, want %s", out, Root())
+	}
+}
+
+// startFakeDaemon runs a process that looks to `ps` exactly like a leaked
+// daemon — a binary named sonar in dir, with `serve` as its first argument —
+// and returns its pid. It is this test binary under another name, told by the
+// environment to sit still rather than run the suite.
+func startFakeDaemon(t *testing.T, dir string) int {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", dir, err)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("finding this test binary: %v", err)
+	}
+	bin := filepath.Join(dir, "sonar")
+	if err := clone(self, bin); err != nil {
+		t.Fatalf("putting a stand-in binary at %s: %v", bin, err)
+	}
+
+	cmd := exec.Command(bin, "serve")
+	cmd.Env = append(os.Environ(), helperEnv+"="+helperServe)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("opening the stand-in's stdin: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting the stand-in daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// clone puts a runnable copy of src at dst, by link where the filesystem
+// allows it because the test binary is not small.
+func clone(src, dst string) error {
+	if err := os.Link(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func hasPID(daemons []Daemon, pid int) bool {
+	for _, d := range daemons {
+		if d.PID == pid {
+			return true
+		}
+	}
+	return false
+}
+
+func skipWithoutPS(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the leak gate reads ps, which Windows does not have")
+	}
+	if _, err := exec.LookPath("ps"); err != nil {
+		t.Skipf("no ps on this machine: %v", err)
+	}
+}

--- a/internal/testenv/main_test.go
+++ b/internal/testenv/main_test.go
@@ -1,8 +1,37 @@
 package testenv
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"testing"
+	"time"
 )
 
-func TestMain(m *testing.M) { os.Exit(Run(m)) }
+// helperEnv turns this binary into a stand-in child process rather than a test
+// run. The leak-gate tests need a process that looks to `ps` exactly like a
+// leaked daemon — argv[0] a binary called sonar, argv[1] "serve" — and the
+// TMPDIR test needs a child that reports the temp directory it inherited.
+const helperEnv = "SONAR_TESTENV_HELPER"
+
+// Helper modes.
+const (
+	helperTempDir = "tmpdir"
+	helperServe   = "serve"
+)
+
+func TestMain(m *testing.M) {
+	switch os.Getenv(helperEnv) {
+	case "":
+	case helperTempDir:
+		fmt.Print(os.TempDir())
+		os.Exit(0)
+	case helperServe:
+		// Alive until the parent closes our stdin, and never past the suite: a
+		// stand-in for a leaked daemon must not turn into one.
+		time.AfterFunc(2*time.Minute, func() { os.Exit(0) })
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		os.Exit(0)
+	}
+	os.Exit(Run(m))
+}

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -14,6 +14,12 @@
 // TestMain, and from then on nothing in that binary can find the real install
 // even if it tries.
 //
+// A run also gets a private root under the machine's temp directory, which
+// becomes its TMPDIR (Root). t.TempDir, os.CreateTemp and a harness that
+// builds the real binary with `go build -o` therefore all write inside it, and
+// the leak gate can name the daemons this run is responsible for without
+// touching another `go test` running beside it on the same machine.
+//
 // Usage:
 //
 //	func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }
@@ -48,14 +54,20 @@ const (
 	socketEnv      = "SONAR_SOCKET"
 	dbEnv          = "SONAR_DB"
 	allowTestEnv   = "SONAR_ALLOW_TEST_DAEMON"
+	gateAllEnv     = "SONAR_TESTENV_GATE_ALL"
 )
 
-// root is the isolated HOME, and sockRoot the short directory holding the
-// socket. They are set once, by Isolate, before any test runs.
+// runRoot is this run's private directory under the machine's temp directory
+// and the TMPDIR every child inherits; home is the isolated HOME inside it,
+// and sockRoot the short directory holding the socket. realTemp is the
+// machine's temp directory as it was before runRoot displaced it. They are set
+// once, by Isolate, before any test runs.
 var (
-	root     string
+	runRoot  string
+	home     string
 	sockRoot string
 	realHome string
+	realTemp string
 )
 
 // Run isolates the process, runs the tests, and fails the run if the suite
@@ -82,19 +94,32 @@ func Run(m *testing.M) int {
 // developer's real install, and there is no test result worth that.
 func Isolate() func() {
 	realHome, _ = os.UserHomeDir()
+	realTemp = os.TempDir()
 	preserveGoEnv()
 
-	home, err := os.MkdirTemp("", "sonar-testhome")
+	// One root per run, and TMPDIR points at it, so t.TempDir, os.CreateTemp and
+	// a harness `go build -o` all land in a directory this run owns. That
+	// ownership is what lets the leak gate tell a daemon this run started from
+	// one another `go test` on the same machine is still using: every run
+	// shares os.TempDir(), and a gate that matched all of it killed its
+	// neighbours.
+	//
+	// The names are terse because they are a prefix of every socket path, and
+	// macOS caps a unix socket at about 104 bytes.
+	run, err := os.MkdirTemp("", "snrun")
 	if err != nil {
-		die("creating an isolated HOME: %v", err)
+		die("creating this run's temp root: %v", err)
 	}
-	// Not under home: macOS caps a unix socket path at about 104 bytes and
-	// "<tmp>/sonar-testhome<random>/.config/sonar/daemon.sock" is over it.
-	sock, err := os.MkdirTemp("", "snrt")
-	if err != nil {
+	runRoot = run
+	setTempDir(run)
+
+	// The socket directory is a sibling of HOME rather than a child: macOS caps
+	// a unix socket path at about 104 bytes and
+	// "<run>/h/.config/sonar/daemon.sock" leaves too little room.
+	home, sockRoot = filepath.Join(run, "h"), filepath.Join(run, "s")
+	if err := os.MkdirAll(sockRoot, 0o700); err != nil {
 		die("creating an isolated socket directory: %v", err)
 	}
-	root, sockRoot = home, sock
 
 	configDir := filepath.Join(home, ".config", "sonar")
 	if err := os.MkdirAll(configDir, 0o700); err != nil {
@@ -109,7 +134,7 @@ func Isolate() func() {
 	set("XDG_CONFIG_HOME", filepath.Join(home, ".config")) // freedesktop
 	set("XDG_RUNTIME_DIR", filepath.Join(home, "run"))     // outranks HOME for the socket
 	set(dbEnv, filepath.Join(configDir, "sonar.db"))
-	set(socketEnv, socketPath(sock))
+	set(socketEnv, socketPath(sockRoot))
 	set(noAutostartEnv, "1")
 	// A leftover opt-in from the developer's shell must not disarm the guard
 	// that keeps a test binary from becoming a daemon.
@@ -124,12 +149,23 @@ func Isolate() func() {
 		die("HOME is still %s; refusing to run tests against the live install", realHome)
 	}
 	if !Isolated(configDir) {
-		die("the isolated config directory %s is not under %s", configDir, os.TempDir())
+		die("the isolated config directory %s is not under %s", configDir, runRoot)
+	}
+	if !sameDir(os.TempDir(), runRoot) {
+		die("os.TempDir() is %s, not this run's root %s", os.TempDir(), runRoot)
 	}
 
-	return func() {
-		os.RemoveAll(home)
-		os.RemoveAll(sock)
+	return func() { os.RemoveAll(runRoot) }
+}
+
+// setTempDir makes dir the temp directory of this process and of every child
+// it spawns, so that everything a test writes outside its own HOME still lands
+// in a directory this run owns.
+func setTempDir(dir string) {
+	set("TMPDIR", dir) // unix, and what os.TempDir reads there
+	if os.PathSeparator == '\\' {
+		set("TMP", dir) // windows, in the order os.TempDir consults them
+		set("TEMP", dir)
 	}
 }
 
@@ -164,8 +200,13 @@ func setDefault(key, value string) {
 	}
 }
 
-// Root is the isolated HOME. It is empty before Isolate runs.
-func Root() string { return root }
+// Root is this run's private temp root: the directory TMPDIR points at while
+// the tests run, and the one a harness building a binary should build into so
+// the leak gate recognises what it starts. It is empty before Isolate runs.
+func Root() string { return runRoot }
+
+// Home is the isolated HOME, inside Root.
+func Home() string { return home }
 
 // RealHome is the home directory this run displaced: the one the developer's
 // live sonar install lives in. Isolate is the only chance to read it, because
@@ -173,9 +214,9 @@ func Root() string { return root }
 func RealHome() string { return realHome }
 
 // ConfigDir is the isolated ~/.config/sonar.
-func ConfigDir() string { return filepath.Join(root, ".config", "sonar") }
+func ConfigDir() string { return filepath.Join(home, ".config", "sonar") }
 
-// Isolated reports whether path lies inside this run's temp directories. It is
+// Isolated reports whether path lies inside this run's own temp root. It is
 // what a package's own TestMain uses to check the real resolvers agree:
 //
 //	if !testenv.Isolated(config.Path(), store.Path(), daemon.SocketPath()) { ... }
@@ -184,21 +225,21 @@ func Isolated(paths ...string) bool {
 		return false
 	}
 	for _, p := range paths {
-		if p == "" || !(under(p, root) || under(p, sockRoot) || under(p, os.TempDir())) {
+		if p == "" || !under(p, runRoot) {
 			return false
 		}
 	}
 	return true
 }
 
-// RequireIsolated fails the test unless every path is inside this run's temp
-// directories.
+// RequireIsolated fails the test unless every path is inside this run's own
+// temp root.
 func RequireIsolated(t testing.TB, paths ...string) {
 	t.Helper()
 	for _, p := range paths {
 		if !Isolated(p) {
 			t.Fatalf("%s is outside the isolated test environment (HOME=%s, TMPDIR=%s)",
-				p, root, os.TempDir())
+				p, home, runRoot)
 		}
 	}
 }

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -12,14 +12,14 @@ func TestIsolateMovesEverythingIntoTempDir(t *testing.T) {
 	if Root() == "" {
 		t.Fatal("Isolate did not run before the tests")
 	}
-	RequireIsolated(t, Root(), ConfigDir(), os.Getenv("HOME"), os.Getenv("SONAR_DB"))
+	RequireIsolated(t, Home(), ConfigDir(), os.Getenv("HOME"), os.Getenv("SONAR_DB"))
 
 	real, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatalf("resolving the home directory: %v", err)
 	}
-	if real != Root() {
-		t.Fatalf("os.UserHomeDir() = %s, want the isolated %s", real, Root())
+	if real != Home() {
+		t.Fatalf("os.UserHomeDir() = %s, want the isolated %s", real, Home())
 	}
 	if _, err := os.Stat(ConfigDir()); err != nil {
 		t.Errorf("the isolated config directory is not there: %v", err)
@@ -58,10 +58,15 @@ func TestIsolatedRejectsPathsOutside(t *testing.T) {
 	if Isolated("/etc/passwd") {
 		t.Error("/etc/passwd counted as isolated")
 	}
+	// Another run's directory is under the same machine temp directory and is
+	// no more this run's business than /etc is.
+	if Isolated(filepath.Join(machineTempDir(), "snrun-some-other-run")) {
+		t.Error("another run's temp directory counted as isolated")
+	}
 	if Isolated() {
 		t.Error("no paths at all counted as isolated")
 	}
-	if !Isolated(filepath.Join(Root(), ".config", "sonar", "sonar.db")) {
+	if !Isolated(filepath.Join(Home(), ".config", "sonar", "sonar.db")) {
 		t.Error("a path under the isolated HOME did not count as isolated")
 	}
 }
@@ -93,8 +98,31 @@ func TestIsDaemonOf(t *testing.T) {
 	}
 }
 
+// isRunRootDaemon is the default second rule: anything under this run's root,
+// and nothing else, because nothing else put anything there.
+func TestIsRunRootDaemon(t *testing.T) {
+	inRoot := filepath.Join(Root(), "sonar-itest-bin123", "sonar")
+	if !isRunRootDaemon(inRoot + " serve") {
+		t.Errorf("%s serve was not recognised as this run's daemon", inRoot)
+	}
+	if isRunRootDaemon(inRoot + " list") {
+		t.Error("`sonar list` was mistaken for a daemon")
+	}
+	if isRunRootDaemon("/usr/local/bin/sonar serve") {
+		t.Error("an installed sonar daemon was mistaken for a test leak")
+	}
+	// The whole point: another run's binary is under the machine's temp
+	// directory too, and must not be touched.
+	other := filepath.Join(machineTempDir(), "snrun999", "sonar-itest-bin", "sonar")
+	if isRunRootDaemon(other + " serve") {
+		t.Errorf("%s serve, which belongs to another test run, matched", other)
+	}
+}
+
+// The opt-in wide net for CI keeps the old shape: any `sonar serve` from
+// anywhere under the machine's temp directory.
 func TestIsTempBuiltDaemon(t *testing.T) {
-	inTemp := filepath.Join(os.TempDir(), "sonar-itest-bin123", "sonar")
+	inTemp := filepath.Join(machineTempDir(), "sonar-itest-bin123", "sonar")
 	if !isTempBuiltDaemon(inTemp + " serve") {
 		t.Errorf("%s serve was not recognised as a test-built daemon", inTemp)
 	}
@@ -103,6 +131,34 @@ func TestIsTempBuiltDaemon(t *testing.T) {
 	}
 	if isTempBuiltDaemon(inTemp + " list") {
 		t.Error("`sonar list` was mistaken for a daemon")
+	}
+}
+
+// `ps -axo command=` joins argv with spaces and quotes nothing, so the
+// executable of a `serve` has to be found by the argument boundary rather than
+// by splitting on whitespace.
+func TestSplitServe(t *testing.T) {
+	tests := []struct {
+		cmdline string
+		want    string
+		ok      bool
+	}{
+		{"/tmp/x/sonar serve", "/tmp/x/sonar", true},
+		{"/tmp/x/sonar serve --detach", "/tmp/x/sonar", true},
+		{"/tmp/my dir/sonar serve --detach", "/tmp/my dir/sonar", true},
+		// A directory called "serve" is not the argument.
+		{"/tmp/a serve/sonar serve", "/tmp/a serve/sonar", true},
+		{"/tmp/x/sonar serveall", "", false},
+		{"/tmp/x/sonar list", "", false},
+		{"/tmp/x/sonar", "", false},
+		{"serve", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := splitServe(tt.cmdline)
+		if got != tt.want || ok != tt.ok {
+			t.Errorf("splitServe(%q) = (%q, %v), want (%q, %v)", tt.cmdline, got, ok, tt.want, tt.ok)
+		}
 	}
 }
 


### PR DESCRIPTION
Each test run gets its own temp root exported as TMPDIR; the after-run leak gate matches only the test binary itself and daemons whose executable lives under that root, so parallel suites no longer kill each other. SONAR_TESTENV_GATE_ALL=1 restores machine-wide matching and is set in CI. The ps parser handles paths with spaces.