### PR TITLE
feat: add, rename and remove services through groups.config.set and merge into an existing file with groups.init

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,13 @@ ports: [9229]        # ports that belong to this project without a service
 
 `.sonar.yml` is read if that is how you spell it; `sonar init` always writes
 `.sonar.yaml`. The daemon watches the projects it knows about and picks up
-edits to the file without a restart. When the desktop app edits a service the
-file is re-rendered from its own syntax tree, so comments, key order and layout
-survive — except that extra spaces lining a trailing comment up (`cmd: x     #
-note`) collapse to one, because the YAML library keeps the comment but not its
-column.
+edits to the file without a restart. Every edit sonar makes — from the desktop
+app, from `sonar groups add`, `rename` and `remove`, from an agent — goes
+through the daemon, which re-renders the file from its own syntax tree, so
+comments, key order and layout survive an edit that adds, renames or removes a
+service just as they survive a metadata change. The one exception: extra spaces
+lining a trailing comment up (`cmd: x     # note`) collapse to one, because the
+YAML library keeps the comment but not its column.
 
 ### `sonar up`
 
@@ -279,8 +281,14 @@ already running.
 
 ```sh
 sonar init --dry-run
+sonar init --service api:8000:/healthz --service web:5173
 sonar groups
 sonar groups --json
+
+group=$(basename "$PWD")           # sonar init names the group after the directory
+sonar groups add "$group" worker --port 9000 --cmd 'uv run worker' --depends-on api
+sonar groups rename "$group" worker jobs
+sonar groups remove "$group" jobs
 # check
 ```
 
@@ -293,6 +301,26 @@ that are declared but not running.
 `sonar init` writes a `.sonar.yaml` at the git root from what is listening right
 now — desktop apps and ports below 1024 left out. It refuses to overwrite
 without `--force`, and `--dry-run` prints the file instead of writing it.
+`--merge` appends to a file that is already there instead of refusing, and
+`--service name:port[:health]` — repeatable — writes the services you name
+instead of the ones it found, keeping the command it guessed for a port you
+kept. `--force` and `--merge` are mutually exclusive.
+
+`sonar groups add <group> <name> --port N` appends a service to that group's
+`.sonar.yaml`, with `--cmd`, `--cwd`, `--health`, `--description`, `--icon`,
+`--color` and a repeatable `--depends-on` for the rest of it. `sonar groups
+rename <group> <old> <new>` renames one everywhere in the file, `depends_on`
+references included, and `sonar groups remove <group> <name>` deletes one and
+drops it from every `depends_on` that named it. All three refuse an edit that
+would leave the file invalid — a duplicate name, a port another service already
+claims, a service that is not there — and none of them writes a byte until the
+whole edit is known to be good.
+
+The daemon does the writing, which is why the file comes back with its comments
+and key order intact whether the edit came from the CLI, the desktop app or an
+agent. `sonar groups add`, `rename` and `remove` need the daemon and start it if
+it is not already running; the three names are subcommands, so a group actually
+called `add` is read with `sonar groups --json`.
 
 ### `sonar kill`
 

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -1164,12 +1164,29 @@
             "$ref": "#/definitions/ServiceEdit"
           },
           "type": "array"
+        },
+        "add": {
+          "items": {
+            "$ref": "#/definitions/ServiceAdd"
+          },
+          "type": "array"
+        },
+        "rename": {
+          "items": {
+            "$ref": "#/definitions/ServiceRename"
+          },
+          "type": "array"
+        },
+        "remove": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object",
       "required": [
-        "path",
-        "services"
+        "path"
       ]
     },
     "GroupsConfigSetResult": {
@@ -1211,6 +1228,15 @@
         },
         "force": {
           "type": "boolean"
+        },
+        "merge": {
+          "type": "boolean"
+        },
+        "services": {
+          "items": {
+            "$ref": "#/definitions/ServiceAdd"
+          },
+          "type": "array"
         }
       },
       "type": "object",
@@ -3301,6 +3327,44 @@
         "port_actual"
       ]
     },
+    "ServiceAdd": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "cmd": {
+          "type": "string"
+        },
+        "cwd": {
+          "type": "string"
+        },
+        "health": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "depends_on": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
     "ServiceEdit": {
       "properties": {
         "name": {
@@ -3370,6 +3434,21 @@
         }
       },
       "type": "object"
+    },
+    "ServiceRename": {
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "from",
+        "to"
+      ]
     },
     "Session": {
       "properties": {

--- a/internal/cmd/groups_edit.go
+++ b/internal/cmd/groups_edit.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/spf13/cobra"
+)
+
+// `sonar groups add|rename|remove` are the CLI half of `groups.config.set`
+// (contract §13.2, step 5A.4). The daemon owns every write to a `.sonar.yaml`,
+// so these commands resolve the group to a path and send the edit; nothing here
+// touches the file itself. That is the whole point: the desktop app, the MCP
+// server and the CLI all go through the same handler, so comments and ordering
+// survive an edit whoever made it.
+//
+// Naming these as subcommands of `sonar groups` costs the three names as
+// literal group arguments: `sonar groups add` is the subcommand, so a group
+// actually called `add` is inspected with `sonar groups --json` instead.
+
+var (
+	groupsAddPort        int
+	groupsAddCmdFlag     string
+	groupsAddCwd         string
+	groupsAddHealth      string
+	groupsAddIcon        string
+	groupsAddColor       string
+	groupsAddDescription string
+	groupsAddDependsOn   []string
+	groupsEditJSON       bool
+)
+
+var groupsAddCmd = &cobra.Command{
+	Use:   "add <group> <name>",
+	Short: "Add a service to a group's " + groups.ConfigName,
+	Long: "Appends a service to the group's " + groups.ConfigName + ". The daemon writes\n" +
+		"the file, so its comments and key order survive. A name or a port the\n" +
+		"file already declares is refused.",
+	Args: cobra.ExactArgs(2),
+	RunE: groupsAddRun,
+}
+
+var groupsRenameCmd = &cobra.Command{
+	Use:   "rename <group> <old> <new>",
+	Short: "Rename a service in a group's " + groups.ConfigName,
+	Long: "Renames the service everywhere in the file, depends_on references\n" +
+		"included, so the file stays valid across the rename.",
+	Args: cobra.ExactArgs(3),
+	RunE: groupsRenameRun,
+}
+
+var groupsRemoveCmd = &cobra.Command{
+	Use:     "remove <group> <name>",
+	Aliases: []string{"rm"},
+	Short:   "Remove a service from a group's " + groups.ConfigName,
+	Long: "Removes the service and drops it from every other service's\n" +
+		"depends_on, so the file stays valid.",
+	Args: cobra.ExactArgs(2),
+	RunE: groupsRemoveRun,
+}
+
+func init() {
+	groupsAddCmd.Flags().IntVar(&groupsAddPort, "port", 0, "The `port` the service listens on")
+	groupsAddCmd.Flags().StringVar(&groupsAddCmdFlag, "cmd", "", "The `command` that starts it, for `sonar up`")
+	groupsAddCmd.Flags().StringVar(&groupsAddCwd, "cwd", "", "Working `directory` for the command, relative to the file")
+	groupsAddCmd.Flags().StringVar(&groupsAddHealth, "health", "", "HTTP `path` the daemon polls while it is up")
+	groupsAddCmd.Flags().StringVar(&groupsAddIcon, "icon", "", "Free-form `icon` name for the desktop app")
+	groupsAddCmd.Flags().StringVar(&groupsAddColor, "color", "", "Free-form `color` for the desktop app")
+	groupsAddCmd.Flags().StringVar(&groupsAddDescription, "description", "", "One-line `description` of the service")
+	groupsAddCmd.Flags().StringArrayVar(&groupsAddDependsOn, "depends-on", nil, "A `service` that must start first (repeatable)")
+	if err := groupsAddCmd.MarkFlagRequired("port"); err != nil {
+		panic(err)
+	}
+
+	for _, c := range []*cobra.Command{groupsAddCmd, groupsRenameCmd, groupsRemoveCmd} {
+		c.Flags().BoolVar(&groupsEditJSON, "json", false, "Output as JSON")
+		groupsCmd.AddCommand(c)
+	}
+}
+
+func groupsAddRun(cmd *cobra.Command, args []string) error {
+	name := strings.TrimSpace(args[1])
+	if name == "" {
+		return fmt.Errorf("the service name is empty")
+	}
+	return editConfig(cmd, args[0], groups.ConfigEdit{Add: []groups.ServiceAdd{{
+		Name:        name,
+		Port:        groupsAddPort,
+		Cmd:         strings.TrimSpace(groupsAddCmdFlag),
+		Cwd:         strings.TrimSpace(groupsAddCwd),
+		Health:      strings.TrimSpace(groupsAddHealth),
+		Description: strings.TrimSpace(groupsAddDescription),
+		Icon:        strings.TrimSpace(groupsAddIcon),
+		Color:       strings.TrimSpace(groupsAddColor),
+		DependsOn:   groupsAddDependsOn,
+	}}}, fmt.Sprintf("added %s to %s", display.Bold(name), args[0]))
+}
+
+func groupsRenameRun(cmd *cobra.Command, args []string) error {
+	from, to := strings.TrimSpace(args[1]), strings.TrimSpace(args[2])
+	if from == "" || to == "" {
+		return fmt.Errorf("both the old and the new service name are required")
+	}
+	return editConfig(cmd, args[0], groups.ConfigEdit{Rename: []groups.ServiceRename{{From: from, To: to}}},
+		fmt.Sprintf("%s is now %s in %s", from, display.Bold(to), args[0]))
+}
+
+func groupsRemoveRun(cmd *cobra.Command, args []string) error {
+	name := strings.TrimSpace(args[1])
+	if name == "" {
+		return fmt.Errorf("the service name is empty")
+	}
+	return editConfig(cmd, args[0], groups.ConfigEdit{Remove: []string{name}},
+		fmt.Sprintf("removed %s from %s", display.Bold(name), args[0]))
+}
+
+// editConfig resolves the group to a config path and sends one edit.
+func editConfig(cmd *cobra.Command, group string, edit groups.ConfigEdit, done string) error {
+	name := strings.TrimSpace(group)
+	if name == "" {
+		return fmt.Errorf("a group name is required (`sonar groups` lists them)")
+	}
+	c, err := connectForWrite(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	path, err := configPathForGroup(cmd.Context(), c, name)
+	if err != nil {
+		return err
+	}
+
+	var res rpc.GroupsConfigSetResult
+	if err := c.Call(cmd.Context(), "groups.config.set", rpc.GroupsConfigSetParams{
+		Path:     path,
+		Add:      edit.Add,
+		Rename:   edit.Rename,
+		Remove:   edit.Remove,
+		Services: edit.Services,
+	}, &res); err != nil {
+		return daemonError(err)
+	}
+	if groupsEditJSON {
+		return writeJSON(res)
+	}
+	fmt.Printf("%s (%s)\n", done, shortPath(res.Path))
+	return nil
+}
+
+// configPathForGroup is the `.sonar.yaml` a group name stands for. The daemon
+// answers first, because its index is the authority on which files exist. A
+// project it has never seen a process in is not in that index, so the working
+// directory's own config is the fallback — and only when it carries the name
+// that was asked for, so a mistyped group never silently edits the file you
+// happen to be standing in.
+func configPathForGroup(ctx context.Context, c *client.Client, name string) (string, error) {
+	var got rpc.GroupsConfigGetResult
+	err := c.Call(ctx, "groups.config.get", rpc.GroupsConfigGetParams{Name: &name}, &got)
+	if err == nil {
+		return got.Path, nil
+	}
+	if cfg := localConfig(); cfg != nil && cfg.Name == name {
+		return cfg.Path, nil
+	}
+	return "", daemonError(err)
+}
+
+// localConfig is the `.sonar.yaml` at or above the working directory, or nil.
+func localConfig() *groups.Config {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	index := groups.NewIndex()
+	index.Observe(wd)
+	return index.Nearest(wd)
+}

--- a/internal/cmd/groups_edit_test.go
+++ b/internal/cmd/groups_edit_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/spf13/cobra"
+)
+
+// TestGroupsEditSubcommandsAreWired: the three commands hang off `sonar groups`
+// and take exactly the arguments the README documents.
+func TestGroupsEditSubcommandsAreWired(t *testing.T) {
+	byName := map[string]*cobra.Command{}
+	for _, c := range groupsCmd.Commands() {
+		byName[c.Name()] = c
+	}
+	for _, want := range []string{"add", "rename", "remove"} {
+		if byName[want] == nil {
+			t.Fatalf("`sonar groups %s` is not registered", want)
+		}
+	}
+
+	for _, tc := range []struct {
+		cmd  *cobra.Command
+		good []string
+		bad  [][]string
+	}{
+		{byName["add"], []string{"demo", "worker"}, [][]string{{"demo"}, {"demo", "worker", "extra"}}},
+		{byName["rename"], []string{"demo", "db", "database"}, [][]string{{"demo", "db"}, {"demo"}}},
+		{byName["remove"], []string{"demo", "worker"}, [][]string{{"demo"}, {"demo", "a", "b"}}},
+	} {
+		if err := tc.cmd.Args(tc.cmd, tc.good); err != nil {
+			t.Errorf("%s %v: %v", tc.cmd.Name(), tc.good, err)
+		}
+		for _, bad := range tc.bad {
+			if err := tc.cmd.Args(tc.cmd, bad); err == nil {
+				t.Errorf("%s %v was accepted", tc.cmd.Name(), bad)
+			}
+		}
+	}
+
+	// `sonar groups remove` is what the daemon calls it, but `rm` is what
+	// fingers type.
+	if got := byName["remove"].Aliases; len(got) != 1 || got[0] != "rm" {
+		t.Errorf("remove aliases = %v, want rm", got)
+	}
+	// A port is how a service is found again, so `add` insists on one.
+	if byName["add"].Flags().Lookup("port").Annotations[cobra.BashCompOneRequiredFlag] == nil {
+		t.Error("`sonar groups add` should require --port")
+	}
+}
+
+// TestLocalConfigFindsTheNearestFile is the fallback that lets these commands
+// work in a project the daemon has never seen a process in.
+func TestLocalConfigFindsTheNearestFile(t *testing.T) {
+	dir := t.TempDir()
+	// A git root, because that is how far the resolver walks up: the same rule
+	// `sonar up` follows when it is given no group name.
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, groups.ConfigName), []byte("name: demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(dir, "backend")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+
+	cfg := localConfig()
+	if cfg == nil {
+		t.Fatal("no config found at or above the working directory")
+	}
+	if cfg.Name != "demo" {
+		t.Errorf("config = %+v, want the demo group", cfg)
+	}
+}
+
+// TestLocalConfigIsNilWithoutAFile: the fallback must not invent one.
+func TestLocalConfigIsNilWithoutAFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if cfg := localConfig(); cfg != nil {
+		t.Errorf("localConfig() = %+v, want nil", cfg)
+	}
+}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/raskrebs/sonar/internal/docker"
 	"github.com/raskrebs/sonar/internal/groups"
@@ -12,8 +14,10 @@ import (
 )
 
 var (
-	initForceFlag  bool
-	initDryRunFlag bool
+	initForceFlag   bool
+	initDryRunFlag  bool
+	initMergeFlag   bool
+	initServiceFlag []string
 )
 
 var initCmd = &cobra.Command{
@@ -21,18 +25,29 @@ var initCmd = &cobra.Command{
 	Short: "Write a .sonar.yaml for this project from what is running now",
 	Long: "Proposes a group name and one service per listening port whose process\n" +
 		"works inside this repository, and writes it next to .git. Edit and\n" +
-		"commit the result.",
+		"commit the result, or name the services yourself with --service.",
 	Args: cobra.NoArgs,
 	RunE: initRun,
 }
 
 func init() {
 	initCmd.Flags().BoolVar(&initForceFlag, "force", false, "Overwrite an existing "+groups.ConfigName)
+	initCmd.Flags().BoolVar(&initMergeFlag, "merge", false, "Append to an existing "+groups.ConfigName+" instead of refusing")
 	initCmd.Flags().BoolVar(&initDryRunFlag, "dry-run", false, "Print the proposed file instead of writing it")
+	initCmd.Flags().StringArrayVar(&initServiceFlag, "service", nil,
+		"Write this service instead of the proposal, as `name:port[:health]` (repeatable)")
 	rootCmd.AddCommand(initCmd)
 }
 
 func initRun(cmd *cobra.Command, args []string) error {
+	if initForceFlag && initMergeFlag {
+		return fmt.Errorf("--force and --merge cannot both be given: --force replaces the file, --merge appends to it")
+	}
+	curated, err := parseInitServices(initServiceFlag)
+	if err != nil {
+		return err
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -43,23 +58,29 @@ func initRun(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "note: %s is not inside a git repository; using it as the project root\n", cwd)
 	}
 	target := filepath.Join(root, groups.ConfigName)
+	_, statErr := os.Lstat(target)
+	exists := statErr == nil
 
-	if _, err := os.Lstat(target); err == nil && !initForceFlag && !initDryRunFlag {
-		return fmt.Errorf("%s already exists; pass --force to overwrite it", target)
+	if exists && !initForceFlag && !initMergeFlag && !initDryRunFlag {
+		return fmt.Errorf("%s already exists; pass --force to overwrite it or --merge to append to it", target)
 	}
 
-	results, err := ports.Scan()
+	cfg, err := proposeConfig(root, curated)
 	if err != nil {
 		return err
 	}
-	docker.EnrichPorts(results)
-	ports.Enrich(results)
-	results = excludeApps(results)
 
-	_, index := groups.Attribute(results)
-	cfg := groups.Propose(root, results, index)
+	if initMergeFlag && exists {
+		return initMerge(target, cfg)
+	}
+
 	data, err := groups.Marshal(cfg)
 	if err != nil {
+		return err
+	}
+	// A curated list is the user's, so it is checked before it is written
+	// rather than discovered by the next scan. The pure proposal cannot fail.
+	if _, err := groups.Parse(target, data); err != nil {
 		return err
 	}
 
@@ -67,7 +88,7 @@ func initRun(cmd *cobra.Command, args []string) error {
 		fmt.Print(string(data))
 		return nil
 	}
-	if err := os.WriteFile(target, data, 0o644); err != nil {
+	if err := groups.WriteConfigFile(target, data); err != nil {
 		return err
 	}
 	fmt.Printf("wrote %s: group %s with %d %s\n",
@@ -76,6 +97,78 @@ func initRun(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, "note: nothing was listening inside this project, so no services were proposed")
 	}
 	return nil
+}
+
+// proposeConfig is the file this run would write: the proposal built from what
+// is listening, with the caller's own service list put in its place when
+// --service was given.
+func proposeConfig(root string, curated []groups.ServiceAdd) (*groups.Config, error) {
+	results, err := ports.Scan()
+	if err != nil {
+		return nil, err
+	}
+	docker.EnrichPorts(results)
+	ports.Enrich(results)
+	results = excludeApps(results)
+
+	_, index := groups.Attribute(results)
+	cfg := groups.Propose(root, results, index)
+	if len(curated) > 0 {
+		cfg = groups.Curate(cfg, curated)
+	}
+	return cfg, nil
+}
+
+// initMerge appends the proposal into a file that is already there. The append
+// goes through the node-level edit the daemon uses, so the existing file's
+// comments and key order survive and a name or port it already declares is
+// refused rather than duplicated.
+func initMerge(target string, cfg *groups.Config) error {
+	adds := groups.AddsFrom(cfg)
+	if len(adds) == 0 {
+		return fmt.Errorf("nothing to merge into %s: no services were proposed", target)
+	}
+	data, merged, err := groups.RenderEdit(target, groups.ConfigEdit{Add: adds})
+	if err != nil {
+		return err
+	}
+	if initDryRunFlag {
+		fmt.Print(string(data))
+		return nil
+	}
+	if err := groups.WriteConfigFile(merged.Path, data); err != nil {
+		return err
+	}
+	fmt.Printf("merged %d %s into %s: group %s\n",
+		len(adds), pluralWord(len(adds), "service"), target, merged.Name)
+	return nil
+}
+
+// parseInitServices reads the repeatable --service flag. The form is
+// `name:port[:health]`: the two things a service needs to be found again, plus
+// the health path when there is one. A command and the display metadata are
+// added afterwards, with `sonar groups add` or the desktop app.
+func parseInitServices(values []string) ([]groups.ServiceAdd, error) {
+	out := make([]groups.ServiceAdd, 0, len(values))
+	for _, raw := range values {
+		// SplitN with 3: a health path may itself contain a colon, and it is
+		// the last field, so it keeps whatever is left.
+		parts := strings.SplitN(strings.TrimSpace(raw), ":", 3)
+		name := strings.TrimSpace(parts[0])
+		if name == "" || len(parts) < 2 {
+			return nil, fmt.Errorf("--service %q: the form is name:port[:health], for example api:8000:/healthz", raw)
+		}
+		port, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil || port < 1 || port > 65535 {
+			return nil, fmt.Errorf("--service %q: %q is not a port between 1 and 65535", raw, parts[1])
+		}
+		svc := groups.ServiceAdd{Name: name, Port: port}
+		if len(parts) == 3 {
+			svc.Health = strings.TrimSpace(parts[2])
+		}
+		out = append(out, svc)
+	}
+	return out, nil
 }
 
 func pluralWord(n int, word string) string {

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/groups"
+)
+
+func TestParseInitServices(t *testing.T) {
+	got, err := parseInitServices([]string{"api:8000:/healthz", " web : 5173 ", "db:5432"})
+	if err != nil {
+		t.Fatalf("parseInitServices: %v", err)
+	}
+	want := []groups.ServiceAdd{
+		{Name: "api", Port: 8000, Health: "/healthz"},
+		{Name: "web", Port: 5173},
+		{Name: "db", Port: 5432},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d services, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Name != want[i].Name || got[i].Port != want[i].Port || got[i].Health != want[i].Health {
+			t.Errorf("service %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// A health path may carry a colon of its own; it is the last field, so it
+	// keeps everything that is left.
+	odd, err := parseInitServices([]string{"api:8000:http://localhost:8000/health"})
+	if err != nil {
+		t.Fatalf("parseInitServices: %v", err)
+	}
+	if odd[0].Health != "http://localhost:8000/health" {
+		t.Errorf("health = %q, want the whole rest of the value", odd[0].Health)
+	}
+
+	for _, bad := range []string{"", "api", "api:", ":8000", "api:http", "api:0", "api:70000", "api:-1"} {
+		if _, err := parseInitServices([]string{bad}); err == nil {
+			t.Errorf("--service %q was accepted", bad)
+		}
+	}
+}
+
+// TestInitRefusesForceAndMerge: one replaces the file, the other keeps it.
+func TestInitRefusesForceAndMerge(t *testing.T) {
+	initForceFlag, initMergeFlag = true, true
+	t.Cleanup(func() { initForceFlag, initMergeFlag = false, false })
+
+	err := initRun(initCmd, nil)
+	if err == nil {
+		t.Fatal("--force with --merge was accepted")
+	}
+	if !strings.Contains(err.Error(), "--merge") {
+		t.Errorf("error = %v, want it to name the flags", err)
+	}
+}
+
+// TestInitMergeAppendsToAnExistingFile drives the merge path over a file with
+// comments in it: the CLI and the daemon share the node-level edit, so what
+// `sonar init --merge` writes keeps the author's own lines.
+func TestInitMergeAppendsToAnExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, groups.ConfigName)
+	const hand = `# hand written
+name: demo
+services:
+  # the queue was here first
+  - name: queue
+    port: 6379
+`
+	if err := os.WriteFile(target, []byte(hand), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &groups.Config{Name: "demo", Dir: dir, Path: target, Services: []groups.Service{
+		{Name: "api", Port: 8000, Cmd: "uv run api"},
+	}}
+	if err := initMerge(target, cfg); err != nil {
+		t.Fatalf("initMerge: %v", err)
+	}
+
+	out, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"# hand written", "# the queue was here first", "name: api", "port: 8000"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("%q is missing from the merged file:\n%s", want, out)
+		}
+	}
+
+	// The same merge again clashes rather than duplicating the service.
+	if err := initMerge(target, cfg); err == nil {
+		t.Error("merging the same service twice was accepted")
+	}
+}

--- a/internal/daemon/config_edit_integration_test.go
+++ b/internal/daemon/config_edit_integration_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+// Step 5A.4's acceptance path through the real binary: `sonar init --service`
+// writes a curated `.sonar.yaml`, `sonar init --merge` appends to it, and
+// `sonar groups add|rename|remove` edit it through the daemon — which is the
+// point, because it means the desktop app, the MCP server and the CLI all reach
+// the same handler and the file's comments survive whoever made the edit.
+// Run with `go test -tags integration ./internal/daemon/...`.
+package daemon_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+)
+
+func TestServiceEditCycleThroughTheDaemon(t *testing.T) {
+	e := newEnv(t)
+	project := filepath.Join(e.home, "demo")
+	if err := os.MkdirAll(filepath.Join(project, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(project, groups.ConfigName)
+
+	e.serve()
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := e.command(args...)
+		cmd.Dir = project
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("sonar %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+	fails := func(args ...string) string {
+		t.Helper()
+		cmd := e.command(args...)
+		cmd.Dir = project
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("sonar %s should have failed:\n%s", strings.Join(args, " "), out)
+		}
+		return string(out)
+	}
+	load := func() *groups.Config {
+		t.Helper()
+		cfg, err := groups.Load(configPath)
+		if err != nil {
+			t.Fatalf("loading the file the daemon wrote: %v", err)
+		}
+		return cfg
+	}
+	names := func() []string {
+		t.Helper()
+		cfg := load()
+		out := make([]string, 0, len(cfg.Services))
+		for _, s := range cfg.Services {
+			out = append(out, s.Name)
+		}
+		return out
+	}
+
+	// A curated file in one command: nothing has to be listening for the user
+	// to describe what this project is.
+	run("init", "--service", "db:5432", "--service", "api:8000:/healthz")
+	if got := names(); !equal(got, []string{"db", "api"}) {
+		t.Fatalf("services = %v, want the two that were named", got)
+	}
+	if load().Services[1].Health != "/healthz" {
+		t.Errorf("api health = %q, want /healthz", load().Services[1].Health)
+	}
+
+	// A comment the author adds by hand has to survive every edit below.
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withComment := strings.Replace(string(raw), "services:", "# the services, in order\nservices:", 1)
+	if err := os.WriteFile(configPath, []byte(withComment), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// init refuses to overwrite, and says both ways past it.
+	refusal := fails("init")
+	if !strings.Contains(refusal, "--force") || !strings.Contains(refusal, "--merge") {
+		t.Errorf("the refusal should name both ways out:\n%s", refusal)
+	}
+	// --merge appends instead of refusing; nothing is listening in this
+	// checkout, so the proposal is empty and there is nothing to append.
+	if out := fails("init", "--merge"); !strings.Contains(out, "nothing to merge") {
+		t.Errorf("an empty merge should say so:\n%s", out)
+	}
+
+	// add
+	run("groups", "add", "demo", "worker", "--port", "9000",
+		"--cmd", "uv run worker", "--health", "/live", "--color", "#7c3aed",
+		"--description", "background jobs", "--depends-on", "db")
+	if got := names(); !equal(got, []string{"db", "api", "worker"}) {
+		t.Fatalf("services = %v, want worker appended", got)
+	}
+	worker := load().Services[2]
+	if worker.Port != 9000 || worker.Cmd != "uv run worker" || worker.Health != "/live" ||
+		worker.Color != "#7c3aed" || worker.Description != "background jobs" ||
+		len(worker.DependsOn) != 1 || worker.DependsOn[0] != "db" {
+		t.Errorf("worker = %+v", worker)
+	}
+
+	// A name and a port the file already has are both refused.
+	if out := fails("groups", "add", "demo", "api", "--port", "9100"); !strings.Contains(out, "already exists") {
+		t.Errorf("a duplicate name should be refused by name:\n%s", out)
+	}
+	if out := fails("groups", "add", "demo", "other", "--port", "8000"); !strings.Contains(out, "8000") {
+		t.Errorf("a duplicate port should be refused by port:\n%s", out)
+	}
+
+	// rename, depends_on and all
+	run("groups", "rename", "demo", "db", "database")
+	if got := names(); !equal(got, []string{"database", "api", "worker"}) {
+		t.Fatalf("services = %v, want db renamed", got)
+	}
+	if deps := load().Services[2].DependsOn; len(deps) != 1 || deps[0] != "database" {
+		t.Errorf("worker depends_on = %v, want the rename to have followed", deps)
+	}
+	if out := fails("groups", "rename", "demo", "nope", "other"); !strings.Contains(out, "no service") {
+		t.Errorf("renaming an unknown service should say so:\n%s", out)
+	}
+
+	// remove, and the dependency on it
+	var res rpc.GroupsConfigSetResult
+	out := run("groups", "remove", "demo", "database", "--json")
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("decoding --json: %v\n%s", err, out)
+	}
+	if !res.OK || len(res.Affected) != 1 || res.Affected[0] != "database" {
+		t.Errorf("result = %+v", res)
+	}
+	if got := names(); !equal(got, []string{"api", "worker"}) {
+		t.Fatalf("services = %v, want database gone", got)
+	}
+	if deps := load().Services[1].DependsOn; len(deps) != 0 {
+		t.Errorf("worker depends_on = %v, want the removed service dropped", deps)
+	}
+
+	// The whole cycle went through the daemon, and the hand-written comment is
+	// still there.
+	final, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(final), "# the services, in order") {
+		t.Errorf("the comment was lost somewhere in the cycle:\n%s", final)
+	}
+	if !strings.Contains(string(final), "written by") {
+		t.Errorf("`sonar init`'s own header was lost:\n%s", final)
+	}
+
+	// `sonar groups demo` still reads the file the edits left behind.
+	if out := run("groups", "demo"); !strings.Contains(out, "worker") {
+		t.Errorf("`sonar groups demo` does not show the edited services:\n%s", out)
+	}
+
+	e.stopDaemon(0)
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/daemon/groups_config.go
+++ b/internal/daemon/groups_config.go
@@ -49,9 +49,19 @@ func handleGroupsConfigSet(_ context.Context, req *Request) (any, error) {
 		return nil, rpc.NewError(rpc.CodeInvalidParams, "path is required",
 			`send {"path": "/repo/.sonar.yaml", "services": [{"name": "api", "patch": {"icon": "server"}}]}`)
 	}
-	if len(p.Services) == 0 {
-		return nil, rpc.NewError(rpc.CodeInvalidParams, "services is required",
-			`each entry is {"name": "<service>", "patch": {...}}; a null value clears a key`)
+	edit := groups.ConfigEdit{
+		Remove:   p.Remove,
+		Rename:   p.Rename,
+		Add:      p.Add,
+		Services: p.Services,
+	}
+	if edit.Empty() {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "services, add, rename or remove is required",
+			`send {"path": "…", "add": [{"name": "worker", "port": 9000}]}, or a rename, a remove, `+
+				`or {"services": [{"name": "api", "patch": {...}}]}`)
+	}
+	if err := checkEditNames(edit); err != nil {
+		return nil, err
 	}
 	if err := checkConfigPath(path); err != nil {
 		return nil, err
@@ -64,29 +74,62 @@ func handleGroupsConfigSet(_ context.Context, req *Request) (any, error) {
 	// for a LineComment and the emitter always writes exactly one space, so
 	// preserving it would mean re-rendering the file by hand; the comment
 	// itself is never lost, and that is where this stops.
-	cfg, err := groups.PatchServices(path, p.Services)
+	//
+	// The whole edit is applied to the node tree and validated before a byte is
+	// written, so a rename that clashes half way through a batch leaves the
+	// file exactly as it was.
+	cfg, err := groups.EditServices(path, edit)
 	if err != nil {
 		return nil, configError(path, err)
 	}
 
 	// Index the file the daemon just wrote, then republish: the edit reaches
 	// subscribers as a groups delta before the caller's own next read
-	// (contract §13.2).
+	// (contract §13.2, §38, §44).
 	if err := req.Runtime.Scanner.LoadConfig(cfg.Path); err != nil {
 		req.Runtime.Logger.Warn("reloading a config after writing it", "path", cfg.Path, "error", err)
 	}
-	req.Runtime.Logger.Info("config written", "path", cfg.Path, "services", len(p.Services))
+	affected := edit.Affected()
+	req.Runtime.Logger.Info("config written", "path", cfg.Path, "services", len(affected))
 	republish(req.Runtime)
 
-	affected := make([]string, 0, len(p.Services))
-	for _, edit := range p.Services {
-		affected = append(affected, edit.Name)
-	}
 	return rpc.GroupsConfigSetResult{
 		MutationResult: rpc.MutationResult{OK: true, Affected: affected},
 		Path:           cfg.Path,
 		Config:         configRow(req.Runtime, cfg),
 	}, nil
+}
+
+// checkEditNames rejects an edit whose shape is wrong before anything is read
+// from the disk. An empty service name is a caller bug, not a config problem,
+// so it is `invalid_params` rather than the `invalid_config` a nameless service
+// would earn once written.
+func checkEditNames(edit groups.ConfigEdit) error {
+	for _, name := range edit.Remove {
+		if strings.TrimSpace(name) == "" {
+			return rpc.NewError(rpc.CodeInvalidParams, "remove names an empty service",
+				`each entry is the name of a service in the file: {"remove": ["worker"]}`)
+		}
+	}
+	for _, r := range edit.Rename {
+		if strings.TrimSpace(r.From) == "" || strings.TrimSpace(r.To) == "" {
+			return rpc.NewError(rpc.CodeInvalidParams, "rename needs a from and a to",
+				`each entry is {"from": "<current name>", "to": "<new name>"}`)
+		}
+	}
+	for _, a := range edit.Add {
+		if strings.TrimSpace(a.Name) == "" {
+			return rpc.NewError(rpc.CodeInvalidParams, "add names an empty service",
+				`each entry is {"name": "worker", "port": 9000}`)
+		}
+	}
+	for _, e := range edit.Services {
+		if strings.TrimSpace(e.Name) == "" {
+			return rpc.NewError(rpc.CodeInvalidParams, "services names an empty service",
+				`each entry is {"name": "<service>", "patch": {...}}; a null value clears a key`)
+		}
+	}
+	return nil
 }
 
 func handleGroupsReload(_ context.Context, req *Request) (any, error) {
@@ -147,13 +190,23 @@ func checkConfigPath(path string) error {
 }
 
 // configError maps a config failure onto the contract's error registry: a
-// missing file or service is `not_found`, a file that no longer validates is
-// `1006 invalid_config` with the problems in data.detail (contract §13.2).
+// missing file or service is `not_found`, a name or a port an added or renamed
+// service would take twice is `1011 conflict`, and a file that no longer
+// validates is `1006 invalid_config` with the problems in data.detail
+// (contract §13.2, step 5A.4).
 func configError(path string, err error) error {
 	var missing *groups.ServiceNotFoundError
 	if errors.As(err, &missing) {
 		return rpc.NewError(rpc.CodeNotFound, missing.Error(),
 			"`groups.config.get` lists the service names this file declares")
+	}
+	var clash *groups.ServiceConflictError
+	if errors.As(err, &clash) {
+		hint := "pick another name, or rename the service that has it"
+		if clash.Port != 0 {
+			hint = "pick another port, or remove " + clash.Name + " in the same call"
+		}
+		return rpc.NewError(rpc.CodeConflict, clash.Error(), hint)
 	}
 	var bad *groups.ConfigError
 	if errors.As(err, &bad) {

--- a/internal/daemon/groups_config_test.go
+++ b/internal/daemon/groups_config_test.go
@@ -367,3 +367,210 @@ func waitForGroup(t *testing.T, c *testClient, name string) *state.Group {
 	}
 	return nil
 }
+
+// TestGroupsConfigSetAddsRenamesAndRemoves is step 5A.4's reason to exist: the
+// daemon owns every edit to a `.sonar.yaml`, so a client never has to write the
+// file itself to add a service or rename one.
+func TestGroupsConfigSetAddsRenamesAndRemoves(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _, path := configHarness(t, ctx)
+	c := h.dial(ctx)
+
+	var snap state.Snapshot
+	if e := c.call("state.subscribe", rpc.StateSubscribeParams{}, &snap); e != nil {
+		t.Fatalf("state.subscribe: %v", e)
+	}
+
+	// Add. The delta collected here is the one published before the reply was
+	// queued (contract §38, §44): the caller cannot see the acknowledgement
+	// before the change.
+	var res rpc.GroupsConfigSetResult
+	seen := callCollectingGroups(t, c, "groups.config.set", rpc.GroupsConfigSetParams{
+		Path: path,
+		Add: []groups.ServiceAdd{{
+			Name: "worker", Port: 9000, Cmd: "uv run worker", Color: "green", DependsOn: []string{"db"},
+		}},
+	}, &res)
+	if !res.OK || len(res.Affected) != 1 || res.Affected[0] != "worker" {
+		t.Errorf("result = %+v", res.MutationResult)
+	}
+	if len(res.Config.Services) != 3 || res.Config.Services[2].Name != "worker" {
+		t.Fatalf("returned config = %+v", res.Config.Services)
+	}
+	g, ok := seen["demo"]
+	if !ok {
+		t.Fatal("the add was acknowledged before the delta that carries it")
+	}
+	if len(g.Services) != 3 || g.Services[2].Name != "worker" {
+		t.Errorf("the published group is stale: %+v", g.Services)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "# the database goes first") {
+		t.Errorf("the comment was lost:\n%s", raw)
+	}
+
+	// Rename, and every depends_on reference with it.
+	seen = callCollectingGroups(t, c, "groups.config.set", rpc.GroupsConfigSetParams{
+		Path:   path,
+		Rename: []groups.ServiceRename{{From: "db", To: "database"}},
+	}, &res)
+	if len(res.Affected) != 1 || res.Affected[0] != "database" {
+		t.Errorf("affected = %v, want the new name", res.Affected)
+	}
+	raw, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "depends_on: [db]") || !strings.Contains(string(raw), "depends_on: [database]") {
+		t.Errorf("the rename did not follow depends_on:\n%s", raw)
+	}
+	if g, ok := seen["demo"]; ok && g.Services[0].Name != "database" {
+		t.Errorf("the published group is stale: %+v", g.Services[0])
+	}
+
+	// Remove, and the dependency on it.
+	if e := c.call("groups.config.set", rpc.GroupsConfigSetParams{
+		Path:   path,
+		Remove: []string{"database"},
+	}, &res); e != nil {
+		t.Fatalf("groups.config.set remove: %v", e)
+	}
+	if len(res.Affected) != 1 || res.Affected[0] != "database" {
+		t.Errorf("affected = %v", res.Affected)
+	}
+	raw, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "database") {
+		t.Errorf("the removed service is still referenced:\n%s", raw)
+	}
+	if len(res.Config.Services) != 2 {
+		t.Errorf("config = %+v, want api and worker left", res.Config.Services)
+	}
+}
+
+// TestGroupsConfigSetIsAtomic: the four lists are one change. A rename that
+// clashes after an add has already been applied must leave the file byte for
+// byte as it was.
+func TestGroupsConfigSetIsAtomic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _, path := configHarness(t, ctx)
+	c := h.dial(ctx)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := c.call("groups.config.set", rpc.GroupsConfigSetParams{
+		Path:     path,
+		Add:      []groups.ServiceAdd{{Name: "worker", Port: 9000}},
+		Rename:   []groups.ServiceRename{{From: "db", To: "api"}},
+		Services: []groups.ServiceEdit{{Name: "api", Patch: groups.ServicePatch{}.SetString(groups.FieldIcon, "gear")}},
+	}, nil)
+	if e == nil {
+		t.Fatal("a rename onto an existing name should fail the whole call")
+	}
+	if e.Code != rpc.CodeConflict || e.Data.Code != "conflict" {
+		t.Errorf("error = %+v, want 1011 conflict", e)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("a failed edit changed the file:\n%s", after)
+	}
+}
+
+// TestGroupsConfigSetEditErrors walks the codes the new lists can return.
+func TestGroupsConfigSetEditErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _, path := configHarness(t, ctx)
+	c := h.dial(ctx)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name   string
+		params rpc.GroupsConfigSetParams
+		want   string
+	}{
+		{"a name the file already has", rpc.GroupsConfigSetParams{
+			Path: path, Add: []groups.ServiceAdd{{Name: "api", Port: 9000}},
+		}, "conflict"},
+		{"a port the file already has", rpc.GroupsConfigSetParams{
+			Path: path, Add: []groups.ServiceAdd{{Name: "worker", Port: 8000}},
+		}, "conflict"},
+		{"renaming a service that is not there", rpc.GroupsConfigSetParams{
+			Path: path, Rename: []groups.ServiceRename{{From: "worker", To: "jobs"}},
+		}, "not_found"},
+		{"removing a service that is not there", rpc.GroupsConfigSetParams{
+			Path: path, Remove: []string{"worker"},
+		}, "not_found"},
+		{"an edit that asks for nothing", rpc.GroupsConfigSetParams{Path: path}, "invalid_params"},
+		{"a rename with no target name", rpc.GroupsConfigSetParams{
+			Path: path, Rename: []groups.ServiceRename{{From: "db", To: "  "}},
+		}, "invalid_params"},
+		{"an add with no name", rpc.GroupsConfigSetParams{
+			Path: path, Add: []groups.ServiceAdd{{Port: 9000}},
+		}, "invalid_params"},
+		{"an add whose depends_on names nothing", rpc.GroupsConfigSetParams{
+			Path: path, Add: []groups.ServiceAdd{{Name: "worker", Port: 9000, DependsOn: []string{"nope"}}},
+		}, "invalid_config"},
+	}
+	for _, tc := range cases {
+		e := c.call("groups.config.set", tc.params, nil)
+		if e == nil {
+			t.Errorf("%s: should have failed", tc.name)
+			continue
+		}
+		if e.Data.Code != tc.want {
+			t.Errorf("%s: error = %+v, want %s", tc.name, e, tc.want)
+		}
+		if e.Data.Hint == "" {
+			t.Errorf("%s: error carries no hint: %+v", tc.name, e)
+		}
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("a failed edit changed the file:\n%s", after)
+	}
+}
+
+// TestGroupsConfigSetRemoveThenAddReusesThePort: the lists are applied remove
+// first, so swapping one service for another on the same port is one call.
+func TestGroupsConfigSetRemoveThenAddReusesThePort(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _, path := configHarness(t, ctx)
+	c := h.dial(ctx)
+
+	var res rpc.GroupsConfigSetResult
+	if e := c.call("groups.config.set", rpc.GroupsConfigSetParams{
+		Path:   path,
+		Remove: []string{"api"},
+		Add:    []groups.ServiceAdd{{Name: "gateway", Port: 8000}},
+	}, &res); e != nil {
+		t.Fatalf("groups.config.set: %v", e)
+	}
+	if len(res.Affected) != 2 || res.Affected[0] != "api" || res.Affected[1] != "gateway" {
+		t.Errorf("affected = %v, want the removal then the add", res.Affected)
+	}
+	if len(res.Config.Services) != 2 || res.Config.Services[1].Name != "gateway" {
+		t.Errorf("config = %+v", res.Config.Services)
+	}
+}

--- a/internal/daemon/groups_init.go
+++ b/internal/daemon/groups_init.go
@@ -38,6 +38,16 @@ func handleGroupsInit(_ context.Context, req *Request) (any, error) {
 	if err := req.Bind(&p); err != nil {
 		return nil, err
 	}
+	if p.Force && p.Merge {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "force and merge cannot both be set",
+			"force replaces the file, merge appends to it; pick one")
+	}
+	for _, svc := range p.Services {
+		if strings.TrimSpace(svc.Name) == "" {
+			return nil, rpc.NewError(rpc.CodeInvalidParams, "services names an empty service",
+				`each entry is {"name": "api", "port": 8000}`)
+		}
+	}
 	root, err := initRoot(p.RootDir)
 	if err != nil {
 		return nil, err
@@ -54,17 +64,35 @@ func handleGroupsInit(_ context.Context, req *Request) (any, error) {
 		return nil, err
 	}
 	cfg := groups.Propose(root, state.ToListeningAll(snap.Ports), nil)
+	if len(p.Services) > 0 {
+		// The caller curated the proposal: names, ports and metadata are
+		// theirs, and the cmd the proposal guessed is carried onto an entry
+		// that kept the port it was guessed for.
+		cfg = groups.Curate(cfg, p.Services)
+	}
+
+	_, statErr := os.Lstat(target)
+	exists := statErr == nil
+	if p.Merge && exists {
+		return mergeInit(req, target, cfg, snap, p.Write)
+	}
+
 	data, err := groups.Marshal(cfg)
 	if err != nil {
 		return nil, rpc.NewError(rpc.CodeInternal, "rendering "+groups.ConfigName+": "+err.Error(),
 			"check `sonar daemon log`")
+	}
+	// A curated list is the caller's, so it is validated here rather than
+	// discovered by the next scan. The pure proposal cannot fail this.
+	if _, err := groups.Parse(target, data); err != nil {
+		return nil, configError(target, err)
 	}
 
 	result := rpc.GroupsInitResult{
 		MutationResult: rpc.MutationResult{OK: true, Affected: serviceNames(cfg)},
 		Path:           target,
 		YAML:           string(data),
-		Proposal:       proposalGroup(cfg),
+		Proposal:       proposalGroup(cfg, snapshotPorts(snap)),
 	}
 	if !p.Write {
 		// The default is a preview: the caller gets the exact bytes a write
@@ -75,26 +103,67 @@ func handleGroupsInit(_ context.Context, req *Request) (any, error) {
 	// §16: `sonar init` refuses to overwrite without --force, and so does this.
 	// The registry (contract §2) has no `already_exists`, and inventing a code
 	// for one method is worse than the accurate hint, so this is
-	// `invalid_params` naming the parameter that unblocks it.
-	if _, err := os.Lstat(target); err == nil && !p.Force {
+	// `invalid_params` naming the parameters that unblock it.
+	if exists && !p.Force {
 		return nil, rpc.NewError(rpc.CodeInvalidParams, target+" already exists",
-			`pass {"force": true} to overwrite it, or read it with groups.config.get`)
+			`pass {"force": true} to overwrite it or {"merge": true} to append to it, `+
+				"or read it with groups.config.get")
 	}
-	if err := os.WriteFile(target, data, 0o644); err != nil {
+	if err := groups.WriteConfigFile(target, data); err != nil {
 		return nil, rpc.NewError(rpc.CodeInternal, "writing "+target+": "+err.Error(),
 			"check that the daemon may write to "+root)
 	}
-
-	// Index the file the daemon just wrote and republish, so the group flips to
-	// source `file` in the delta subscribers get before the caller's own next
-	// read (the same order `groups.config.set` keeps).
-	if err := req.Runtime.Scanner.LoadConfig(target); err != nil {
-		req.Runtime.Logger.Warn("reloading a config after writing it", "path", target, "error", err)
-	}
-	req.Runtime.Logger.Info("wrote "+groups.ConfigName,
-		"path", target, "group", cfg.Name, "services", len(cfg.Services))
-	republish(req.Runtime)
+	publishConfig(req, target, cfg.Name, len(cfg.Services))
 	return result, nil
+}
+
+// mergeInit appends a proposal into a `.sonar.yaml` that is already there,
+// rather than refusing it. The append goes through the same node-level edit
+// `groups.config.set` uses, so the file's comments and order survive and a
+// service name or port the file already has is a `conflict` — and, because the
+// bytes are rendered before anything is written, `write: false` previews the
+// merged file exactly.
+func mergeInit(req *Request, target string, cfg *groups.Config, snap state.Snapshot, write bool) (any, error) {
+	adds := groups.AddsFrom(cfg)
+	data, merged, err := groups.RenderEdit(target, groups.ConfigEdit{Add: adds})
+	if err != nil {
+		return nil, configError(target, err)
+	}
+	result := rpc.GroupsInitResult{
+		MutationResult: rpc.MutationResult{OK: true, Affected: serviceNames(cfg)},
+		Path:           target,
+		YAML:           string(data),
+		Proposal:       proposalGroup(merged, snapshotPorts(snap)),
+	}
+	if !write {
+		return result, nil
+	}
+	if err := groups.WriteConfigFile(merged.Path, data); err != nil {
+		return nil, rpc.NewError(rpc.CodeInternal, "writing "+target+": "+err.Error(),
+			"check that the daemon may write to "+filepath.Dir(target))
+	}
+	publishConfig(req, merged.Path, merged.Name, len(adds))
+	return result, nil
+}
+
+// publishConfig indexes a file the daemon just wrote and republishes, so the
+// group reaches subscribers as a groups delta before the caller's own next read
+// (the same order `groups.config.set` keeps, contract §38 and §44).
+func publishConfig(req *Request, path, group string, services int) {
+	if err := req.Runtime.Scanner.LoadConfig(path); err != nil {
+		req.Runtime.Logger.Warn("reloading a config after writing it", "path", path, "error", err)
+	}
+	req.Runtime.Logger.Info("wrote "+groups.ConfigName, "path", path, "group", group, "services", services)
+	republish(req.Runtime)
+}
+
+// snapshotPorts is the set of ports the snapshot this call read saw listening.
+func snapshotPorts(snap state.Snapshot) map[int]bool {
+	out := make(map[int]bool, len(snap.Ports))
+	for _, p := range snap.Ports {
+		out[p.Port] = true
+	}
+	return out
 }
 
 // initRoot validates the caller's root and resolves it the way `sonar init`
@@ -153,11 +222,12 @@ func serviceNames(cfg *groups.Config) []string {
 	return out
 }
 
-// proposalGroup renders the proposed config as the group row it would produce.
-// Every proposed service came from a port listening in the snapshot this call
-// read, so the rows are marked running: that is what "proposed from what is
-// running now" means, and it saves a client a second join to say so.
-func proposalGroup(cfg *groups.Config) state.Group {
+// proposalGroup renders the config this call would write as the group row it
+// produces. A service is marked running when its port is listening in the
+// snapshot the call read: every service of a plain proposal came from such a
+// port, so that path is unchanged, while a curated or merged file can honestly
+// carry services that are declared but down.
+func proposalGroup(cfg *groups.Config, listening map[int]bool) state.Group {
 	dir, path := cfg.Dir, cfg.Path
 	g := state.Group{
 		Name:       cfg.Name,
@@ -168,17 +238,24 @@ func proposalGroup(cfg *groups.Config) state.Group {
 		Members:    []int{},
 		Services:   groups.ServiceRows(cfg),
 	}
+	up := 0
 	for i := range g.Services {
-		if g.Services[i].Port == nil {
+		if g.Services[i].Port == nil || !listening[*g.Services[i].Port] {
 			continue
 		}
 		port := *g.Services[i].Port
 		g.Services[i].Running, g.Services[i].PortActual = true, &port
 		g.Members = append(g.Members, port)
+		up++
 	}
 	sort.Ints(g.Members)
-	if len(g.Services) > 0 {
+	switch {
+	case up == 0:
+		g.Status = "stopped"
+	case up == len(g.Services):
 		g.Status = "running"
+	default:
+		g.Status = "partial"
 	}
 	return g
 }

--- a/internal/daemon/groups_init_test.go
+++ b/internal/daemon/groups_init_test.go
@@ -265,3 +265,220 @@ func groupNamed(gg []state.Group, name string) (state.Group, bool) {
 	}
 	return state.Group{}, false
 }
+
+// TestGroupsInitCuratesTheProposal: a caller that has let a user name the
+// services writes the whole curated file in one call (step 5A.4). The command
+// the proposal guessed for a port the caller kept survives the curation, so the
+// file is still one `sonar up` can use.
+func TestGroupsInitCuratesTheProposal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	res, e := callInit(t, c, rpc.GroupsInitParams{
+		RootDir: root,
+		Write:   true,
+		Services: []groups.ServiceAdd{
+			{Name: "gateway", Port: 8000, Health: "/healthz", Color: "#4f8cc9", Description: "the api"},
+			{Name: "storefront", Port: 5173},
+			{Name: "worker", Port: 9000, Cmd: "uv run worker"},
+		},
+	})
+	if e != nil {
+		t.Fatalf("groups.init with services: %v", e)
+	}
+	if len(res.Affected) != 3 || res.Affected[0] != "gateway" {
+		t.Errorf("affected = %v, want the curated names", res.Affected)
+	}
+
+	cfg := loadYAML(t, res.YAML)
+	if len(cfg.Services) != 3 {
+		t.Fatalf("the file has %d services, want the three that were asked for:\n%s", len(cfg.Services), res.YAML)
+	}
+	if cfg.Services[0].Name != "gateway" || cfg.Services[0].Health != "/healthz" ||
+		cfg.Services[0].Color != "#4f8cc9" || cfg.Services[0].Description != "the api" {
+		t.Errorf("gateway = %+v, want the caller's own metadata", cfg.Services[0])
+	}
+	if cfg.Services[0].Cmd != "uv run api" {
+		t.Errorf("gateway cmd = %q, want the command the proposal guessed for port 8000", cfg.Services[0].Cmd)
+	}
+	if cfg.Services[1].Cwd != "web" {
+		t.Errorf("storefront cwd = %q, want the proposal's own", cfg.Services[1].Cwd)
+	}
+	if cfg.Services[2].Cmd != "uv run worker" {
+		t.Errorf("worker cmd = %q, want the caller's own", cfg.Services[2].Cmd)
+	}
+
+	// A service nothing is listening on is not reported as running.
+	byName := map[string]state.Service{}
+	for _, s := range res.Proposal.Services {
+		byName[s.Name] = s
+	}
+	if !byName["gateway"].Running {
+		t.Errorf("gateway should be running: port 8000 is listening")
+	}
+	if byName["worker"].Running {
+		t.Errorf("worker should not be running: nothing is on port 9000")
+	}
+	if res.Proposal.Status != "partial" {
+		t.Errorf("proposal status = %q, want partial", res.Proposal.Status)
+	}
+
+	written, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(written) != res.YAML {
+		t.Errorf("the file on disk is not the yaml that was returned:\n%s", written)
+	}
+}
+
+// TestGroupsInitCuratedListIsValidated: the service list is the caller's, so it
+// is checked before anything is written rather than found by the next scan.
+func TestGroupsInitCuratedListIsValidated(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	_, e := callInit(t, c, rpc.GroupsInitParams{
+		RootDir:  root,
+		Write:    true,
+		Services: []groups.ServiceAdd{{Name: "api", Port: 8000, DependsOn: []string{"nope"}}},
+	})
+	if e == nil || e.Data.Code != "invalid_config" {
+		t.Fatalf("error = %+v, want invalid_config", e)
+	}
+	if _, err := os.Lstat(target); err == nil {
+		t.Error("the invalid file was written anyway")
+	}
+
+	_, e = callInit(t, c, rpc.GroupsInitParams{
+		RootDir:  root,
+		Services: []groups.ServiceAdd{{Name: "  ", Port: 8000}},
+	})
+	if e == nil || e.Data.Code != "invalid_params" {
+		t.Fatalf("error = %+v, want invalid_params for an empty name", e)
+	}
+}
+
+// TestGroupsInitMergeAppends: `merge` is the way past an existing file that
+// keeps what is in it, and the file's comments and order come through the
+// append because it goes down the same node-level path as groups.config.set.
+func TestGroupsInitMergeAppends(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	const hand = `# hand written, and it stays that way
+name: demo
+services:
+  # the queue was here first
+  - name: queue
+    port: 6379
+`
+	if err := os.WriteFile(target, []byte(hand), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A dry-run merge previews the merged file without touching it.
+	res, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root, Merge: true})
+	if e != nil {
+		t.Fatalf("groups.init --merge dry run: %v", e)
+	}
+	if !strings.Contains(res.YAML, "# the queue was here first") || !strings.Contains(res.YAML, "port: 8000") {
+		t.Errorf("the previewed merge is wrong:\n%s", res.YAML)
+	}
+	if b, _ := os.ReadFile(target); string(b) != hand {
+		t.Errorf("a dry-run merge wrote to the file:\n%s", b)
+	}
+
+	res, e = callInit(t, c, rpc.GroupsInitParams{RootDir: root, Merge: true, Write: true})
+	if e != nil {
+		t.Fatalf("groups.init --merge: %v", e)
+	}
+	written, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(written) != res.YAML {
+		t.Errorf("the file on disk is not the yaml that was returned:\n%s", written)
+	}
+	cfg := loadYAML(t, string(written))
+	if cfg.Name != "demo" {
+		t.Errorf("name = %q, want the existing file's own", cfg.Name)
+	}
+	if len(cfg.Services) != 3 || cfg.Services[0].Name != "queue" {
+		t.Fatalf("services = %+v, want the queue plus the two proposed", cfg.Services)
+	}
+	if !strings.Contains(string(written), "# hand written, and it stays that way") ||
+		!strings.Contains(string(written), "# the queue was here first") {
+		t.Errorf("the comments were lost:\n%s", written)
+	}
+	if len(res.Affected) != 2 {
+		t.Errorf("affected = %v, want only the appended services", res.Affected)
+	}
+
+	// Merging the same proposal again is a conflict, not a duplicate.
+	_, e = callInit(t, c, rpc.GroupsInitParams{RootDir: root, Merge: true, Write: true})
+	if e == nil || e.Data.Code != "conflict" {
+		t.Fatalf("error = %+v, want conflict", e)
+	}
+}
+
+// TestGroupsInitMergeOnANewFileJustWrites: merge is about not refusing, so with
+// nothing there it behaves exactly like a plain init.
+func TestGroupsInitMergeOnANewFileJustWrites(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	res, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root, Merge: true, Write: true})
+	if e != nil {
+		t.Fatalf("groups.init --merge on a new file: %v", e)
+	}
+	b, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != res.YAML || !strings.Contains(string(b), "written by") {
+		t.Errorf("merge on a new file should write the proposal with its header:\n%s", b)
+	}
+}
+
+// TestGroupsInitMergeAndForceAreExclusive: one replaces the file, the other
+// keeps it; asking for both is a caller bug worth naming.
+func TestGroupsInitMergeAndForceAreExclusive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, _ := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	_, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root, Write: true, Force: true, Merge: true})
+	if e == nil || e.Data.Code != "invalid_params" {
+		t.Fatalf("error = %+v, want invalid_params", e)
+	}
+}
+
+// TestGroupsInitRefusalNamesMerge: the hint past an existing file now has two
+// ways out, and both have to be in it.
+func TestGroupsInitRefusalNamesMerge(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, root, target := initHarness(t, ctx)
+	c := h.dial(ctx)
+
+	if err := os.WriteFile(target, []byte("name: hand-written\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, e := callInit(t, c, rpc.GroupsInitParams{RootDir: root, Write: true})
+	if e == nil {
+		t.Fatal("writing over an existing file should have been refused")
+	}
+	if !strings.Contains(e.Data.Hint, "force") || !strings.Contains(e.Data.Hint, "merge") {
+		t.Errorf("hint = %q, want both ways out named", e.Data.Hint)
+	}
+}

--- a/internal/daemon/rpc/errors.go
+++ b/internal/daemon/rpc/errors.go
@@ -34,6 +34,7 @@ const (
 	CodeTimeout         = 1008
 	CodeInvalidSelector = 1009
 	CodeOutsideHome     = 1010
+	CodeConflict        = 1011
 
 	// 1100-1199 are owned by spec 3 (expose and proxies).
 	CodeTargetNotListening   = 1100
@@ -65,6 +66,7 @@ var codeNames = map[int]string{
 	CodeTimeout:         "timeout",
 	CodeInvalidSelector: "invalid_selector",
 	CodeOutsideHome:     "outside_home",
+	CodeConflict:        "conflict",
 
 	CodeTargetNotListening:   "target_not_listening",
 	CodeProviderNotInstalled: "provider_not_installed",

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -425,15 +425,33 @@ type GroupsConfigGetResult struct {
 	Config GroupConfig `json:"config"`
 }
 
+// GroupsConfigSetParams is one atomic edit of a `.sonar.yaml` (contract §13.2,
+// extended by step 5A.4). The four lists may be combined in a single call and
+// are applied in this order — Remove, Rename, Add, then the Services metadata
+// patches — with each list seeing the file as the previous ones left it.
+// Nothing is written unless the whole edit succeeds and the result still
+// validates, so a call that fails leaves the file byte-identical.
 type GroupsConfigSetParams struct {
 	HostParams
-	Path     string               `json:"path"`
-	Services []groups.ServiceEdit `json:"services"`
+	Path string `json:"path"`
+	// Services patches the metadata of services that already exist.
+	Services []groups.ServiceEdit `json:"services,omitempty"`
+	// Add appends services. A name or a port the file already uses is
+	// `conflict`.
+	Add []groups.ServiceAdd `json:"add,omitempty"`
+	// Rename renames services everywhere in the file, depends_on references
+	// included. An unknown `from` is `not_found`, a `to` already in the file is
+	// `conflict`.
+	Rename []groups.ServiceRename `json:"rename,omitempty"`
+	// Remove deletes services and drops them from every other service's
+	// depends_on. An unknown name is `not_found`.
+	Remove []string `json:"remove,omitempty"`
 }
 
 // GroupsConfigSetResult is the file after the write. Affected carries the
-// service names that were patched: this method mutates a config, not a port,
-// so there is no port key to report (step 1A.7).
+// service names the edit touched, in the order it applied them — a removed
+// name, a rename's new name, an added name, a patched name: this method mutates
+// a config, not a port, so there is no port key to report (step 1A.7).
 type GroupsConfigSetResult struct {
 	MutationResult
 	Path   string      `json:"path"`
@@ -453,13 +471,19 @@ type ConfigProblem struct {
 
 // GroupsInitParams asks for a proposed `.sonar.yaml` for the checkout at
 // RootDir. Write is the contract's opt-in to actually writing it, so the
-// default is a preview; Force is the wire form of `sonar init --force` and is
-// the only way past an existing file (contract §4, §16).
+// default is a preview; Force is the wire form of `sonar init --force` and
+// overwrites an existing file, while Merge appends into one instead (contract
+// §4, §16, step 5A.4). Force and Merge are mutually exclusive.
 type GroupsInitParams struct {
 	HostParams
 	RootDir string `json:"root_dir"`
 	Write   bool   `json:"write,omitempty"`
 	Force   bool   `json:"force,omitempty"`
+	Merge   bool   `json:"merge,omitempty"`
+	// Services replaces the proposed service list with the caller's own, so a
+	// curated file can be written in one call. An entry that names a port the
+	// proposal also found keeps that proposal's cmd and cwd.
+	Services []groups.ServiceAdd `json:"services,omitempty"`
 }
 
 type GroupsInitResult struct {

--- a/internal/groups/config.go
+++ b/internal/groups/config.go
@@ -74,6 +74,17 @@ func Load(path string) (*Config, error) {
 	return parse(abs, data)
 }
 
+// Parse validates config bytes as if they had been read from path. It is what
+// a caller rendering a config in memory — `groups.init` writing a curated
+// proposal — checks before putting anything on disk.
+func Parse(path string, data []byte) (*Config, error) {
+	abs := Canonical(path)
+	if abs == "" {
+		return nil, fmt.Errorf("no config path given")
+	}
+	return parse(abs, data)
+}
+
 func parse(abs string, data []byte) (*Config, error) {
 	dir := filepath.Dir(abs)
 

--- a/internal/groups/edit.go
+++ b/internal/groups/edit.go
@@ -1,0 +1,440 @@
+package groups
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// rootKeyOrder is where a top-level key belongs in a `.sonar.yaml`. It is the
+// same idea as keyOrder one level up: a `services:` list this package has to
+// create lands where a hand-written file would put it.
+var rootKeyOrder = []string{"name", "services", "ports"}
+
+// ServiceAdd is a service to append to a `.sonar.yaml`. It is the whole
+// editable service, not a patch: an added service does not exist yet, so
+// "absent" and "null" mean the same thing and the zero value of every field is
+// simply left out of the file.
+type ServiceAdd struct {
+	Name        string   `json:"name"`
+	Port        int      `json:"port,omitempty"`
+	Cmd         string   `json:"cmd,omitempty"`
+	Cwd         string   `json:"cwd,omitempty"`
+	Health      string   `json:"health,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Icon        string   `json:"icon,omitempty"`
+	Color       string   `json:"color,omitempty"`
+	DependsOn   []string `json:"depends_on,omitempty"`
+}
+
+// Service is the config entry the add describes.
+func (a ServiceAdd) Service() Service {
+	return Service{
+		Name:        a.Name,
+		Cmd:         a.Cmd,
+		Cwd:         a.Cwd,
+		Port:        a.Port,
+		Health:      a.Health,
+		Description: a.Description,
+		Icon:        a.Icon,
+		Color:       a.Color,
+		DependsOn:   append([]string{}, a.DependsOn...),
+	}
+}
+
+// AddFrom is the add entry that would recreate a service.
+func AddFrom(s Service) ServiceAdd {
+	return ServiceAdd{
+		Name:        s.Name,
+		Port:        s.Port,
+		Cmd:         s.Cmd,
+		Cwd:         s.Cwd,
+		Health:      s.Health,
+		Description: s.Description,
+		Icon:        s.Icon,
+		Color:       s.Color,
+		DependsOn:   append([]string{}, s.DependsOn...),
+	}
+}
+
+// AddsFrom is AddFrom over a whole config, which is how a proposal becomes the
+// list of services to merge into a file that already exists.
+func AddsFrom(cfg *Config) []ServiceAdd {
+	out := make([]ServiceAdd, 0, len(cfg.Services))
+	for _, s := range cfg.Services {
+		out = append(out, AddFrom(s))
+	}
+	return out
+}
+
+// ServiceRename renames a service. Every depends_on entry naming From is
+// rewritten too, so the file stays valid across the rename.
+type ServiceRename struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// ConfigEdit is one atomic set of changes to a `.sonar.yaml`. The four lists
+// are applied in the order the fields are declared — remove, rename, add, then
+// the metadata patches — and each one sees the file as the previous ones left
+// it. Nothing is written unless every step succeeds and the result still
+// parses, so a failed edit leaves the file byte-identical.
+//
+// Removing first is what makes `{"remove": ["old"], "add": [{"name": "new",
+// "port": 8000}]}` work when the two want the same port: the port is free by
+// the time the add is checked.
+type ConfigEdit struct {
+	Remove   []string        `json:"remove,omitempty"`
+	Rename   []ServiceRename `json:"rename,omitempty"`
+	Add      []ServiceAdd    `json:"add,omitempty"`
+	Services []ServiceEdit   `json:"services,omitempty"`
+}
+
+// Empty reports whether the edit asks for nothing at all.
+func (e ConfigEdit) Empty() bool {
+	return len(e.Remove) == 0 && len(e.Rename) == 0 && len(e.Add) == 0 && len(e.Services) == 0
+}
+
+// Affected is the service names the edit touched, in the order it applied
+// them: a removed name, a rename's new name, an added name, a patched name.
+// It is what a mutating method reports as `affected` (contract §22).
+func (e ConfigEdit) Affected() []string {
+	out := make([]string, 0, len(e.Remove)+len(e.Rename)+len(e.Add)+len(e.Services))
+	for _, name := range e.Remove {
+		out = append(out, name)
+	}
+	for _, r := range e.Rename {
+		out = append(out, r.To)
+	}
+	for _, a := range e.Add {
+		out = append(out, a.Name)
+	}
+	for _, s := range e.Services {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+// ServiceConflictError is returned when an add or a rename would give a file
+// two services with the same name, or two services claiming the same port. It
+// maps onto the contract's `conflict`.
+type ServiceConflictError struct {
+	Path string
+	Name string // the service already holding the name or the port
+	Port int    // non-zero when the clash is a port rather than a name
+}
+
+func (e *ServiceConflictError) Error() string {
+	if e.Port != 0 {
+		return fmt.Sprintf("port %d is already service %q in %s", e.Port, e.Name, e.Path)
+	}
+	return fmt.Sprintf("service %q already exists in %s", e.Name, e.Path)
+}
+
+// RenderEdit applies an edit to the `.sonar.yaml` at path and returns the bytes
+// it would write, without writing them. The rewrite goes through the YAML node
+// API rather than marshalling a struct, so comments, key order and the
+// author's own formatting survive (contract §13.2).
+//
+// The returned Config is the file as it would then stand: it is parsed from the
+// rendered bytes, so what a later Load sees is what has been validated here.
+func RenderEdit(path string, edit ConfigEdit) ([]byte, *Config, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, nil, &ConfigError{Path: abs, Problems: []string{err.Error()}}
+	}
+	root := documentRoot(&doc)
+	if root == nil || root.Kind != yaml.MappingNode {
+		return nil, nil, &ConfigError{Path: abs, Problems: []string{"the file is not a YAML mapping"}}
+	}
+
+	if err := applyEdit(abs, root, edit); err != nil {
+		return nil, nil, err
+	}
+
+	out, err := encode(&doc)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Validate the bytes that would hit the disk, not the node tree.
+	cfg, err := parse(abs, out)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, cfg, nil
+}
+
+// EditServices applies an edit and writes the file back. Nothing reaches the
+// disk unless the whole edit succeeded and the result validates.
+func EditServices(path string, edit ConfigEdit) (*Config, error) {
+	out, cfg, err := RenderEdit(path, edit)
+	if err != nil {
+		return nil, err
+	}
+	if err := WriteConfigFile(cfg.Path, out); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// applyEdit mutates the node tree in place. It returns on the first problem,
+// and because the caller only writes after it returns nil, a half-applied tree
+// is thrown away rather than rendered.
+func applyEdit(abs string, root *yaml.Node, edit ConfigEdit) error {
+	for _, name := range edit.Remove {
+		if err := removeService(abs, root, name); err != nil {
+			return err
+		}
+	}
+	for _, r := range edit.Rename {
+		if err := renameService(abs, root, r); err != nil {
+			return err
+		}
+	}
+	for _, add := range edit.Add {
+		if err := addService(abs, root, add); err != nil {
+			return err
+		}
+	}
+	services := mappingValue(root, "services")
+	for _, e := range edit.Services {
+		// The service is checked even for a patch that changes nothing: a
+		// caller naming a service that is not there has made a mistake, and an
+		// empty patch is not the place to swallow it.
+		svc := findService(services, e.Name)
+		if svc == nil {
+			return &ServiceNotFoundError{Path: abs, Name: e.Name}
+		}
+		if e.Patch.Empty() {
+			continue
+		}
+		applyPatch(svc, e.Patch)
+	}
+	return nil
+}
+
+// removeService drops a service from the list and from every other service's
+// depends_on, so the file that is left still validates.
+func removeService(abs string, root *yaml.Node, name string) error {
+	services := mappingValue(root, "services")
+	at := serviceIndex(services, name)
+	if at < 0 {
+		return &ServiceNotFoundError{Path: abs, Name: name}
+	}
+	services.Content = slices.Delete(services.Content, at, at+1)
+	for _, item := range services.Content {
+		if item.Kind == yaml.MappingNode {
+			dropDependency(item, name)
+		}
+	}
+	return nil
+}
+
+// renameService rewrites a service's name key and every reference to it.
+func renameService(abs string, root *yaml.Node, r ServiceRename) error {
+	services := mappingValue(root, "services")
+	svc := findService(services, r.From)
+	if svc == nil {
+		return &ServiceNotFoundError{Path: abs, Name: r.From}
+	}
+	if r.From != r.To {
+		if findService(services, r.To) != nil {
+			return &ServiceConflictError{Path: abs, Name: r.To}
+		}
+	}
+	// The name scalar is edited in place, so a comment sitting on that line
+	// stays on it and the key keeps its position in the mapping.
+	if node := mappingValue(svc, "name"); node != nil {
+		node.Value = r.To
+	}
+	for _, item := range services.Content {
+		if item.Kind == yaml.MappingNode {
+			renameDependency(item, r.From, r.To)
+		}
+	}
+	return nil
+}
+
+// addService appends a service, refusing a name or a port the file already
+// uses. A file with no `services:` key at all grows one.
+func addService(abs string, root *yaml.Node, add ServiceAdd) error {
+	services := mappingValue(root, "services")
+	if services == nil || services.Kind != yaml.SequenceNode {
+		if services != nil {
+			// A `services:` that is not a list is a file this package will not
+			// guess at; say so rather than silently replacing it.
+			return &ConfigError{Path: abs, Problems: []string{"services is not a list"}}
+		}
+		services = &yaml.Node{Kind: yaml.SequenceNode}
+		setKeyIn(root, "services", services, rootKeyOrder)
+	}
+	if findService(services, add.Name) != nil {
+		return &ServiceConflictError{Path: abs, Name: add.Name}
+	}
+	if add.Port != 0 {
+		if holder := servicePortHolder(services, add.Port); holder != "" {
+			return &ServiceConflictError{Path: abs, Name: holder, Port: add.Port}
+		}
+	}
+	services.Content = append(services.Content, serviceNode(add))
+	return nil
+}
+
+// serviceNode renders one added service as the mapping the encoder writes.
+// Keys go in through setKey, so the order matches what `sonar init` produces
+// and what a hand-written file looks like.
+func serviceNode(add ServiceAdd) *yaml.Node {
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	setKey(m, "name", strNode(add.Name))
+	if add.Cmd != "" {
+		setKey(m, "cmd", strNode(add.Cmd))
+	}
+	if add.Cwd != "" {
+		setKey(m, "cwd", strNode(add.Cwd))
+	}
+	if add.Port != 0 {
+		setKey(m, FieldPort, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(add.Port)})
+	}
+	if add.Health != "" {
+		setKey(m, FieldHealth, strNode(add.Health))
+	}
+	if add.Description != "" {
+		setKey(m, FieldDescription, strNode(add.Description))
+	}
+	if add.Icon != "" {
+		setKey(m, FieldIcon, strNode(add.Icon))
+	}
+	if add.Color != "" {
+		setKey(m, FieldColor, strNode(add.Color))
+	}
+	if len(add.DependsOn) > 0 {
+		// Flow style, because that is how `depends_on: [db]` is written
+		// everywhere else in this file format.
+		seq := &yaml.Node{Kind: yaml.SequenceNode, Style: yaml.FlowStyle}
+		for _, dep := range add.DependsOn {
+			seq.Content = append(seq.Content, strNode(dep))
+		}
+		setKey(m, "depends_on", seq)
+	}
+	return m
+}
+
+func strNode(s string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}
+}
+
+// serviceIndex is the position of a named service in the services sequence.
+func serviceIndex(services *yaml.Node, name string) int {
+	if services == nil || services.Kind != yaml.SequenceNode {
+		return -1
+	}
+	for i, item := range services.Content {
+		if item.Kind == yaml.MappingNode && mappingName(item) == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// servicePortHolder is the name of the service already declaring this port.
+func servicePortHolder(services *yaml.Node, port int) string {
+	if services == nil || services.Kind != yaml.SequenceNode {
+		return ""
+	}
+	want := strconv.Itoa(port)
+	for _, item := range services.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		if node := mappingValue(item, FieldPort); node != nil && node.Value == want {
+			return mappingName(item)
+		}
+	}
+	return ""
+}
+
+// dropDependency removes one name from a service's depends_on, and the key
+// itself once nothing is left in it.
+func dropDependency(svc *yaml.Node, name string) {
+	deps := mappingValue(svc, "depends_on")
+	if deps == nil || deps.Kind != yaml.SequenceNode {
+		return
+	}
+	kept := make([]*yaml.Node, 0, len(deps.Content))
+	for _, dep := range deps.Content {
+		if dep.Value != name {
+			kept = append(kept, dep)
+		}
+	}
+	if len(kept) == len(deps.Content) {
+		return
+	}
+	if len(kept) == 0 {
+		removeKey(svc, "depends_on")
+		return
+	}
+	deps.Content = kept
+}
+
+// renameDependency rewrites the depends_on entries naming from.
+func renameDependency(svc *yaml.Node, from, to string) {
+	deps := mappingValue(svc, "depends_on")
+	if deps == nil || deps.Kind != yaml.SequenceNode {
+		return
+	}
+	for _, dep := range deps.Content {
+		if dep.Value == from {
+			dep.Value = to
+		}
+	}
+}
+
+// Curate replaces a proposal's services with the caller's own list, which is
+// how `groups.init` writes a curated file in one call. An entry that names a
+// port the proposal also found keeps that proposal's cmd and cwd, so a client
+// editing only names, ports and metadata does not throw away the command
+// `sonar up` would need to start the service again.
+func Curate(cfg *Config, services []ServiceAdd) *Config {
+	out := *cfg
+	out.Services = make([]Service, 0, len(services))
+	for _, add := range services {
+		svc := add.Service()
+		if svc.Cmd == "" || svc.Cwd == "" {
+			if from, ok := proposedForPort(cfg, add.Port); ok {
+				if svc.Cmd == "" {
+					svc.Cmd = from.Cmd
+				}
+				if svc.Cwd == "" {
+					svc.Cwd = from.Cwd
+				}
+			}
+		}
+		out.Services = append(out.Services, svc)
+	}
+	return &out
+}
+
+func proposedForPort(cfg *Config, port int) (Service, bool) {
+	if port == 0 {
+		return Service{}, false
+	}
+	for _, s := range cfg.Services {
+		if s.Port == port {
+			return s, true
+		}
+	}
+	return Service{}, false
+}

--- a/internal/groups/edit_test.go
+++ b/internal/groups/edit_test.go
@@ -1,0 +1,498 @@
+package groups
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// oddlyOrdered is the file the add/rename/remove round trips start from:
+// comments above, beside and inside the services list, top-level keys in an
+// order nobody would choose, and one service whose own keys are back to front.
+// Every assertion below is about this file coming back recognisable.
+const oddlyOrdered = `# The sonar repo itself.
+ports: [9229] # the debugger
+services:
+  # The database has to be up before anything else.
+  - port: 5432
+    name: db
+    cmd: docker compose up db
+  - name: api
+    cmd: uv run api # served by uvicorn
+    cwd: backend
+    port: 8000
+    health: /health
+    depends_on: [db, cache]
+  # Optional, but everything is slower without it.
+  - name: cache
+    port: 6379
+name: sonar
+`
+
+// allComments are the comments this file carries; none of them may be lost by
+// an edit, wherever in the file the edit lands.
+var allComments = []string{
+	"# The sonar repo itself.",
+	"# the debugger",
+	"# The database has to be up before anything else.",
+	"# served by uvicorn",
+	"# Optional, but everything is slower without it.",
+}
+
+func requireComments(t *testing.T, out string) {
+	t.Helper()
+	for _, want := range allComments {
+		if !strings.Contains(out, want) {
+			t.Errorf("comment %q was lost:\n%s", want, out)
+		}
+	}
+}
+
+// topLevelKeys is the order of the mapping keys at column zero.
+func topLevelKeys(out string) []string {
+	var keys []string
+	for _, line := range strings.Split(out, "\n") {
+		if line == "" || line[0] == ' ' || line[0] == '#' || line[0] == '-' {
+			continue
+		}
+		if i := strings.Index(line, ":"); i > 0 {
+			keys = append(keys, line[:i])
+		}
+	}
+	return keys
+}
+
+// serviceEntry is one service's lines, found by its name key wherever in the
+// entry that key sits. patch_test.go's serviceBlock only finds a service whose
+// first key is `name`, and half the point of this file is that it need not be.
+func serviceEntry(t *testing.T, yaml, name string) []string {
+	t.Helper()
+	var blocks [][]string
+	var cur []string
+	for _, line := range strings.Split(yaml, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "- "):
+			if cur != nil {
+				blocks = append(blocks, cur)
+			}
+			cur = []string{strings.TrimPrefix(trimmed, "- ")}
+		case cur != nil && strings.HasPrefix(line, "    ") && trimmed != "":
+			cur = append(cur, trimmed)
+		case cur != nil:
+			blocks = append(blocks, cur)
+			cur = nil
+		}
+	}
+	if cur != nil {
+		blocks = append(blocks, cur)
+	}
+	for _, block := range blocks {
+		for _, line := range block {
+			if line == "name: "+name {
+				return block
+			}
+		}
+	}
+	t.Fatalf("no service %q in:\n%s", name, yaml)
+	return nil
+}
+
+// serviceNamesInFile is the services in the order the file lists them.
+func serviceNamesInFile(t *testing.T, path string) []string {
+	t.Helper()
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	out := make([]string, 0, len(cfg.Services))
+	for _, s := range cfg.Services {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+// TestAddServiceKeepsCommentsAndOrder: a service appended by the daemon must
+// leave every other line of the file where the author put it.
+func TestAddServiceKeepsCommentsAndOrder(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+
+	cfg, err := EditServices(path, ConfigEdit{Add: []ServiceAdd{{
+		Name:        "worker",
+		Port:        9000,
+		Cmd:         "uv run worker",
+		Health:      "/live",
+		Description: "background jobs",
+		Icon:        "gear",
+		Color:       "#7c3aed",
+		DependsOn:   []string{"db"},
+	}}})
+	if err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	out := read(t, path)
+	requireComments(t, out)
+
+	if got := topLevelKeys(out); !equalStrings(got, []string{"ports", "services", "name"}) {
+		t.Errorf("top-level key order = %v, want the file's own ports, services, name:\n%s", got, out)
+	}
+	// db still leads with the port key it was written with.
+	if got := keysOf(serviceEntry(t, out, "db")); !equalStrings(got, []string{"port", "name", "cmd"}) {
+		t.Errorf("db keys = %v, want the file's own order", got)
+	}
+	// The new service is last, with its keys in the order a hand-written file
+	// would use.
+	if got := serviceNamesInFile(t, path); !equalStrings(got, []string{"db", "api", "cache", "worker"}) {
+		t.Errorf("services = %v, want worker appended last", got)
+	}
+	want := []string{"name", "cmd", "port", "health", "description", "icon", "color", "depends_on"}
+	if got := keysOf(serviceEntry(t, out, "worker")); !equalStrings(got, want) {
+		t.Errorf("worker keys = %v, want %v:\n%s", got, want, out)
+	}
+	if !strings.Contains(out, "depends_on: [db]") {
+		t.Errorf("depends_on should be written in flow style:\n%s", out)
+	}
+
+	svc := cfg.Services[3]
+	if svc.Name != "worker" || svc.Port != 9000 || svc.Color != "#7c3aed" || len(svc.DependsOn) != 1 {
+		t.Errorf("returned service = %+v", svc)
+	}
+}
+
+// TestAddServiceConflicts: a name or a port the file already has is refused,
+// and the file is not touched.
+func TestAddServiceConflicts(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	before := read(t, path)
+
+	_, err := EditServices(path, ConfigEdit{Add: []ServiceAdd{{Name: "api", Port: 9000}}})
+	var clash *ServiceConflictError
+	if !errors.As(err, &clash) {
+		t.Fatalf("adding a duplicate name = %v, want *ServiceConflictError", err)
+	}
+	if clash.Name != "api" || clash.Port != 0 {
+		t.Errorf("conflict = %+v, want the name api", clash)
+	}
+
+	_, err = EditServices(path, ConfigEdit{Add: []ServiceAdd{{Name: "worker", Port: 8000}}})
+	if !errors.As(err, &clash) {
+		t.Fatalf("adding a duplicate port = %v, want *ServiceConflictError", err)
+	}
+	if clash.Port != 8000 || clash.Name != "api" {
+		t.Errorf("conflict = %+v, want port 8000 held by api", clash)
+	}
+
+	// Two adds of the same name in one call clash with each other.
+	_, err = EditServices(path, ConfigEdit{Add: []ServiceAdd{
+		{Name: "worker", Port: 9000},
+		{Name: "worker", Port: 9001},
+	}})
+	if !errors.As(err, &clash) {
+		t.Fatalf("adding the same name twice = %v, want *ServiceConflictError", err)
+	}
+
+	if after := read(t, path); after != before {
+		t.Errorf("a refused add changed the file:\n%s", after)
+	}
+}
+
+// TestAddServiceCreatesTheServicesKey: a file that only names the group grows a
+// services list in the right place.
+func TestAddServiceCreatesTheServicesKey(t *testing.T) {
+	path := writePatchable(t, "# just a name\nname: sonar\nports: [9229]\n")
+
+	if _, err := EditServices(path, ConfigEdit{Add: []ServiceAdd{{Name: "api", Port: 8000}}}); err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	out := read(t, path)
+	if !strings.Contains(out, "# just a name") {
+		t.Errorf("the comment was lost:\n%s", out)
+	}
+	if got := topLevelKeys(out); !equalStrings(got, []string{"name", "services", "ports"}) {
+		t.Errorf("top-level key order = %v, want services between name and ports:\n%s", got, out)
+	}
+}
+
+// TestRenameServiceRewritesEveryReference is the point of doing this in the
+// daemon: a rename that missed a depends_on would leave an invalid file behind.
+func TestRenameServiceRewritesEveryReference(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+
+	if _, err := EditServices(path, ConfigEdit{Rename: []ServiceRename{{From: "db", To: "database"}}}); err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	out := read(t, path)
+	requireComments(t, out)
+
+	if got := serviceNamesInFile(t, path); !equalStrings(got, []string{"database", "api", "cache"}) {
+		t.Errorf("services = %v, want db renamed in place", got)
+	}
+	if !strings.Contains(out, "depends_on: [database, cache]") {
+		t.Errorf("the depends_on reference was not rewritten:\n%s", out)
+	}
+	// The renamed service keeps its own odd key order.
+	if got := keysOf(serviceEntry(t, out, "database")); !equalStrings(got, []string{"port", "name", "cmd"}) {
+		t.Errorf("database keys = %v, want the file's own order", got)
+	}
+}
+
+func TestRenameServiceErrors(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	before := read(t, path)
+
+	_, err := EditServices(path, ConfigEdit{Rename: []ServiceRename{{From: "worker", To: "jobs"}}})
+	var missing *ServiceNotFoundError
+	if !errors.As(err, &missing) || missing.Name != "worker" {
+		t.Fatalf("renaming an unknown service = %v, want *ServiceNotFoundError", err)
+	}
+
+	_, err = EditServices(path, ConfigEdit{Rename: []ServiceRename{{From: "db", To: "api"}}})
+	var clash *ServiceConflictError
+	if !errors.As(err, &clash) || clash.Name != "api" {
+		t.Fatalf("renaming onto an existing name = %v, want *ServiceConflictError", err)
+	}
+
+	if after := read(t, path); after != before {
+		t.Errorf("a refused rename changed the file:\n%s", after)
+	}
+}
+
+// TestRenameToItselfIsAllowed: a no-op rename is not a conflict with itself.
+func TestRenameToItselfIsAllowed(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	if _, err := EditServices(path, ConfigEdit{Rename: []ServiceRename{{From: "db", To: "db"}}}); err != nil {
+		t.Fatalf("renaming a service to its own name: %v", err)
+	}
+}
+
+// TestRemoveServiceDropsDependsOn: the removed name may not survive anywhere,
+// or the file it leaves behind would not validate.
+func TestRemoveServiceDropsDependsOn(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+
+	if _, err := EditServices(path, ConfigEdit{Remove: []string{"db"}}); err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	out := read(t, path)
+
+	if got := serviceNamesInFile(t, path); !equalStrings(got, []string{"api", "cache"}) {
+		t.Errorf("services = %v, want db gone", got)
+	}
+	if !strings.Contains(out, "depends_on: [cache]") {
+		t.Errorf("db was not dropped from depends_on:\n%s", out)
+	}
+	// The comments belonging to the services that are left stay put; the one
+	// introducing db goes with it.
+	for _, want := range []string{"# The sonar repo itself.", "# served by uvicorn", "# Optional, but everything is slower without it."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("comment %q was lost:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "# The database has to be up") {
+		t.Errorf("the removed service's own comment should go with it:\n%s", out)
+	}
+
+	// Removing the last dependency takes the now-empty key with it.
+	if _, err := EditServices(path, ConfigEdit{Remove: []string{"cache"}}); err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	if out := read(t, path); strings.Contains(out, "depends_on") {
+		t.Errorf("an emptied depends_on should be removed, not left as []:\n%s", out)
+	}
+}
+
+func TestRemoveServiceUnknown(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	before := read(t, path)
+
+	var missing *ServiceNotFoundError
+	if _, err := EditServices(path, ConfigEdit{Remove: []string{"worker"}}); !errors.As(err, &missing) {
+		t.Fatalf("removing an unknown service = %v, want *ServiceNotFoundError", err)
+	}
+	if after := read(t, path); after != before {
+		t.Errorf("a refused remove changed the file:\n%s", after)
+	}
+}
+
+// TestEditIsAtomic: the four lists are one change. A rename that clashes after
+// an add has already been applied to the tree must leave the disk untouched.
+func TestEditIsAtomic(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	before := read(t, path)
+
+	_, err := EditServices(path, ConfigEdit{
+		Add:      []ServiceAdd{{Name: "worker", Port: 9000}},
+		Rename:   []ServiceRename{{From: "db", To: "api"}},
+		Services: []ServiceEdit{{Name: "cache", Patch: ServicePatch{}.SetString(FieldIcon, "zap")}},
+	})
+	var clash *ServiceConflictError
+	if !errors.As(err, &clash) {
+		t.Fatalf("the clashing rename should fail the whole edit, got %v", err)
+	}
+	if after := read(t, path); after != before {
+		t.Errorf("a failed edit wrote to the file:\n%s", after)
+	}
+}
+
+// TestEditRemoveThenAddReusesThePort is why remove runs first: swapping a
+// service for another on the same port is one call, not two.
+func TestEditRemoveThenAddReusesThePort(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+
+	cfg, err := EditServices(path, ConfigEdit{
+		Remove: []string{"cache"},
+		Add:    []ServiceAdd{{Name: "redis", Port: 6379}},
+	})
+	if err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	if got := serviceNamesInFile(t, path); !equalStrings(got, []string{"db", "api", "redis"}) {
+		t.Errorf("services = %v, want cache replaced by redis", got)
+	}
+	if cfg.Services[2].Port != 6379 {
+		t.Errorf("redis = %+v, want port 6379", cfg.Services[2])
+	}
+}
+
+// TestEditCombinesEveryList: rename, add and patch in one call, applied in the
+// documented order so each list sees what the last one did.
+func TestEditCombinesEveryList(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+
+	cfg, err := EditServices(path, ConfigEdit{
+		Remove: []string{"cache"},
+		Rename: []ServiceRename{{From: "db", To: "database"}},
+		Add:    []ServiceAdd{{Name: "worker", Port: 9000, DependsOn: []string{"database"}}},
+		Services: []ServiceEdit{
+			{Name: "worker", Patch: ServicePatch{}.SetString(FieldColor, "green")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	if got := serviceNamesInFile(t, path); !equalStrings(got, []string{"database", "api", "worker"}) {
+		t.Errorf("services = %v", got)
+	}
+	if cfg.Services[2].Color != "green" {
+		t.Errorf("the patch did not reach the service the add created: %+v", cfg.Services[2])
+	}
+	// The patch list may name a service the add list just created, and the add
+	// may depend on a service the rename just renamed.
+	if got := cfg.Services[2].DependsOn; len(got) != 1 || got[0] != "database" {
+		t.Errorf("worker depends_on = %v, want the renamed database", got)
+	}
+	// Every comment but the one introducing the removed service survives.
+	out := read(t, path)
+	for _, want := range []string{"# The sonar repo itself.", "# the debugger", "# served by uvicorn"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("comment %q was lost:\n%s", want, out)
+		}
+	}
+}
+
+// TestEditRejectsAnInvalidResult: validation runs on the rendered bytes, so a
+// depends_on pointing at nothing never reaches the disk.
+func TestEditRejectsAnInvalidResult(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	before := read(t, path)
+
+	_, err := EditServices(path, ConfigEdit{Add: []ServiceAdd{{
+		Name: "worker", Port: 9000, DependsOn: []string{"nope"},
+	}}})
+	var bad *ConfigError
+	if !errors.As(err, &bad) {
+		t.Fatalf("a dangling depends_on = %v, want *ConfigError", err)
+	}
+	if after := read(t, path); after != before {
+		t.Errorf("an invalid edit was written:\n%s", after)
+	}
+}
+
+// TestRenderEditDoesNotWrite is what `groups.init --merge` previews with.
+func TestRenderEditDoesNotWrite(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	before := read(t, path)
+
+	data, cfg, err := RenderEdit(path, ConfigEdit{Add: []ServiceAdd{{Name: "worker", Port: 9000}}})
+	if err != nil {
+		t.Fatalf("RenderEdit: %v", err)
+	}
+	if !strings.Contains(string(data), "name: worker") {
+		t.Errorf("the rendered bytes do not carry the add:\n%s", data)
+	}
+	if len(cfg.Services) != 4 {
+		t.Errorf("rendered config has %d services, want 4", len(cfg.Services))
+	}
+	if after := read(t, path); after != before {
+		t.Errorf("RenderEdit wrote to the file:\n%s", after)
+	}
+}
+
+func TestConfigEditAffectedAndEmpty(t *testing.T) {
+	if !(ConfigEdit{}).Empty() {
+		t.Error("an edit with no lists should be empty")
+	}
+	edit := ConfigEdit{
+		Remove:   []string{"old"},
+		Rename:   []ServiceRename{{From: "db", To: "database"}},
+		Add:      []ServiceAdd{{Name: "worker"}},
+		Services: []ServiceEdit{{Name: "api"}},
+	}
+	if edit.Empty() {
+		t.Error("an edit with four lists should not be empty")
+	}
+	want := []string{"old", "database", "worker", "api"}
+	if got := edit.Affected(); !equalStrings(got, want) {
+		t.Errorf("Affected() = %v, want %v", got, want)
+	}
+}
+
+// TestCurateKeepsTheProposedCommand: a client that edits names, ports and
+// colours must not throw away the command the proposal guessed.
+func TestCurateKeepsTheProposedCommand(t *testing.T) {
+	proposal := &Config{
+		Name: "demo",
+		Services: []Service{
+			{Name: "node-8000", Port: 8000, Cmd: "npm run dev", Cwd: "web"},
+			{Name: "postgres-5432", Port: 5432, Cmd: "docker compose up db"},
+		},
+	}
+	cfg := Curate(proposal, []ServiceAdd{
+		{Name: "web", Port: 8000, Color: "blue"},
+		{Name: "db", Port: 5432, Cmd: "docker start db"},
+		{Name: "worker", Port: 9000},
+	})
+
+	if len(cfg.Services) != 3 || cfg.Name != "demo" {
+		t.Fatalf("curated config = %+v", cfg)
+	}
+	if cfg.Services[0].Cmd != "npm run dev" || cfg.Services[0].Cwd != "web" || cfg.Services[0].Color != "blue" {
+		t.Errorf("web = %+v, want the proposal's cmd and cwd kept", cfg.Services[0])
+	}
+	if cfg.Services[1].Cmd != "docker start db" {
+		t.Errorf("db = %+v, want the caller's own cmd to win", cfg.Services[1])
+	}
+	if cfg.Services[2].Cmd != "" {
+		t.Errorf("worker = %+v, want no cmd: its port was not in the proposal", cfg.Services[2])
+	}
+	// The proposal itself is not modified.
+	if proposal.Services[0].Name != "node-8000" {
+		t.Errorf("Curate mutated the proposal: %+v", proposal.Services[0])
+	}
+}
+
+func TestAddsFromRoundTrips(t *testing.T) {
+	cfg := &Config{Services: []Service{
+		{Name: "api", Port: 8000, Cmd: "uv run api", Cwd: "backend", Health: "/health",
+			Description: "the api", Icon: "server", Color: "blue", DependsOn: []string{"db"}},
+	}}
+	adds := AddsFrom(cfg)
+	if len(adds) != 1 {
+		t.Fatalf("AddsFrom returned %d entries", len(adds))
+	}
+	if got := adds[0].Service(); got.Name != "api" || got.Port != 8000 || got.Cmd != "uv run api" ||
+		got.Cwd != "backend" || got.Health != "/health" || got.Description != "the api" ||
+		got.Icon != "server" || got.Color != "blue" || len(got.DependsOn) != 1 {
+		t.Errorf("round trip = %+v, want the whole service back", got)
+	}
+}

--- a/internal/groups/patch.go
+++ b/internal/groups/patch.go
@@ -165,62 +165,11 @@ func (e *ServiceNotFoundError) Error() string {
 	return fmt.Sprintf("no service %q in %s", e.Name, e.Path)
 }
 
-// PatchServices applies edits to the services in a `.sonar.yaml` and writes the
-// file back. The rewrite goes through the YAML node API rather than
-// marshalling a struct, so comments, key order and the author's own formatting
-// survive an edit made from the desktop app (contract §13.2).
-//
-// The result is validated before anything is written: a patch that would make
-// the file invalid returns a *ConfigError and leaves the file untouched. The
-// returned Config is the file as it now stands.
+// PatchServices applies metadata edits to the services in a `.sonar.yaml` and
+// writes the file back. It is EditServices with only the patch list filled in;
+// see ConfigEdit for adding, renaming and removing services.
 func PatchServices(path string, edits []ServiceEdit) (*Config, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return nil, err
-	}
-	data, err := os.ReadFile(abs)
-	if err != nil {
-		return nil, err
-	}
-
-	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil, &ConfigError{Path: abs, Problems: []string{err.Error()}}
-	}
-	root := documentRoot(&doc)
-	if root == nil || root.Kind != yaml.MappingNode {
-		return nil, &ConfigError{Path: abs, Problems: []string{"the file is not a YAML mapping"}}
-	}
-
-	services := mappingValue(root, "services")
-	for _, edit := range edits {
-		// The service is checked even for a patch that changes nothing: a
-		// caller naming a service that is not there has made a mistake, and an
-		// empty patch is not the place to swallow it.
-		svc := findService(services, edit.Name)
-		if svc == nil {
-			return nil, &ServiceNotFoundError{Path: abs, Name: edit.Name}
-		}
-		if edit.Patch.Empty() {
-			continue
-		}
-		applyPatch(svc, edit.Patch)
-	}
-
-	out, err := encode(&doc)
-	if err != nil {
-		return nil, err
-	}
-	// Validate the bytes that are about to hit the disk, not the node tree:
-	// what a later Load sees is what has to be valid.
-	cfg, err := parse(abs, out)
-	if err != nil {
-		return nil, err
-	}
-	if err := writeConfigFile(abs, out); err != nil {
-		return nil, err
-	}
-	return cfg, nil
+	return EditServices(path, ConfigEdit{Services: edits})
 }
 
 // applyPatch sets, replaces or removes each sent key of one service mapping.
@@ -235,9 +184,14 @@ func applyPatch(svc *yaml.Node, patch ServicePatch) {
 	}
 }
 
-// setKey replaces the value of an existing key in place — keeping the key's
-// comments and position — or inserts the pair where keyOrder says it belongs.
+// setKey sets a key of one service mapping, in keyOrder.
 func setKey(mapping *yaml.Node, key string, value *yaml.Node) {
+	setKeyIn(mapping, key, value, keyOrder)
+}
+
+// setKeyIn replaces the value of an existing key in place — keeping the key's
+// comments and position — or inserts the pair where order says it belongs.
+func setKeyIn(mapping *yaml.Node, key string, value *yaml.Node, order []string) {
 	for i := 0; i+1 < len(mapping.Content); i += 2 {
 		if mapping.Content[i].Value != key {
 			continue
@@ -248,27 +202,27 @@ func setKey(mapping *yaml.Node, key string, value *yaml.Node) {
 		return
 	}
 	pair := []*yaml.Node{{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, value}
-	at := insertionPoint(mapping, key)
+	at := insertionPoint(mapping, key, order)
 	mapping.Content = slices.Insert(mapping.Content, at, pair...)
 }
 
 // insertionPoint is the index in a mapping's Content where a new key belongs:
 // before the first key that sorts after it, and at the end otherwise.
-func insertionPoint(mapping *yaml.Node, key string) int {
-	rank := keyRank(key)
+func insertionPoint(mapping *yaml.Node, key string, order []string) int {
+	rank := keyRank(key, order)
 	for i := 0; i+1 < len(mapping.Content); i += 2 {
-		if keyRank(mapping.Content[i].Value) > rank {
+		if keyRank(mapping.Content[i].Value, order) > rank {
 			return i
 		}
 	}
 	return len(mapping.Content)
 }
 
-func keyRank(key string) int {
-	if i := slices.Index(keyOrder, key); i >= 0 {
+func keyRank(key string, order []string) int {
+	if i := slices.Index(order, key); i >= 0 {
 		return i
 	}
-	return len(keyOrder)
+	return len(order)
 }
 
 // removeKey drops a key and its value from a mapping.
@@ -330,9 +284,12 @@ func encode(doc *yaml.Node) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// writeConfigFile replaces a config atomically, keeping its current permissions so a
-// file the user chmodded stays that way.
-func writeConfigFile(path string, data []byte) error {
+// WriteConfigFile replaces a config atomically, keeping its current permissions so a
+// file the user chmodded stays that way. A caller that has already rendered the
+// bytes — `groups.init` merging into a file it just previewed — writes them
+// through here rather than through os.WriteFile, so a crash mid-write can never
+// leave a half a config behind.
+func WriteConfigFile(path string, data []byte) error {
 	mode := os.FileMode(0o644)
 	if info, err := os.Stat(path); err == nil {
 		mode = info.Mode().Perm()


### PR DESCRIPTION
`groups.config.set` gains `add`, `rename` and `remove` lists applied atomically in that order before `services` patches, preserving comments and ordering; a new `conflict` (1011) error covers duplicate names and ports. `groups.init` gains `services` to curate its proposal and `merge` to append into an existing file. CLI: `sonar groups add|rename|remove` and `sonar init --service --merge`. Contract §48.