### PR TITLE
feat: install the desktop app with sonar install desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,7 @@ is 0 unless something **failed**, so `sonar doctor` belongs in a setup script.
 | `hooks_installed` | the optional Claude Code hooks are installed |
 | `project_config` | this project has a `.sonar.yaml` that loads |
 | `docker` | the docker CLI is there and its daemon answers |
+| `desktop_installed` | the desktop app is installed, and which version (`skip` on Windows) |
 | `tray` | the superseded macOS `sonar-tray` binary is still around |
 
 `--fix` applies only the repairs that are safe to make unattended, and asks
@@ -764,13 +765,71 @@ process; the three checks that are about the CLI binary you invoked
 The Sonar app is the same picture in a window and in the menu bar or system
 tray: groups down the side, ports in a grid with live stats and health, logs,
 and the buttons for everything above. It talks to the same daemon, so the CLI
-and the app never disagree. `sonar tray` launches it if it is installed and
-otherwise tells you where to get it:
-<https://github.com/raskrebs/sonar/releases>.
+and the app never disagree. `sonar install desktop` installs it and `sonar
+tray` launches it.
 
 Until the app ships, macOS release tarballs still carry the old `sonar-tray`
 menu bar binary, and `sonar tray` falls back to it when the app is not
 installed.
+
+### `sonar install desktop`
+
+The app is in beta and is not signed by Apple yet, so the CLI installs it:
+
+```sh
+brew install raskrebs/sonar/sonar && sonar install desktop
+```
+
+That is the whole tester setup. Sonar fetches a manifest of published builds,
+picks the one for your machine, checks its sha256 and its size, installs it,
+and opens it.
+
+**This is why the CLI does the download.** macOS attaches a quarantine
+attribute to anything a *browser* saves, and Gatekeeper refuses to open a
+quarantined app that Apple has not notarised. A file this CLI downloads never
+gets the attribute in the first place, so the beta opens with no prompt and no
+right-click-Open dance. Sonar neither sets nor strips quarantine attributes —
+there is nothing to strip.
+
+```sh
+sonar install desktop                    # install and launch
+sonar install desktop --no-launch        # install only
+sonar install desktop --update           # update; does nothing if current
+sonar install desktop --check            # exit 1 when an update is available
+sonar install desktop --version 0.1.0-beta.1
+sonar install desktop --force            # ask a running Sonar to quit first
+sonar install desktop --json             # for scripts
+```
+
+The command needs no network to tell you what it does:
+
+```sh
+sonar install desktop --help | grep -- '--no-launch'
+# check
+```
+
+Where it goes:
+
+| | |
+| --- | --- |
+| macOS | `/Applications/Sonar.app`, or `~/Applications/Sonar.app` when the first is not writable (sonar never uses `sudo`) |
+| Linux | `~/.local/opt/sonar-desktop/Sonar.AppImage`, plus a menu entry in `~/.local/share/applications` and a `sonar-desktop` link in `~/.local/bin` |
+| Windows | not yet — the command says so and exits 1 |
+
+`--dir` overrides the directory on both. On Linux, `--deb` installs the `.deb`
+through `apt`/`dpkg` instead of the AppImage, where the release publishes one.
+
+The install is atomic: the new app is unpacked beside the old one and swapped
+in with a rename, so a failed download never leaves you without a working app.
+If the app is open, sonar refuses rather than replacing a bundle underneath it;
+`--force` asks it to quit and waits up to ten seconds.
+
+`sonar install desktop` records `desktop.installed_version` and
+`desktop.installed_path` in `~/.config/sonar/config.yaml`, which is how `sonar
+tray` finds an app installed with `--dir` and how `sonar doctor`'s
+`desktop_installed` check knows the version. Where the builds come from is
+`desktop.download_base`, overridden by `SONAR_DESKTOP_BASE` and then by
+`--base` — point them at your own build to test one.
 
 ### `sonar relay`
 
@@ -874,6 +933,10 @@ one: `/proc` on Linux, `lsof` on macOS, and on Windows a read of the process's
 own PEB. So git-root groups, `project_root` and cwd-based names work the same
 everywhere, and `sonar init` can propose a `.sonar.yaml` from what is listening
 on any of the three.
+
+The desktop app is narrower for now: `sonar install desktop` installs it on
+macOS (Apple Silicon and Intel) and Linux (x86_64 and aarch64). On Windows the
+command says the app is not available yet and exits 1.
 
 The one gap is a 32-bit `sonar.exe` on 64-bit Windows: it cannot read a 64-bit
 process's memory, so those ports come back without a working directory and fall

--- a/internal/cmd/install_desktop.go
+++ b/internal/cmd/install_desktop.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/raskrebs/sonar/internal/desktop"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/spf13/cobra"
+)
+
+var (
+	installDesktopBase     string
+	installDesktopVersion  string
+	installDesktopDir      string
+	installDesktopNoLaunch bool
+	installDesktopJSON     bool
+	installDesktopForce    bool
+	installDesktopUpdate   bool
+	installDesktopCheck    bool
+	installDesktopDeb      bool
+)
+
+var installDesktopCmd = &cobra.Command{
+	Use:   "desktop",
+	Short: "Download and install the Sonar desktop app",
+	Long: `Download and install the Sonar desktop app.
+
+Sonar fetches a signed manifest of published builds, downloads the one for this
+machine, checks its sha256 and size, and puts it where the system expects it:
+/Applications on macOS (falling back to ~/Applications when that is not
+writable — never sudo), ~/.local/opt/sonar-desktop on Linux, with a menu entry
+and a sonar-desktop link in ~/.local/bin. Then it opens the app.
+
+The app is not signed by Apple yet. Because sonar downloads it rather than a
+browser, macOS attaches no quarantine attribute and it opens without a
+Gatekeeper prompt — nothing here sets or strips quarantine.
+
+Examples:
+  sonar install desktop                       # install and launch
+  sonar install desktop --no-launch           # install only
+  sonar install desktop --update              # update, no-op if current
+  sonar install desktop --check               # exit 1 if an update is available
+  sonar install desktop --version 0.1.0-beta.1
+  sonar install desktop --base https://example.com/sonar-desktop`,
+	Args: cobra.NoArgs,
+	// The report is the output. Without this, cobra prints its own "Error:"
+	// line on top of the one Execute prints, and --check's silent non-zero
+	// exit prints a bare "Error:" with nothing after it.
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          installDesktopRun,
+}
+
+func init() {
+	f := installDesktopCmd.Flags()
+	f.StringVar(&installDesktopBase, "base", "", "Where to fetch desktop.json and its artifacts")
+	f.StringVar(&installDesktopVersion, "version", "", "Install a specific version instead of the latest")
+	f.StringVar(&installDesktopDir, "dir", "", "Install directory (default /Applications, or ~/.local/opt/sonar-desktop on Linux)")
+	f.BoolVar(&installDesktopNoLaunch, "no-launch", false, "Install without opening the app")
+	f.BoolVar(&installDesktopJSON, "json", false, "Print the result as JSON")
+	f.BoolVar(&installDesktopForce, "force", false, "Ask a running Sonar to quit instead of refusing")
+	f.BoolVar(&installDesktopUpdate, "update", false, "Update an existing install, doing nothing when it is current")
+	f.BoolVar(&installDesktopCheck, "check", false, "Report installed and available versions; exit 1 when an update is available")
+	f.BoolVar(&installDesktopDeb, "deb", false, "Linux: install the .deb through apt/dpkg instead of the AppImage")
+	installCmd.AddCommand(installDesktopCmd)
+}
+
+func installDesktopRun(cmd *cobra.Command, args []string) error {
+	opts := desktop.Options{
+		Base: desktop.ResolveBase(
+			installDesktopBase,
+			os.Getenv(desktop.BaseEnv),
+			loadedConfig.Desktop.DownloadBase,
+		),
+		Version:  installDesktopVersion,
+		Dir:      installDesktopDir,
+		NoLaunch: installDesktopNoLaunch,
+		Force:    installDesktopForce,
+		Update:   installDesktopUpdate,
+		Check:    installDesktopCheck,
+		Deb:      installDesktopDeb,
+		Out:      os.Stderr,
+		// A progress line is redrawn with carriage returns, which is noise in
+		// a log and corruption in a JSON pipeline.
+		Progress: !installDesktopJSON && isTerminal(os.Stderr),
+	}
+
+	res, err := desktop.Run(cmd.Context(), opts)
+	if err != nil {
+		var notAvailable *desktop.ErrNotAvailable
+		if errors.As(err, &notAvailable) && installDesktopJSON {
+			// Even the refusal is machine-readable under --json, so a
+			// cross-platform installer script can branch on it.
+			printJSON(map[string]any{"action": "unavailable", "error": err.Error()})
+			return errSilent
+		}
+		return err
+	}
+
+	if installDesktopJSON {
+		printJSON(res)
+		if res.Action == desktop.ActionChecked && !res.UpToDate {
+			return errSilent
+		}
+		return nil
+	}
+	return reportDesktopResult(res)
+}
+
+func reportDesktopResult(res *desktop.Result) error {
+	switch res.Action {
+	case desktop.ActionChecked:
+		installed := res.InstalledVersion
+		if installed == "" {
+			installed = "not installed"
+		} else if res.Path != "" {
+			installed = fmt.Sprintf("%s (%s)", installed, res.Path)
+		}
+		fmt.Printf("installed:  %s\n", installed)
+		fmt.Printf("available:  %s\n", res.Version)
+		if res.UpToDate {
+			fmt.Println(display.Dim("up to date"))
+			return nil
+		}
+		fmt.Println("run `sonar install desktop --update` to update")
+		return errSilent
+
+	case desktop.ActionUpToDate:
+		fmt.Printf("Sonar %s is already installed at %s\n", res.InstalledVersion, res.Path)
+		return nil
+	}
+
+	for _, note := range res.Notes {
+		fmt.Fprintln(os.Stderr, "note: "+note)
+	}
+	verb := "installed"
+	if res.Action == desktop.ActionUpdated {
+		verb = fmt.Sprintf("updated %s →", res.PreviousVersion)
+	}
+	fmt.Printf("Sonar %s %s at %s\n", verb, res.Version, res.Path)
+	if res.Launched {
+		fmt.Println("launched — it lives in the menu bar; `sonar tray` opens it again")
+	} else if res.NotesURL != "" {
+		fmt.Println("release notes: " + res.NotesURL)
+	}
+	return nil
+}
+
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+// isTerminal reports whether w is a character device, which is the only place
+// a redrawing progress line makes sense.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/cmd/install_desktop_test.go
+++ b/internal/cmd/install_desktop_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/desktop"
+)
+
+func TestInstallDesktopIsRegisteredWithItsFlags(t *testing.T) {
+	var found bool
+	for _, c := range rootCmd.Commands() {
+		if c.Name() != "install" {
+			continue
+		}
+		for _, s := range c.Commands() {
+			if s.Name() != "desktop" {
+				continue
+			}
+			found = true
+			for _, name := range []string{"base", "version", "dir", "no-launch", "json", "force", "update", "check", "deb"} {
+				if s.Flags().Lookup(name) == nil {
+					t.Errorf("install desktop has no --%s", name)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("`sonar install desktop` is not registered")
+	}
+}
+
+func TestReportDesktopCheck(t *testing.T) {
+	t.Run("behind exits non-zero", func(t *testing.T) {
+		var err error
+		out := captureStdout(t, func() {
+			err = reportDesktopResult(&desktop.Result{
+				Action:           desktop.ActionChecked,
+				Version:          "0.2.0",
+				InstalledVersion: "0.1.0",
+				Path:             "/Applications/Sonar.app",
+			})
+		})
+		if !errors.Is(err, errSilent) {
+			t.Errorf("err = %v, want the silent non-zero exit", err)
+		}
+		for _, want := range []string{"0.1.0", "/Applications/Sonar.app", "0.2.0", "--update"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output is missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("current exits zero", func(t *testing.T) {
+		var err error
+		out := captureStdout(t, func() {
+			err = reportDesktopResult(&desktop.Result{
+				Action:           desktop.ActionChecked,
+				Version:          "0.2.0",
+				InstalledVersion: "0.2.0",
+				Path:             "/Applications/Sonar.app",
+				UpToDate:         true,
+			})
+		})
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+		if !strings.Contains(out, "up to date") {
+			t.Errorf("output = %q", out)
+		}
+	})
+
+	t.Run("nothing installed", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			_ = reportDesktopResult(&desktop.Result{Action: desktop.ActionChecked, Version: "0.2.0"})
+		})
+		if !strings.Contains(out, "not installed") {
+			t.Errorf("output = %q, want it to say nothing is installed", out)
+		}
+	})
+}
+
+func TestReportDesktopUpToDateUpdate(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := reportDesktopResult(&desktop.Result{
+			Action:           desktop.ActionUpToDate,
+			InstalledVersion: "0.2.0",
+			Path:             "/Applications/Sonar.app",
+		})
+		if err != nil {
+			t.Errorf("a no-op update is not a failure: %v", err)
+		}
+	})
+	if !strings.Contains(out, "already installed") {
+		t.Errorf("output = %q", out)
+	}
+}
+
+func TestReportDesktopInstalled(t *testing.T) {
+	out := captureStdout(t, func() {
+		_ = reportDesktopResult(&desktop.Result{
+			Action:   desktop.ActionInstalled,
+			Version:  "0.1.0-beta.1",
+			Path:     "/Applications/Sonar.app",
+			Launched: true,
+		})
+	})
+	for _, want := range []string{"0.1.0-beta.1", "/Applications/Sonar.app", "launched"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output is missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cmd/tray.go
+++ b/internal/cmd/tray.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/raskrebs/sonar/internal/tray"
 	"github.com/spf13/cobra"
+
+	"github.com/raskrebs/sonar/internal/tray"
 )
 
 var trayCmd = &cobra.Command{
@@ -11,8 +12,8 @@ var trayCmd = &cobra.Command{
 	Long: "Launch the Sonar desktop app, which lives in the menu bar or system tray\n" +
 		"and shows every port, group and health check live.\n\n" +
 		"If the app is not installed, sonar falls back to the older macOS menu bar\n" +
-		"binary (sonar-tray) when it is present, and otherwise prints where to\n" +
-		"download the app: " + tray.DownloadURL,
+		"binary (sonar-tray) when it is present, and otherwise points at\n" +
+		"`sonar install desktop`, which downloads and installs it.",
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,24 @@ type Config struct {
 	// Remote holds the registered SSH hosts the daemon bridges to (see
 	// remote.go).
 	Remote RemoteConfig `yaml:"remote"`
+	// Desktop holds where the desktop app comes from and what
+	// `sonar install desktop` last put on this machine.
+	Desktop DesktopConfig `yaml:"desktop"`
+}
+
+// DesktopConfig is the desktop app's corner of the config. download_base is a
+// setting; the two installed_* keys are a record `sonar install desktop`
+// writes and `sonar tray`, `sonar doctor` and `--check` read, so an app
+// installed with --dir is still found and an update knows what it is
+// replacing.
+type DesktopConfig struct {
+	// DownloadBase overrides where the manifest and artifacts are fetched
+	// from. Empty means the built-in default.
+	DownloadBase string `yaml:"download_base"`
+	// InstalledVersion is the version of the app on this machine.
+	InstalledVersion string `yaml:"installed_version"`
+	// InstalledPath is where it was installed.
+	InstalledPath string `yaml:"installed_path"`
 }
 
 // DefaultIdleTimeout is how long `sonar serve` stays up with no clients, no
@@ -135,17 +153,22 @@ func Path() string {
 // missing file yields an empty Config with no warnings; a malformed file or
 // invalid values yield a Config with the bad settings dropped plus
 // human-readable warning strings for the caller to print.
-func Load() (*Config, []string) {
+func Load() (*Config, []string) { return LoadFrom(Path()) }
+
+// LoadFrom is Load against an explicit file. `sonar doctor` uses it: its
+// checks read the config path in its Env, which a test points at a fixture,
+// and going through Path() would read the developer's own file instead.
+func LoadFrom(path string) (*Config, []string) {
 	cfg := &Config{}
 
-	data, err := os.ReadFile(Path())
+	data, err := os.ReadFile(path)
 	if err != nil {
 		// Missing/unreadable file is not an error — run with defaults.
 		return cfg, nil
 	}
 
 	if err := yaml.Unmarshal(data, cfg); err != nil {
-		return &Config{}, []string{fmt.Sprintf("ignoring %s: %v", Path(), err)}
+		return &Config{}, []string{fmt.Sprintf("ignoring %s: %v", path, err)}
 	}
 
 	warnings := validate(cfg)
@@ -198,6 +221,15 @@ const template = `# sonar configuration
 #       identity: ~/.ssh/id_ed25519
 #       remote_bin: ~/.local/bin/sonar
 
+# desktop:          # the Sonar desktop app
+#   # Where 'sonar install desktop' fetches desktop.json and the artifacts it
+#   # names. --base and SONAR_DESKTOP_BASE both win over this.
+#   download_base: https://github.com/raskrebs/sonar-desktop-releases/releases/latest/download
+#   # Written by 'sonar install desktop'; read by 'sonar tray', 'sonar doctor'
+#   # and 'sonar install desktop --check'. Edit only to point them elsewhere.
+#   installed_version: 0.1.0-beta.1
+#   installed_path: /Applications/Sonar.app
+
 # Environment overrides (no config key; set them in your shell):
 #   SONAR_DB       path to the database of names, pins and history
 #                  (default: sonar.db next to this file)
@@ -208,6 +240,9 @@ const template = `# sonar configuration
 #   SONAR_NO_AUTOSTART
 #                  set to 1 to stop clients starting a daemon that is not
 #                  already running; they report it as unavailable instead
+#   SONAR_DESKTOP_BASE
+#                  where 'sonar install desktop' looks, overriding
+#                  desktop.download_base
 `
 
 // WriteTemplate writes a commented starter config to Path(), creating the

--- a/internal/desktop/desktop.go
+++ b/internal/desktop/desktop.go
@@ -1,0 +1,384 @@
+package desktop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Actions a run reports.
+const (
+	ActionInstalled = "installed"
+	ActionUpdated   = "updated"
+	ActionUpToDate  = "up-to-date"
+	ActionChecked   = "checked"
+)
+
+// QuitWait is how long --force waits for a running app to go away after it has
+// been asked to quit.
+const QuitWait = 10 * time.Second
+
+// Exec runs an external command and returns its combined output. Every process
+// this package starts goes through it, so a test can drive the whole installer
+// on a machine that has neither `open` nor `pgrep -f Sonar.AppImage` matching
+// anything real.
+type Exec func(ctx context.Context, name string, args ...string) (string, error)
+
+// Options is one `sonar install desktop` invocation.
+type Options struct {
+	// Base is the resolved download base; empty means DefaultBase.
+	Base string
+	// Version pins a release; empty means whatever the base serves.
+	Version string
+	// Dir overrides the install directory: the Applications directory on
+	// macOS, the opt directory holding the AppImage on Linux.
+	Dir string
+
+	NoLaunch bool
+	Force    bool
+	Update   bool
+	Check    bool
+	Deb      bool
+
+	// GOOS and GOARCH default to this build's, and are fields so the Linux
+	// path can be exercised from a macOS test run and back.
+	GOOS, GOARCH string
+	// Home is the user's home directory; every path this package writes on
+	// Linux, and the /Applications fallback on macOS, hangs off it.
+	Home string
+	// TempDir is where downloads land before they are verified.
+	TempDir string
+
+	// Out receives the human-readable notes and the progress line.
+	Out io.Writer
+	// Progress asks for a redrawing progress line; callers set it only on a
+	// terminal.
+	Progress bool
+
+	HTTPClient *http.Client
+	Exec       Exec
+	LookPath   func(string) (string, error)
+	// Launch starts the installed app. It is a seam because the two platforms
+	// start an app in genuinely different ways and neither is something a test
+	// should actually do.
+	Launch func(ctx context.Context, opts *Options, path string) error
+	// State reads and writes desktop.installed_* in the user's config.
+	State StateStore
+
+	// systemApps is /Applications, as a field so a test can point the
+	// not-writable fallback at a directory it owns. Nothing outside this
+	// package sets it, and nothing should: an explicit --dir is the supported
+	// way to install somewhere else.
+	systemApps string
+}
+
+// Result is what a run did, and the shape of `--json`.
+type Result struct {
+	Action   string `json:"action"`
+	Platform string `json:"platform"`
+	// Version is what the manifest offers.
+	Version string `json:"version"`
+	// InstalledVersion is what is on the machine after the run — the same as
+	// Version except for `--check`, where it is what was already there.
+	InstalledVersion string `json:"installed_version"`
+	// PreviousVersion is what was replaced, when anything was.
+	PreviousVersion string `json:"previous_version,omitempty"`
+	Path            string `json:"path,omitempty"`
+	NotesURL        string `json:"notes_url,omitempty"`
+	PublishedAt     string `json:"published_at,omitempty"`
+	Launched        bool   `json:"launched"`
+	// UpToDate is only meaningful for `--check` and `--update`.
+	UpToDate bool `json:"up_to_date"`
+	// Notes are the things a human should read: the ~/Applications fallback,
+	// a skipped desktop-database refresh.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// ErrNotAvailable is the platforms sonar has no installer for at all. It is
+// separate from UnsupportedPlatformError, which is a manifest that happens not
+// to carry this machine.
+type ErrNotAvailable struct{ GOOS string }
+
+func (e *ErrNotAvailable) Error() string {
+	return fmt.Sprintf("the desktop app is not available for %s yet", e.GOOS)
+}
+
+// ErrRunning is the app being open when it is about to be replaced.
+type ErrRunning struct{ PIDs []int }
+
+func (e *ErrRunning) Error() string {
+	return fmt.Sprintf("Sonar is running (pid %s) — quit it first, or pass --force to have sonar ask it to quit",
+		strings.Join(pidStrings(e.PIDs), ", "))
+}
+
+func pidStrings(pids []int) []string {
+	out := make([]string, 0, len(pids))
+	for _, p := range pids {
+		out = append(out, strconv.Itoa(p))
+	}
+	return out
+}
+
+func (o *Options) fill() {
+	if o.GOOS == "" {
+		o.GOOS = runtime.GOOS
+	}
+	if o.GOARCH == "" {
+		o.GOARCH = runtime.GOARCH
+	}
+	if o.Home == "" {
+		o.Home, _ = os.UserHomeDir()
+	}
+	if o.TempDir == "" {
+		o.TempDir = os.TempDir()
+	}
+	if o.Out == nil {
+		o.Out = io.Discard
+	}
+	if o.HTTPClient == nil {
+		o.HTTPClient = newHTTPClient()
+	}
+	if o.LookPath == nil {
+		o.LookPath = exec.LookPath
+	}
+	if o.Exec == nil {
+		o.Exec = runCommand
+	}
+	if o.Launch == nil {
+		o.Launch = launch
+	}
+	if o.State == nil {
+		o.State = ConfigStore{}
+	}
+	if o.Base == "" {
+		o.Base = DefaultBase
+	}
+}
+
+// runCommand is the real Exec.
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	return string(out), err
+}
+
+// Supported reports whether this package can install the app for a GOOS.
+// Windows is deliberately absent: the app has an installer of its own there
+// and no manifest entry yet, so the command builds and refuses rather than
+// pretending.
+func Supported(goos string) bool { return goos == "darwin" || goos == "linux" }
+
+// Run performs one invocation: fetch the manifest, decide, and either report
+// (`--check`), do nothing (`--update` on the current version) or download,
+// verify, install, record and launch.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	o := &opts
+	o.fill()
+
+	if !Supported(o.GOOS) {
+		return nil, &ErrNotAvailable{GOOS: o.GOOS}
+	}
+
+	key := PlatformKey(o.GOOS, o.GOARCH)
+	manifestURL := ManifestURL(o.Base, o.Version)
+	manifest, err := o.fetchManifest(ctx, manifestURL)
+	if err != nil {
+		return nil, err
+	}
+	platform, err := manifest.Pick(key, manifestURL)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := o.State.Load()
+	if err != nil {
+		return nil, err
+	}
+	// A recorded version whose bundle has since been dragged to the trash is
+	// not installed. Trusting the config alone would make `--update` a no-op
+	// on a machine with no app on it.
+	if state.Path != "" && !exists(state.Path) {
+		state = State{}
+	}
+
+	res := &Result{
+		Action:           ActionInstalled,
+		Platform:         key,
+		Version:          manifest.Version,
+		InstalledVersion: state.Version,
+		PreviousVersion:  state.Version,
+		Path:             state.Path,
+		NotesURL:         manifest.NotesURL,
+		PublishedAt:      manifest.PublishedAt,
+		UpToDate:         state.Version != "" && SameVersion(state.Version, manifest.Version),
+	}
+
+	if o.Check {
+		res.Action = ActionChecked
+		return res, nil
+	}
+	if o.Update && res.UpToDate {
+		res.Action = ActionUpToDate
+		return res, nil
+	}
+
+	art := platform.Artifact
+	if o.Deb {
+		if o.GOOS != "linux" {
+			return nil, errors.New("--deb is a Linux option")
+		}
+		if platform.Deb == nil {
+			return nil, fmt.Errorf("this release publishes no .deb for %s", key)
+		}
+		art = *platform.Deb
+	}
+
+	archive, err := o.downloadArtifact(ctx, art, o.TempDir, "Sonar "+manifest.Version)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.Remove(archive) }()
+
+	var path string
+	var notes []string
+	if o.GOOS == "darwin" {
+		path, notes, err = o.installMacOS(ctx, archive)
+	} else {
+		path, notes, err = o.installLinux(ctx, archive)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	res.Path = path
+	res.Notes = notes
+	res.InstalledVersion = manifest.Version
+	res.UpToDate = true
+	if state.Version != "" {
+		res.Action = ActionUpdated
+	}
+
+	if err := o.State.Save(State{Version: manifest.Version, Path: path}); err != nil {
+		// The app is installed; failing the command now would make a
+		// successful install look like a failed one. Say it and carry on.
+		res.Notes = append(res.Notes, "could not record the install in the config: "+err.Error())
+	}
+
+	if !o.NoLaunch {
+		if err := o.Launch(ctx, o, path); err != nil {
+			res.Notes = append(res.Notes, "could not launch the app: "+err.Error())
+		} else {
+			res.Launched = true
+		}
+	}
+	return res, nil
+}
+
+// running returns the pids of a running desktop app, found by the command line
+// each platform's app actually has.
+func (o *Options) running(ctx context.Context) []int {
+	pattern := runningPattern(o.GOOS)
+	if pattern == "" {
+		return nil
+	}
+	out, err := o.Exec(ctx, "pgrep", "-f", pattern)
+	if err != nil {
+		// pgrep exits 1 when nothing matches, which is the common case, and
+		// exits 127 when it is not installed at all. Neither is worth
+		// reporting: the worst outcome is replacing a bundle under a running
+		// app, which macOS tolerates and the user notices on next launch.
+		return nil
+	}
+	var pids []int
+	for _, line := range strings.Fields(out) {
+		if pid, err := strconv.Atoi(line); err == nil && pid > 0 {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+func runningPattern(goos string) string {
+	switch goos {
+	case "darwin":
+		return "Sonar.app/Contents/MacOS/sonar-desktop"
+	case "linux":
+		return "Sonar.AppImage"
+	default:
+		return ""
+	}
+}
+
+// ensureNotRunning is the gate in front of every replace. Without --force it
+// refuses; with it, it asks the app to quit and waits.
+func (o *Options) ensureNotRunning(ctx context.Context) error {
+	pids := o.running(ctx)
+	if len(pids) == 0 {
+		return nil
+	}
+	if !o.Force {
+		return &ErrRunning{PIDs: pids}
+	}
+	o.note("asking Sonar to quit")
+	o.quit(ctx, pids)
+
+	deadline := time.Now().Add(QuitWait)
+	for time.Now().Before(deadline) {
+		if len(o.running(ctx)) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("Sonar did not quit within %s — quit it by hand and run this again", QuitWait)
+}
+
+// quit asks the app to go away the way its platform expects: on macOS through
+// AppleScript, which gives the app the same "quit" a user's ⌘Q does, and on
+// Linux with a TERM to each pid, which is what an AppImage understands.
+func (o *Options) quit(ctx context.Context, pids []int) {
+	if o.GOOS == "darwin" {
+		_, _ = o.Exec(ctx, "osascript", "-e", `quit app "Sonar"`)
+		return
+	}
+	args := append([]string{"-TERM"}, pidStrings(pids)...)
+	_, _ = o.Exec(ctx, "kill", args...)
+}
+
+func (o *Options) note(format string, args ...any) {
+	if o.Out != nil {
+		fmt.Fprintf(o.Out, format+"\n", args...)
+	}
+}
+
+func exists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// writable reports whether a directory can be written to by this process. It
+// answers by creating a file, because the mode bits lie on any machine with
+// ACLs — and /Applications on a managed Mac is exactly such a machine.
+func writable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".sonar-write-test-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	f.Close()
+	_ = os.Remove(name)
+	return true
+}

--- a/internal/desktop/detach_unix.go
+++ b/internal/desktop/detach_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package desktop
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachProcess puts the child in its own session, so the app outlives the
+// shell that installed it.
+func detachProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/desktop/detach_windows.go
+++ b/internal/desktop/detach_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package desktop
+
+import "os/exec"
+
+// detachProcess is a no-op on Windows, which has no installer here yet and no
+// session to leave.
+func detachProcess(cmd *exec.Cmd) {}

--- a/internal/desktop/download.go
+++ b/internal/desktop/download.go
@@ -1,0 +1,204 @@
+package desktop
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// The two budgets are different on purpose. The manifest is a few hundred
+// bytes and a machine that cannot fetch it in a minute is not going to fetch
+// forty megabytes either, so it fails fast. The artifact is the forty
+// megabytes, and a tester on a hotel connection is not doing anything wrong;
+// it gets a budget long enough to finish and short enough that a stalled
+// transfer eventually reports rather than hangs for the afternoon.
+const (
+	// ConnectTimeout is how long a TCP connection may take to establish.
+	ConnectTimeout = 2 * time.Second
+	// ManifestTimeout is the whole-request budget for fetching desktop.json.
+	ManifestTimeout = 60 * time.Second
+	// ArtifactTimeout is the whole-request budget for one artifact.
+	ArtifactTimeout = 15 * time.Minute
+)
+
+// newHTTPClient builds the client both fetches use. Redirects are followed —
+// every GitHub release asset URL is a redirect to object storage — and the
+// connect phase is bounded separately from the transfer, so a host that does
+// not answer is reported in two seconds rather than at the end of the budget.
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext:           (&net.Dialer{Timeout: ConnectTimeout}).DialContext,
+			TLSHandshakeTimeout:   ConnectTimeout,
+			ResponseHeaderTimeout: 30 * time.Second,
+			Proxy:                 http.ProxyFromEnvironment,
+		},
+	}
+}
+
+// fetchManifest reads desktop.json from a URL.
+func (o *Options) fetchManifest(ctx context.Context, manifestURL string) (*Manifest, error) {
+	ctx, cancel := context.WithTimeout(ctx, ManifestTimeout)
+	defer cancel()
+
+	body, err := o.get(ctx, manifestURL, ManifestTimeout)
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	// A manifest is small; a base URL that is really an HTML error page is
+	// not, and reading it whole would be the one way this command uses real
+	// memory. One megabyte is far more than any manifest and far less than a
+	// mistake.
+	data, err := io.ReadAll(io.LimitReader(body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", manifestURL, err)
+	}
+	return ParseManifest(data)
+}
+
+// get issues the GET and returns the body, or an error naming the URL.
+func (o *Options) get(ctx context.Context, rawURL string, budget time.Duration) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s is not a usable URL: %w", rawURL, err)
+	}
+	req.Header.Set("User-Agent", "sonar-install-desktop")
+	resp, err := o.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", rawURL, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		return nil, fmt.Errorf("%s returned 404 — is that the right --base or --version?", rawURL)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("%s returned %s", rawURL, resp.Status)
+	}
+	return resp.Body, nil
+}
+
+// downloadArtifact fetches one artifact into dir and returns the path of the
+// file it wrote. The caller owns the file, including removing it.
+//
+// Verification happens on the way in: the digest is computed from the same
+// bytes that reach the disk, so there is no window in which a verified file
+// could be replaced before it is used.
+func (o *Options) downloadArtifact(ctx context.Context, art Artifact, dir, name string) (string, error) {
+	if strings.TrimSpace(art.SHA256) == "" {
+		return "", fmt.Errorf("%s has no sha256 for %s — refusing to install an unverifiable download", ManifestName, art.URL)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, ArtifactTimeout)
+	defer cancel()
+
+	body, err := o.get(ctx, art.URL, ArtifactTimeout)
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	tmp, err := os.CreateTemp(dir, ".sonar-desktop-*")
+	if err != nil {
+		return "", fmt.Errorf("creating a temporary file in %s: %w", dir, err)
+	}
+	path := tmp.Name()
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.Remove(path)
+		}
+	}()
+
+	sum := sha256.New()
+	written, err := io.Copy(io.MultiWriter(tmp, sum), o.progressReader(body, art.Size, name))
+	o.endProgress()
+	if cerr := tmp.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		return "", fmt.Errorf("downloading %s: %w", art.URL, err)
+	}
+
+	if art.Size > 0 && written != art.Size {
+		return "", fmt.Errorf("%s is %d bytes, the manifest says %d — the download did not complete",
+			filepath.Base(art.URL), written, art.Size)
+	}
+	got := hex.EncodeToString(sum.Sum(nil))
+	if !strings.EqualFold(got, strings.TrimSpace(art.SHA256)) {
+		return "", fmt.Errorf("%s failed its checksum: got %s, the manifest says %s",
+			filepath.Base(art.URL), got, strings.ToLower(strings.TrimSpace(art.SHA256)))
+	}
+
+	ok = true
+	return path, nil
+}
+
+// progressReader wraps r with a progress line when the caller asked for one.
+// Off a TTY (and under --json) it is the reader itself: a build log does not
+// want a hundred carriage returns.
+func (o *Options) progressReader(r io.Reader, total int64, name string) io.Reader {
+	if !o.Progress || o.Out == nil {
+		return r
+	}
+	return &progressReader{r: r, total: total, name: name, out: o.Out, last: time.Now()}
+}
+
+func (o *Options) endProgress() {
+	if o.Progress && o.Out != nil {
+		fmt.Fprintln(o.Out)
+	}
+}
+
+type progressReader struct {
+	r     io.Reader
+	out   io.Writer
+	name  string
+	total int64
+	done  int64
+	last  time.Time
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	p.done += int64(n)
+	// Ten frames a second is smooth to a human and cheap on a serial line;
+	// redrawing per Read would spend more time formatting than copying.
+	if time.Since(p.last) >= 100*time.Millisecond || err == io.EOF {
+		p.last = time.Now()
+		p.draw()
+	}
+	return n, err
+}
+
+func (p *progressReader) draw() {
+	if p.total > 0 {
+		fmt.Fprintf(p.out, "\r  %s  %s / %s (%d%%)   ",
+			p.name, humanBytes(p.done), humanBytes(p.total), p.done*100/p.total)
+		return
+	}
+	fmt.Fprintf(p.out, "\r  %s  %s   ", p.name, humanBytes(p.done))
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/internal/desktop/extract.go
+++ b/internal/desktop/extract.go
@@ -1,0 +1,163 @@
+package desktop
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// extractBundle unpacks a .app.tar.gz into dest, stripping the bundle's own
+// top-level directory. The tarball contains `Sonar.app/Contents/...`, and dest
+// is the path the bundle will end up at, so `Sonar.app/` has to come off:
+// unpacking it verbatim would nest a Sonar.app inside the temporary directory
+// and the atomic rename would then move a directory *containing* a bundle into
+// /Applications.
+//
+// A bundle is not a flat file list. Its Frameworks and Resources are reached
+// through symlinks, and its executables are only executable because of their
+// mode bits, so both are carried across; nothing is chmod'd afterwards and
+// nothing is flattened.
+func extractBundle(archive, dest string) error {
+	f, err := os.Open(archive)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("%s is not a gzip archive: %w", filepath.Base(archive), err)
+	}
+	defer gz.Close()
+
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return err
+	}
+
+	tr := tar.NewReader(gz)
+	var entries int
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", filepath.Base(archive), err)
+		}
+
+		name := path.Clean(strings.TrimPrefix(hdr.Name, "./"))
+		if name == "." || name == "/" || isAppleDouble(name) {
+			continue
+		}
+		rel := stripBundlePrefix(name)
+		if rel == "" {
+			continue
+		}
+
+		target, err := safeJoin(dest, rel)
+		if err != nil {
+			return err
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, hdr.FileInfo().Mode().Perm()); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, hdr.FileInfo().Mode().Perm())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			if err := out.Close(); err != nil {
+				return err
+			}
+			entries++
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			// A symlink inside a bundle points within the bundle
+			// (Versions/Current, Resources -> A/Resources). One that escapes
+			// dest is either a broken build or an attack, and neither is
+			// something to unpack.
+			if _, err := safeJoin(dest, path.Join(path.Dir(rel), hdr.Linkname)); err != nil {
+				if !path.IsAbs(hdr.Linkname) {
+					return err
+				}
+			}
+			_ = os.Remove(target)
+			if err := os.Symlink(hdr.Linkname, target); err != nil {
+				return err
+			}
+			entries++
+		case tar.TypeLink:
+			source, err := safeJoin(dest, stripBundlePrefix(path.Clean(hdr.Linkname)))
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			_ = os.Remove(target)
+			if err := os.Link(source, target); err != nil {
+				return err
+			}
+			entries++
+		default:
+			// Character devices, fifos and the rest have no business in an
+			// application bundle; skipping them is safer than creating them.
+		}
+	}
+
+	if entries == 0 {
+		return fmt.Errorf("%s contains no application bundle", filepath.Base(archive))
+	}
+	return nil
+}
+
+// stripBundlePrefix removes the archive's own `Something.app/` directory from
+// an entry, when it has one. It is decided per entry rather than once from the
+// first, because the first entry is not reliably the bundle: `tar` on macOS
+// emits AppleDouble entries ahead of the file they belong to, and reading the
+// prefix off one of those put every real file one directory too deep.
+func stripBundlePrefix(name string) string {
+	head, rest, _ := strings.Cut(name, "/")
+	if strings.HasSuffix(head, ".app") {
+		// rest is empty for the bundle's own directory entry, and the caller
+		// skips it: dest *is* that directory, so unpacking it would nest a
+		// second Sonar.app inside the installed one.
+		return rest
+	}
+	return name
+}
+
+// isAppleDouble reports whether an entry is the ._name sidecar `tar` on macOS
+// writes to carry a file's extended attributes. The bundle does not need them,
+// and unpacking them would leave ._Sonar.app and friends inside the installed
+// app.
+func isAppleDouble(name string) bool {
+	return strings.HasPrefix(path.Base(name), "._")
+}
+
+// safeJoin refuses any entry that would land outside root, whatever the
+// archive claims its path is.
+func safeJoin(root, rel string) (string, error) {
+	target := filepath.Join(root, filepath.FromSlash(rel))
+	if target != root && !strings.HasPrefix(target, root+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive entry %q escapes the install directory", rel)
+	}
+	return target, nil
+}

--- a/internal/desktop/install_test.go
+++ b/internal/desktop/install_test.go
@@ -1,0 +1,767 @@
+package desktop
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ------------------------------------------------------------ the fixture ---
+
+// fakeRelease is a base URL serving a manifest and its artifacts, all built in
+// the test: a real gzipped tar holding a real (if useless) Sonar.app, and a
+// real AppImage. Nothing here reaches the network.
+type fakeRelease struct {
+	server *httptest.Server
+	// files is what the server serves, by path.
+	files map[string][]byte
+	// manifest is edited by a test before the server is asked for it.
+	manifest Manifest
+	mu       sync.Mutex
+	requests []string
+}
+
+func newFakeRelease(t *testing.T, version string) *fakeRelease {
+	t.Helper()
+	r := &fakeRelease{files: map[string][]byte{}}
+
+	bundle := bundleTarball(t)
+	appImage := []byte("#!/bin/sh\necho fake AppImage\n")
+	deb := []byte("!<arch>\nfake deb\n")
+
+	r.files["/Sonar.app.tar.gz"] = bundle
+	r.files["/Sonar.AppImage"] = appImage
+	r.files["/sonar-desktop.deb"] = deb
+
+	r.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.mu.Lock()
+		r.requests = append(r.requests, req.URL.Path)
+		r.mu.Unlock()
+
+		// Only the two paths a real base serves: the latest manifest, and the
+		// one under this release's version. Anything else 404s, which is what
+		// a wrong --base or --version deserves.
+		if req.URL.Path == "/"+ManifestName || req.URL.Path == "/"+r.manifest.Version+"/"+ManifestName {
+			body, err := json.Marshal(r.manifest)
+			if err != nil {
+				t.Error(err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+			return
+		}
+		if strings.HasSuffix(req.URL.Path, "/"+ChecksumsName) {
+			_, _ = fmt.Fprintf(w, "%s  Sonar.app.tar.gz\n", sum(bundle))
+			return
+		}
+		body, ok := r.files[req.URL.Path]
+		if !ok {
+			http.NotFound(w, req)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(r.server.Close)
+
+	base := r.server.URL
+	r.manifest = Manifest{
+		Version:     version,
+		PublishedAt: "2026-09-07T12:00:00Z",
+		NotesURL:    base + "/notes",
+		Platforms: map[string]Platform{
+			"darwin-aarch64": {Artifact: Artifact{URL: base + "/Sonar.app.tar.gz", SHA256: sum(bundle), Size: int64(len(bundle))}},
+			"darwin-x86_64":  {Artifact: Artifact{URL: base + "/Sonar.app.tar.gz", SHA256: sum(bundle), Size: int64(len(bundle))}},
+			"linux-x86_64": {
+				Artifact: Artifact{URL: base + "/Sonar.AppImage", SHA256: sum(appImage), Size: int64(len(appImage))},
+				Deb:      &Artifact{URL: base + "/sonar-desktop.deb", SHA256: sum(deb), Size: int64(len(deb))},
+			},
+			"linux-aarch64": {Artifact: Artifact{URL: base + "/Sonar.AppImage", SHA256: sum(appImage), Size: int64(len(appImage))}},
+		},
+	}
+	return r
+}
+
+// mutate edits one platform entry, which is how the checksum and size failures
+// are staged: the bytes on the wire stay correct and the manifest lies.
+func (r *fakeRelease) mutate(key string, fn func(*Platform)) {
+	p := r.manifest.Platforms[key]
+	fn(&p)
+	r.manifest.Platforms[key] = p
+}
+
+func sum(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// bundleTarball builds a .app.tar.gz the way the desktop app's own release
+// does: a top-level Sonar.app directory, an executable inside it, and the
+// symlink every real bundle has, so the extractor is exercised on the shapes
+// it will actually meet.
+func bundleTarball(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	dirs := []string{"Sonar.app/", "Sonar.app/Contents/", "Sonar.app/Contents/MacOS/", "Sonar.app/Contents/Resources/"}
+	for _, d := range dirs {
+		if err := tw.WriteHeader(&tar.Header{Name: d, Typeflag: tar.TypeDir, Mode: 0o755}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]struct {
+		body string
+		mode int64
+	}{
+		"Sonar.app/Contents/Info.plist":          {"<plist/>\n", 0o644},
+		"Sonar.app/Contents/MacOS/sonar-desktop": {"#!/bin/sh\nexit 0\n", 0o755},
+		"Sonar.app/Contents/Resources/icon.icns": {"icns", 0o644},
+	}
+	for name, f := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name, Typeflag: tar.TypeReg, Mode: f.mode, Size: int64(len(f.body)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(f.body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "Sonar.app/Contents/Current", Typeflag: tar.TypeSymlink, Linkname: "MacOS", Mode: 0o777,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// ------------------------------------------------------------- the harness ---
+
+// harness is one installer run with every seam pointed somewhere harmless.
+type harness struct {
+	opts     Options
+	state    *MemoryStore
+	release  *fakeRelease
+	launched []string
+	commands [][]string
+	// runningPIDs is what pgrep reports; a test sets it to fake an open app.
+	runningPIDs []int
+	// quitAfter is how many pgrep calls it takes before the app "quits".
+	quitAfter int
+	pgrepCall int
+}
+
+func newHarness(t *testing.T, goos, goarch, version string) *harness {
+	t.Helper()
+	h := &harness{state: &MemoryStore{}, release: newFakeRelease(t, version)}
+	home := t.TempDir()
+	h.opts = Options{
+		Base:     h.release.server.URL,
+		GOOS:     goos,
+		GOARCH:   goarch,
+		Home:     home,
+		TempDir:  t.TempDir(),
+		NoLaunch: false,
+		State:    h.state,
+		LookPath: func(string) (string, error) { return "", errors.New("not installed") },
+		Launch: func(_ context.Context, _ *Options, path string) error {
+			h.launched = append(h.launched, path)
+			return nil
+		},
+		Exec: func(_ context.Context, name string, args ...string) (string, error) {
+			h.commands = append(h.commands, append([]string{name}, args...))
+			if name == "pgrep" {
+				h.pgrepCall++
+				if len(h.runningPIDs) == 0 || (h.quitAfter > 0 && h.pgrepCall > h.quitAfter) {
+					return "", errors.New("exit status 1")
+				}
+				return strings.Join(pidStrings(h.runningPIDs), "\n") + "\n", nil
+			}
+			return "", nil
+		},
+		// Never the real /Applications: a directory this test owns, which it
+		// can also make read-only to exercise the fallback.
+		systemApps: t.TempDir(),
+	}
+	return h
+}
+
+func (h *harness) run(t *testing.T) (*Result, error) {
+	t.Helper()
+	return Run(context.Background(), h.opts)
+}
+
+func (h *harness) mustRun(t *testing.T) *Result {
+	t.Helper()
+	res, err := h.run(t)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return res
+}
+
+func (h *harness) ran(name string) bool {
+	for _, c := range h.commands {
+		if c[0] == name {
+			return true
+		}
+	}
+	return false
+}
+
+// --------------------------------------------------------------- the tests ---
+
+func TestInstallMacOSIntoATempApplicationsDir(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0-beta.1")
+	apps := t.TempDir()
+	h.opts.Dir = apps
+
+	res := h.mustRun(t)
+
+	if res.Action != ActionInstalled {
+		t.Errorf("action = %q, want %q", res.Action, ActionInstalled)
+	}
+	if res.Platform != "darwin-aarch64" {
+		t.Errorf("platform = %q", res.Platform)
+	}
+	app := filepath.Join(apps, BundleName)
+	if res.Path != app {
+		t.Errorf("path = %q, want %q", res.Path, app)
+	}
+	// The bundle's own directory is stripped: Contents sits directly inside.
+	body, err := os.ReadFile(filepath.Join(app, "Contents", "MacOS", "sonar-desktop"))
+	if err != nil {
+		t.Fatalf("the installed bundle has no executable: %v", err)
+	}
+	if !strings.Contains(string(body), "exit 0") {
+		t.Errorf("executable = %q", body)
+	}
+	info, err := os.Stat(filepath.Join(app, "Contents", "MacOS", "sonar-desktop"))
+	if err != nil || info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("mode = %v, want the executable bit preserved", info.Mode())
+	}
+	if target, err := os.Readlink(filepath.Join(app, "Contents", "Current")); err != nil || target != "MacOS" {
+		t.Errorf("symlink = %q (%v), want MacOS", target, err)
+	}
+
+	// The bundle's own directory entry is consumed, not unpacked: no
+	// Sonar.app/Sonar.app.
+	if exists(filepath.Join(app, BundleName)) {
+		t.Error("the bundle was nested inside itself")
+	}
+
+	// Nothing is left behind next to the bundle.
+	entries, _ := os.ReadDir(apps)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".Sonar.app") {
+			t.Errorf("leftover %s", e.Name())
+		}
+	}
+
+	if h.state.State.Version != "0.1.0-beta.1" || h.state.State.Path != app {
+		t.Errorf("recorded %+v, want the version and path", h.state.State)
+	}
+	if len(h.launched) != 1 || h.launched[0] != app {
+		t.Errorf("launched = %v, want [%s]", h.launched, app)
+	}
+	if !res.Launched {
+		t.Error("result should say it launched")
+	}
+}
+
+func TestInstallReplacesAnExistingAppAtomically(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.2.0")
+	apps := t.TempDir()
+	h.opts.Dir = apps
+
+	// An older bundle, with a file the new one does not have: if the replace
+	// merged instead of swapping, this would survive.
+	old := filepath.Join(apps, BundleName)
+	if err := os.MkdirAll(filepath.Join(old, "Contents", "MacOS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(old, "Contents", "MacOS", "leftover")
+	if err := os.WriteFile(stale, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h.state.State = State{Version: "0.1.0", Path: old}
+
+	res := h.mustRun(t)
+
+	if res.Action != ActionUpdated {
+		t.Errorf("action = %q, want %q", res.Action, ActionUpdated)
+	}
+	if res.PreviousVersion != "0.1.0" {
+		t.Errorf("previous_version = %q", res.PreviousVersion)
+	}
+	if exists(stale) {
+		t.Error("the old bundle's contents survived the replace")
+	}
+	if !exists(filepath.Join(old, "Contents", "Info.plist")) {
+		t.Error("the new bundle is not in place")
+	}
+	if exists(filepath.Join(apps, "."+BundleName+".old")) {
+		t.Error("the .old copy was not cleaned up")
+	}
+}
+
+func TestInstallRefusesAChecksumMismatch(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	apps := t.TempDir()
+	h.opts.Dir = apps
+	h.release.mutate("darwin-aarch64", func(p *Platform) {
+		p.SHA256 = strings.Repeat("0", 64)
+	})
+
+	_, err := h.run(t)
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("err = %v, want a checksum failure", err)
+	}
+	if exists(filepath.Join(apps, BundleName)) {
+		t.Error("a bundle was installed from an unverified download")
+	}
+	if h.state.State.Version != "" {
+		t.Error("a failed install was recorded in the config")
+	}
+}
+
+func TestInstallRefusesASizeMismatch(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	apps := t.TempDir()
+	h.opts.Dir = apps
+	h.release.mutate("darwin-aarch64", func(p *Platform) { p.Size = 999999 })
+
+	_, err := h.run(t)
+	if err == nil || !strings.Contains(err.Error(), "the manifest says") {
+		t.Fatalf("err = %v, want a size mismatch", err)
+	}
+	if exists(filepath.Join(apps, BundleName)) {
+		t.Error("a bundle was installed despite the size mismatch")
+	}
+}
+
+func TestInstallRefusesAnArtifactWithNoChecksum(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	h.opts.Dir = t.TempDir()
+	h.release.mutate("darwin-aarch64", func(p *Platform) { p.SHA256 = "" })
+
+	_, err := h.run(t)
+	if err == nil || !strings.Contains(err.Error(), "unverifiable") {
+		t.Fatalf("err = %v, want a refusal to install something unverifiable", err)
+	}
+}
+
+func TestInstallFallsBackToHomeApplications(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can write to a read-only directory")
+	}
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	// No --dir, and the stand-in for /Applications is read-only.
+	if err := os.Chmod(h.opts.systemApps, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(h.opts.systemApps, 0o755) })
+
+	res := h.mustRun(t)
+
+	want := filepath.Join(h.opts.Home, UserApplications, BundleName)
+	if res.Path != want {
+		t.Errorf("path = %q, want %q", res.Path, want)
+	}
+	if !exists(filepath.Join(want, "Contents", "Info.plist")) {
+		t.Error("nothing was installed into the fallback")
+	}
+	if len(res.Notes) == 0 || !strings.Contains(res.Notes[0], "not writable") {
+		t.Errorf("notes = %v, want one explaining the fallback", res.Notes)
+	}
+	if strings.Contains(strings.Join(res.Notes, " "), "sudo ") {
+		t.Error("the fallback must never suggest sudo")
+	}
+}
+
+func TestInstallRefusesWhileTheAppIsRunning(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	h.opts.Dir = t.TempDir()
+	h.runningPIDs = []int{4242}
+
+	_, err := h.run(t)
+	var running *ErrRunning
+	if !errors.As(err, &running) {
+		t.Fatalf("err = %v, want an ErrRunning", err)
+	}
+	if !strings.Contains(err.Error(), "4242") || !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error %q should name the pid and --force", err)
+	}
+}
+
+func TestForceAsksTheAppToQuit(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	h.opts.Dir = t.TempDir()
+	h.opts.Force = true
+	h.runningPIDs = []int{4242}
+	h.quitAfter = 1 // it goes away after the first look
+
+	h.mustRun(t)
+
+	var quit []string
+	for _, c := range h.commands {
+		if c[0] == "osascript" {
+			quit = c
+		}
+	}
+	if len(quit) == 0 || !strings.Contains(strings.Join(quit, " "), `quit app "Sonar"`) {
+		t.Errorf("commands = %v, want an osascript quit", h.commands)
+	}
+}
+
+func TestCheckReportsBothVersionsAndInstallsNothing(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.3.0")
+	apps := t.TempDir()
+	h.opts.Dir = apps
+	h.opts.Check = true
+
+	t.Run("nothing installed", func(t *testing.T) {
+		res := h.mustRun(t)
+		if res.Action != ActionChecked {
+			t.Errorf("action = %q", res.Action)
+		}
+		if res.InstalledVersion != "" {
+			t.Errorf("installed_version = %q, want empty", res.InstalledVersion)
+		}
+		if res.Version != "0.3.0" {
+			t.Errorf("version = %q", res.Version)
+		}
+		if res.UpToDate {
+			t.Error("nothing installed is not up to date")
+		}
+		if exists(filepath.Join(apps, BundleName)) {
+			t.Error("--check installed something")
+		}
+	})
+
+	t.Run("current", func(t *testing.T) {
+		app := filepath.Join(apps, BundleName)
+		if err := os.MkdirAll(app, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		h.state.State = State{Version: "0.3.0", Path: app}
+		res := h.mustRun(t)
+		if !res.UpToDate || res.InstalledVersion != "0.3.0" {
+			t.Errorf("res = %+v, want up to date at 0.3.0", res)
+		}
+	})
+
+	t.Run("a recorded path that is gone reads as not installed", func(t *testing.T) {
+		h.state.State = State{Version: "0.3.0", Path: filepath.Join(apps, "Gone.app")}
+		res := h.mustRun(t)
+		if res.UpToDate || res.InstalledVersion != "" {
+			t.Errorf("res = %+v, want not installed", res)
+		}
+	})
+}
+
+func TestUpdateIsANoOpOnTheCurrentVersion(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.4.0")
+	apps := t.TempDir()
+	h.opts.Dir = apps
+	h.opts.Update = true
+
+	app := filepath.Join(apps, BundleName)
+	if err := os.MkdirAll(app, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h.state.State = State{Version: "v0.4.0", Path: app} // the v is decoration
+
+	res := h.mustRun(t)
+
+	if res.Action != ActionUpToDate {
+		t.Fatalf("action = %q, want %q", res.Action, ActionUpToDate)
+	}
+	if len(h.launched) != 0 {
+		t.Error("a no-op update should not launch the app")
+	}
+	for _, path := range h.release.requests {
+		if !strings.HasSuffix(path, "/"+ManifestName) {
+			t.Errorf("a no-op update downloaded %s", path)
+		}
+	}
+}
+
+func TestUpdateFromAnOlderVersionInstalls(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.5.0")
+	apps := t.TempDir()
+	h.opts.Dir = apps
+	h.opts.Update = true
+
+	app := filepath.Join(apps, BundleName)
+	if err := os.MkdirAll(app, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h.state.State = State{Version: "0.4.0", Path: app}
+
+	res := h.mustRun(t)
+	if res.Action != ActionUpdated {
+		t.Errorf("action = %q, want %q", res.Action, ActionUpdated)
+	}
+	if !exists(filepath.Join(app, "Contents", "Info.plist")) {
+		t.Error("the new bundle is not in place")
+	}
+}
+
+func TestNoLaunchInstallsWithoutOpening(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	h.opts.Dir = t.TempDir()
+	h.opts.NoLaunch = true
+
+	res := h.mustRun(t)
+	if res.Launched || len(h.launched) != 0 {
+		t.Errorf("--no-launch opened the app: %v", h.launched)
+	}
+}
+
+func TestPinnedVersionAsksForThatManifest(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.9.0")
+	h.opts.Dir = t.TempDir()
+	h.opts.Version = "0.9.0"
+	h.opts.NoLaunch = true
+
+	h.mustRun(t)
+
+	if len(h.release.requests) == 0 || h.release.requests[0] != "/0.9.0/"+ManifestName {
+		t.Errorf("first request = %v, want /0.9.0/%s", h.release.requests, ManifestName)
+	}
+}
+
+func TestUnsupportedPlatformNamesWhatIsPublished(t *testing.T) {
+	h := newHarness(t, "darwin", "riscv64", "0.1.0")
+	h.opts.Dir = t.TempDir()
+
+	_, err := h.run(t)
+	var unsupported *UnsupportedPlatformError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("err = %v, want an UnsupportedPlatformError", err)
+	}
+	if !strings.Contains(err.Error(), "darwin-aarch64") {
+		t.Errorf("error %q should list the published platforms", err)
+	}
+}
+
+func TestWindowsIsNotAvailableYet(t *testing.T) {
+	_, err := Run(context.Background(), Options{GOOS: "windows", GOARCH: "amd64", State: &MemoryStore{}})
+	var na *ErrNotAvailable
+	if !errors.As(err, &na) {
+		t.Fatalf("err = %v, want an ErrNotAvailable", err)
+	}
+	if !strings.Contains(err.Error(), "windows") {
+		t.Errorf("error %q should name the platform", err)
+	}
+}
+
+// ---------------------------------------------------------------- linux ---
+
+func TestInstallLinuxPlacesTheAppImageAndWiresItIn(t *testing.T) {
+	h := newHarness(t, "linux", "amd64", "0.1.0-beta.1")
+
+	res := h.mustRun(t)
+
+	appImage := filepath.Join(h.opts.Home, filepath.FromSlash(LinuxOptDir), AppImageName)
+	if res.Path != appImage {
+		t.Fatalf("path = %q, want %q", res.Path, appImage)
+	}
+	info, err := os.Stat(appImage)
+	if err != nil {
+		t.Fatalf("no AppImage: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	entry, err := os.ReadFile(filepath.Join(h.opts.Home, filepath.FromSlash(LinuxDesktopEntry)))
+	if err != nil {
+		t.Fatalf("no desktop entry: %v", err)
+	}
+	for _, want := range []string{"[Desktop Entry]", "Name=Sonar", "Exec=" + appImage, "Categories=Development;Utility;"} {
+		if !strings.Contains(string(entry), want) {
+			t.Errorf("desktop entry is missing %q:\n%s", want, entry)
+		}
+	}
+
+	link := filepath.Join(h.opts.Home, filepath.FromSlash(LinuxBinLink))
+	target, err := os.Readlink(link)
+	if err != nil || target != appImage {
+		t.Errorf("symlink = %q (%v), want %s", target, err, appImage)
+	}
+
+	if h.state.State.Path != appImage || h.state.State.Version != "0.1.0-beta.1" {
+		t.Errorf("recorded %+v", h.state.State)
+	}
+	if len(h.launched) != 1 {
+		t.Errorf("launched = %v, want one launch", h.launched)
+	}
+}
+
+func TestInstallLinuxRefreshesTheDesktopDatabaseWhenItExists(t *testing.T) {
+	h := newHarness(t, "linux", "amd64", "0.1.0")
+	h.opts.LookPath = func(name string) (string, error) {
+		if name == "update-desktop-database" {
+			return "/usr/bin/update-desktop-database", nil
+		}
+		return "", errors.New("not installed")
+	}
+
+	h.mustRun(t)
+
+	if !h.ran("update-desktop-database") {
+		t.Errorf("commands = %v, want update-desktop-database", h.commands)
+	}
+}
+
+func TestInstallLinuxSkipsTheDesktopDatabaseWhenAbsent(t *testing.T) {
+	h := newHarness(t, "linux", "amd64", "0.1.0")
+	h.mustRun(t)
+	if h.ran("update-desktop-database") {
+		t.Error("ran update-desktop-database although it is not installed")
+	}
+}
+
+func TestInstallLinuxReplacesAnExistingAppImage(t *testing.T) {
+	h := newHarness(t, "linux", "amd64", "0.2.0")
+	dir := filepath.Join(h.opts.Home, filepath.FromSlash(LinuxOptDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	appImage := filepath.Join(dir, AppImageName)
+	if err := os.WriteFile(appImage, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h.state.State = State{Version: "0.1.0", Path: appImage}
+
+	res := h.mustRun(t)
+
+	if res.Action != ActionUpdated {
+		t.Errorf("action = %q", res.Action)
+	}
+	body, err := os.ReadFile(appImage)
+	if err != nil || string(body) == "old" {
+		t.Errorf("AppImage = %q (%v), want the new one", body, err)
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "."+AppImageName) {
+			t.Errorf("leftover %s", e.Name())
+		}
+	}
+}
+
+func TestInstallLinuxHonoursDir(t *testing.T) {
+	h := newHarness(t, "linux", "arm64", "0.1.0")
+	opt := t.TempDir()
+	h.opts.Dir = opt
+
+	res := h.mustRun(t)
+	if res.Path != filepath.Join(opt, AppImageName) {
+		t.Errorf("path = %q, want it under --dir", res.Path)
+	}
+	// The desktop entry still points at wherever the AppImage really is.
+	entry, err := os.ReadFile(filepath.Join(h.opts.Home, filepath.FromSlash(LinuxDesktopEntry)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(entry), "Exec="+res.Path) {
+		t.Errorf("desktop entry does not point at %s:\n%s", res.Path, entry)
+	}
+}
+
+func TestInstallLinuxRefusesWhileRunningAndTermsWithForce(t *testing.T) {
+	h := newHarness(t, "linux", "amd64", "0.1.0")
+	h.runningPIDs = []int{777}
+
+	if _, err := h.run(t); !strings.Contains(fmt.Sprint(err), "777") {
+		t.Fatalf("err = %v, want it to name the running pid", err)
+	}
+	// pgrep looks for the AppImage, not the macOS bundle path.
+	for _, c := range h.commands {
+		if c[0] == "pgrep" && c[2] != "Sonar.AppImage" {
+			t.Errorf("pgrep pattern = %q, want Sonar.AppImage", c[2])
+		}
+	}
+
+	h2 := newHarness(t, "linux", "amd64", "0.1.0")
+	h2.runningPIDs = []int{777}
+	h2.quitAfter = 1
+	h2.opts.Force = true
+	h2.mustRun(t)
+	if !h2.ran("kill") {
+		t.Errorf("commands = %v, want a kill -TERM", h2.commands)
+	}
+}
+
+func TestDebIsRefusedOffLinuxAndWhenNotPublished(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	h.opts.Dir = t.TempDir()
+	h.opts.Deb = true
+	if _, err := h.run(t); err == nil || !strings.Contains(err.Error(), "Linux") {
+		t.Errorf("err = %v, want --deb refused off Linux", err)
+	}
+
+	h2 := newHarness(t, "linux", "arm64", "0.1.0") // linux-aarch64 has no deb
+	h2.opts.Deb = true
+	if _, err := h2.run(t); err == nil || !strings.Contains(err.Error(), "no .deb") {
+		t.Errorf("err = %v, want a missing-deb refusal", err)
+	}
+}
+
+func TestAManifestThatIsNotThereSaysSo(t *testing.T) {
+	h := newHarness(t, "darwin", "arm64", "0.1.0")
+	h.opts.Base = h.release.server.URL + "/nope"
+	h.opts.Version = "1.2.3"
+
+	_, err := h.run(t)
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("err = %v, want a 404 that mentions --base or --version", err)
+	}
+}
+
+func TestExtractRefusesAnArchiveThatEscapesTheDirectory(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	body := "pwned"
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "Sonar.app/../../evil", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = tw.Write([]byte(body))
+	_ = tw.Close()
+	_ = gz.Close()
+
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "evil.tar.gz")
+	if err := os.WriteFile(archive, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractBundle(archive, filepath.Join(dir, "dest")); err == nil {
+		t.Fatal("want a refusal")
+	}
+}

--- a/internal/desktop/launch.go
+++ b/internal/desktop/launch.go
@@ -1,0 +1,37 @@
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// launch starts the app that was just installed and returns immediately.
+//
+// macOS hands the bundle to LaunchServices, which is the only way to start an
+// .app correctly: it is the difference between an application with a Dock
+// icon and a bare process. Linux has no such service, so the AppImage is
+// started in a session of its own with its standard streams detached, which is
+// what `setsid` buys — without it the app dies with the terminal that
+// installed it, and with inherited streams it scribbles over the shell prompt.
+func launch(ctx context.Context, o *Options, path string) error {
+	if o.GOOS == "darwin" {
+		if _, err := o.Exec(ctx, "open", "-a", path); err != nil {
+			return fmt.Errorf("open -a %s: %w", path, err)
+		}
+		return nil
+	}
+
+	cmd := exec.Command(path)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
+	if devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0); err == nil {
+		defer devNull.Close()
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = devNull, devNull, devNull
+	}
+	detachProcess(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting %s: %w", path, err)
+	}
+	return cmd.Process.Release()
+}

--- a/internal/desktop/linux.go
+++ b/internal/desktop/linux.go
@@ -1,0 +1,210 @@
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Where a Linux install puts its four pieces. All of them are under $HOME:
+// this installer never needs root, so it never writes anywhere root owns, and
+// a user who wants a system-wide install has --deb.
+const (
+	// LinuxOptDir holds the AppImage, relative to $HOME.
+	LinuxOptDir = ".local/opt/sonar-desktop"
+	// AppImageName is the AppImage's stable name. It is stable on purpose:
+	// the .desktop entry and the ~/.local/bin symlink both point at it, so an
+	// update replaces one file and nothing else has to be rewritten.
+	AppImageName = "Sonar.AppImage"
+	// LinuxDesktopEntry is the freedesktop launcher entry, relative to $HOME.
+	LinuxDesktopEntry = ".local/share/applications/sonar-desktop.desktop"
+	// LinuxBinLink is the command-line entry point, relative to $HOME.
+	LinuxBinLink = ".local/bin/sonar-desktop"
+)
+
+// installLinux places the AppImage and wires it into the desktop.
+//
+// The AppImage itself is the whole app — one file, chmod 755 — so the atomic
+// replace is a single rename rather than macOS's dance with a directory. The
+// three things around it (the .desktop entry, the menu database, the symlink)
+// are conveniences: each failure is a note, never an error, because an app
+// that runs but has no menu icon is installed and an install that failed
+// halfway is not.
+func (o *Options) installLinux(ctx context.Context, archive string) (string, []string, error) {
+	if o.Deb {
+		return o.installDeb(ctx, archive)
+	}
+	if err := o.ensureNotRunning(ctx); err != nil {
+		return "", nil, err
+	}
+
+	dir := o.Dir
+	if dir == "" {
+		if o.Home == "" {
+			return "", nil, fmt.Errorf("no home directory to install into; pass --dir")
+		}
+		dir = filepath.Join(o.Home, filepath.FromSlash(LinuxOptDir))
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("creating %s: %w", dir, err)
+	}
+
+	appImage := filepath.Join(dir, AppImageName)
+	tmp := filepath.Join(dir, fmt.Sprintf(".%s.tmp-%d", AppImageName, os.Getpid()))
+	// The download lives in TMPDIR, which is routinely a different filesystem
+	// from $HOME, so it is copied in rather than renamed in: a cross-device
+	// rename fails, and doing the copy first keeps the visible step atomic.
+	if err := copyFile(archive, tmp, 0o755); err != nil {
+		return "", nil, err
+	}
+	defer func() { _ = os.Remove(tmp) }()
+	if err := os.Chmod(tmp, 0o755); err != nil {
+		return "", nil, err
+	}
+	if err := os.Rename(tmp, appImage); err != nil {
+		return "", nil, fmt.Errorf("installing %s: %w", appImage, err)
+	}
+
+	var notes []string
+	notes = append(notes, o.writeDesktopEntry(ctx, appImage)...)
+	notes = append(notes, o.linkBin(appImage)...)
+	return appImage, notes, nil
+}
+
+// writeDesktopEntry writes the launcher entry and refreshes the menu database.
+//
+// There is deliberately no Icon= line. The icon lives inside the AppImage, and
+// the only way out of it is `./Sonar.AppImage --appimage-extract .DirIcon`,
+// which means executing the binary that was just downloaded before the user
+// has chosen to launch it, on a machine that may not even have FUSE. A missing
+// icon is a generic tile in the menu; running the payload to get a picture is
+// a worse trade.
+func (o *Options) writeDesktopEntry(ctx context.Context, appImage string) []string {
+	if o.Home == "" {
+		return nil
+	}
+	path := filepath.Join(o.Home, filepath.FromSlash(LinuxDesktopEntry))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return []string{"could not create " + filepath.Dir(path) + ": " + err.Error()}
+	}
+	entry := strings.Join([]string{
+		"[Desktop Entry]",
+		"Type=Application",
+		"Name=Sonar",
+		"Comment=See and manage every service listening on a localhost port",
+		"Exec=" + appImage,
+		"Terminal=false",
+		"Categories=Development;Utility;",
+		"StartupWMClass=Sonar",
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(entry), 0o644); err != nil {
+		return []string{"could not write " + path + ": " + err.Error()}
+	}
+
+	// Best effort: a desktop that has no update-desktop-database either does
+	// not need one or picks the entry up on its next scan.
+	if _, err := o.LookPath("update-desktop-database"); err == nil {
+		if _, err := o.Exec(ctx, "update-desktop-database", filepath.Dir(path)); err != nil {
+			return []string{"update-desktop-database failed; the menu entry appears at next login"}
+		}
+	}
+	return nil
+}
+
+// linkBin points ~/.local/bin/sonar-desktop at the AppImage, which is what
+// `sonar tray` and anything else on PATH finds.
+func (o *Options) linkBin(appImage string) []string {
+	if o.Home == "" {
+		return nil
+	}
+	link := filepath.Join(o.Home, filepath.FromSlash(LinuxBinLink))
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		return []string{"could not create " + filepath.Dir(link) + ": " + err.Error()}
+	}
+	// Remove rather than overwrite: a symlink cannot be re-pointed in place,
+	// and an existing regular file there is someone else's and worth saying so.
+	if info, err := os.Lstat(link); err == nil && info.Mode()&os.ModeSymlink == 0 {
+		return []string{link + " already exists and is not a symlink; left it alone"}
+	}
+	_ = os.Remove(link)
+	if err := os.Symlink(appImage, link); err != nil {
+		return []string{"could not link " + link + ": " + err.Error()}
+	}
+	return nil
+}
+
+// installDeb hands the verified package to the system package manager. This is
+// the one path that needs root, and it only exists because the caller asked
+// for it by name with --deb: a .deb install is system-wide by definition, so
+// the "never sudo" rule that governs the AppImage does not apply. When there
+// is no way to elevate, the verified file is kept and the exact command is
+// printed rather than half-done.
+func (o *Options) installDeb(ctx context.Context, archive string) (string, []string, error) {
+	pkg := archive + ".deb" // apt and dpkg both insist on the extension
+	if err := os.Rename(archive, pkg); err != nil {
+		if err := copyFile(archive, pkg, 0o644); err != nil {
+			return "", nil, err
+		}
+	}
+
+	manager, args := o.debCommand()
+	if manager == "" {
+		return "", nil, fmt.Errorf("neither apt-get nor dpkg is installed; the verified package is at %s", pkg)
+	}
+	if os.Geteuid() != 0 {
+		if _, err := o.LookPath("sudo"); err != nil {
+			return "", nil, fmt.Errorf("installing a .deb needs root and sudo is not installed — run: %s %s %s",
+				manager, strings.Join(args, " "), pkg)
+		}
+		args = append([]string{manager}, args...)
+		manager = "sudo"
+	}
+	if out, err := o.Exec(ctx, manager, append(args, pkg)...); err != nil {
+		return "", nil, fmt.Errorf("%s failed: %w\n%s", manager, err, strings.TrimSpace(out))
+	}
+	_ = os.Remove(pkg)
+
+	// A package decides its own layout, so the installed path is looked up
+	// rather than assumed.
+	for _, candidate := range []string{"/usr/bin/sonar-desktop", "/opt/Sonar/sonar-desktop", "/usr/local/bin/sonar-desktop"} {
+		if exists(candidate) {
+			return candidate, nil, nil
+		}
+	}
+	if path, err := o.LookPath("sonar-desktop"); err == nil {
+		return path, nil, nil
+	}
+	return "", nil, fmt.Errorf("the package installed but sonar-desktop is not on PATH")
+}
+
+func (o *Options) debCommand() (string, []string) {
+	if _, err := o.LookPath("apt-get"); err == nil {
+		return "apt-get", []string{"install", "-y"}
+	}
+	if _, err := o.LookPath("dpkg"); err == nil {
+		return "dpkg", []string{"-i"}
+	}
+	return "", nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("writing %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		_ = os.Remove(dst)
+		return fmt.Errorf("writing %s: %w", dst, err)
+	}
+	return out.Close()
+}

--- a/internal/desktop/macos.go
+++ b/internal/desktop/macos.go
@@ -1,0 +1,114 @@
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SystemApplications is where a Mac app belongs, and UserApplications is where
+// it goes when this user cannot write to the first. `sudo` is never an option:
+// an app installed as root in a user's Applications folder is a support ticket
+// waiting to happen, and a user who wants a machine-wide install can run this
+// from an admin account.
+const (
+	SystemApplications = "/Applications"
+	UserApplications   = "Applications" // under $HOME
+)
+
+// BundleName is the bundle this installs, everywhere it looks for one.
+const BundleName = "Sonar.app"
+
+// installMacOS unpacks the .app.tar.gz and swaps it into place.
+//
+// The swap is three renames inside one directory, so it is atomic from the
+// point of view of anything opening the app: at no moment is there a
+// half-written Sonar.app. Unpacking into <dir>/.Sonar.app.tmp-<pid> rather
+// than a temp directory is what makes that true — a rename across filesystems
+// is a copy, and a copy into /Applications is exactly the window this avoids.
+//
+// Nothing here touches com.apple.quarantine. A file this process downloaded
+// never had the attribute (only apps that opt in set it), so the unsigned
+// bundle opens without a Gatekeeper prompt, and a `xattr -d` would only teach
+// the codebase a habit that becomes wrong the moment the app is notarised.
+func (o *Options) installMacOS(ctx context.Context, archive string) (string, []string, error) {
+	dir, notes, err := o.applicationsDir()
+	if err != nil {
+		return "", nil, err
+	}
+	if err := o.ensureNotRunning(ctx); err != nil {
+		return "", nil, err
+	}
+
+	app := filepath.Join(dir, BundleName)
+	tmp := filepath.Join(dir, fmt.Sprintf(".%s.tmp-%d", BundleName, os.Getpid()))
+	old := filepath.Join(dir, "."+BundleName+".old")
+
+	_ = os.RemoveAll(tmp)
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	if err := extractBundle(archive, tmp); err != nil {
+		return "", nil, err
+	}
+	if !exists(filepath.Join(tmp, "Contents", "MacOS")) {
+		return "", nil, fmt.Errorf("the downloaded archive does not look like %s", BundleName)
+	}
+
+	_ = os.RemoveAll(old)
+	hadOld := false
+	if exists(app) {
+		if err := os.Rename(app, old); err != nil {
+			return "", nil, fmt.Errorf("moving the existing %s aside: %w", app, err)
+		}
+		hadOld = true
+	}
+	if err := os.Rename(tmp, app); err != nil {
+		if hadOld {
+			_ = os.Rename(old, app)
+		}
+		return "", nil, fmt.Errorf("installing %s: %w", app, err)
+	}
+	if hadOld {
+		_ = os.RemoveAll(old)
+	}
+	return app, notes, nil
+}
+
+// applicationsDir picks where the bundle goes. An explicit --dir is taken at
+// its word and fails loudly if it cannot be written; the default falls back to
+// ~/Applications, which is a real macOS location LaunchServices indexes, with
+// a note saying so.
+func (o *Options) applicationsDir() (string, []string, error) {
+	if o.Dir != "" {
+		if err := os.MkdirAll(o.Dir, 0o755); err != nil {
+			return "", nil, fmt.Errorf("creating %s: %w", o.Dir, err)
+		}
+		if !writable(o.Dir) {
+			return "", nil, fmt.Errorf("%s is not writable", o.Dir)
+		}
+		return o.Dir, nil, nil
+	}
+
+	system := o.systemApps
+	if system == "" {
+		system = SystemApplications
+	}
+	if exists(system) && writable(system) {
+		return system, nil, nil
+	}
+
+	if o.Home == "" {
+		return "", nil, fmt.Errorf("%s is not writable and there is no home directory to fall back to", system)
+	}
+	fallback := filepath.Join(o.Home, UserApplications)
+	if err := os.MkdirAll(fallback, 0o755); err != nil {
+		return "", nil, fmt.Errorf("creating %s: %w", fallback, err)
+	}
+	if !writable(fallback) {
+		return "", nil, fmt.Errorf("neither %s nor %s is writable", system, fallback)
+	}
+	return fallback, []string{fmt.Sprintf(
+		"%s is not writable, so Sonar went to %s instead (it works the same; sonar never uses sudo)",
+		system, fallback)}, nil
+}

--- a/internal/desktop/main_test.go
+++ b/internal/desktop/main_test.go
@@ -1,0 +1,13 @@
+package desktop
+
+import (
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// The installer writes to the user's config and reads HOME for every Linux
+// path it touches, so this binary gets an isolated HOME like every other.
+// Nothing in here may reach /Applications or the real ~/.config/sonar.
+func TestMain(m *testing.M) { os.Exit(testenv.Run(m)) }

--- a/internal/desktop/manifest.go
+++ b/internal/desktop/manifest.go
@@ -1,0 +1,212 @@
+// Package desktop installs the Sonar desktop app from a published manifest.
+//
+// The app is not signed by Apple yet, which is the whole reason this exists:
+// a tester who downloads a .app.tar.gz in a browser gets a quarantine
+// attribute on the bundle and Gatekeeper refuses to open an adhoc-signed app.
+// A download made by this process gets no quarantine attribute at all, because
+// only the programs that opt in (browsers, mail clients) set one. So the CLI
+// neither sets nor strips com.apple.quarantine — there is nothing to strip,
+// and a `xattr -d` here would be a habit that outlives the reason for it.
+//
+// The layout it reads is deliberately dumb: one JSON manifest and a checksums
+// file beside it, both served from a plain base URL. Today that base is a
+// GitHub release that carries only artifacts; tomorrow it can be a website
+// with the same two names, and nothing here changes.
+package desktop
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// DefaultBase is where the app is published: a public repository that holds
+// artifacts and nothing else, so the CLI's own release page stays about the
+// CLI.
+const DefaultBase = "https://github.com/raskrebs/sonar-desktop-releases/releases/latest/download"
+
+// BaseEnv overrides DefaultBase from the environment.
+const BaseEnv = "SONAR_DESKTOP_BASE"
+
+// ManifestName and ChecksumsName are the two files a base URL must serve.
+// The checksums file is not read by the installer — the manifest already
+// carries a sha256 per artifact — it is there so a human can verify a download
+// by hand with `shasum -c`.
+const (
+	ManifestName  = "desktop.json"
+	ChecksumsName = "sonar-desktop_checksums.txt"
+)
+
+// githubLatestSuffix is the tail of a GitHub "latest release" download base.
+// A --version against such a base has to move to that repository's sibling
+// tag URL rather than append a path segment.
+const githubLatestSuffix = "/releases/latest/download"
+
+// Artifact is one downloadable file: where it is, what it should hash to, and
+// how big it should be. Both the size and the digest are checked, because they
+// fail differently — a truncated transfer is a size mismatch long before it is
+// a digest mismatch, and saying which one happened is the difference between
+// "your network dropped" and "this file is not what the manifest describes".
+type Artifact struct {
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// Platform is what one platform key resolves to: the artifact the installer
+// uses by default, plus optionally a .deb for the Linux platforms, which
+// `--deb` asks for instead.
+type Platform struct {
+	Artifact
+	Deb *Artifact `json:"deb,omitempty"`
+}
+
+// Manifest is the whole desktop.json.
+type Manifest struct {
+	Version     string              `json:"version"`
+	PublishedAt string              `json:"published_at"`
+	NotesURL    string              `json:"notes_url"`
+	Platforms   map[string]Platform `json:"platforms"`
+}
+
+// ParseManifest decodes and sanity-checks a desktop.json. It is strict about
+// the two fields every later step depends on and silent about the rest: a
+// manifest written by a newer publisher may carry keys this build does not
+// know, and refusing it would make the CLI the thing that needs updating
+// first.
+func ParseManifest(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("%s is not valid JSON: %w", ManifestName, err)
+	}
+	if strings.TrimSpace(m.Version) == "" {
+		return nil, fmt.Errorf("%s has no version", ManifestName)
+	}
+	if len(m.Platforms) == 0 {
+		return nil, fmt.Errorf("%s lists no platforms", ManifestName)
+	}
+	return &m, nil
+}
+
+// PlatformKeys lists the manifest's platforms in a stable order, so the
+// "not supported yet" message reads the same on every run.
+func (m *Manifest) PlatformKeys() []string {
+	out := make([]string, 0, len(m.Platforms))
+	for k := range m.Platforms {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Pick resolves the entry for a platform key, and turns every relative URL in
+// it absolute against the manifest's own URL. Publishing absolute URLs is what
+// the contract describes; resolving relative ones anyway means a static site
+// can serve the same manifest from any prefix.
+func (m *Manifest) Pick(key, manifestURL string) (Platform, error) {
+	p, ok := m.Platforms[key]
+	if !ok {
+		return Platform{}, &UnsupportedPlatformError{Key: key, Available: m.PlatformKeys()}
+	}
+	var err error
+	if p.URL, err = resolveURL(manifestURL, p.URL); err != nil {
+		return Platform{}, err
+	}
+	if p.Deb != nil {
+		deb := *p.Deb
+		if deb.URL, err = resolveURL(manifestURL, deb.URL); err != nil {
+			return Platform{}, err
+		}
+		p.Deb = &deb
+	}
+	return p, nil
+}
+
+func resolveURL(base, ref string) (string, error) {
+	if strings.TrimSpace(ref) == "" {
+		return "", fmt.Errorf("%s has an entry with no url", ManifestName)
+	}
+	b, err := url.Parse(base)
+	if err != nil {
+		return ref, nil // a base we cannot parse cannot help; take the ref as-is
+	}
+	r, err := url.Parse(ref)
+	if err != nil {
+		return "", fmt.Errorf("%s has an unusable url %q: %w", ManifestName, ref, err)
+	}
+	return b.ResolveReference(r).String(), nil
+}
+
+// UnsupportedPlatformError is what a manifest that does not carry this machine
+// says. It names what it does carry, because the useful next question is
+// always "then what is published?".
+type UnsupportedPlatformError struct {
+	Key       string
+	Available []string
+}
+
+func (e *UnsupportedPlatformError) Error() string {
+	return fmt.Sprintf("%s is not supported yet — this release publishes %s",
+		e.Key, strings.Join(e.Available, ", "))
+}
+
+// PlatformKey is the manifest key for a Go platform pair. The names are the
+// Rust target vocabulary the desktop app's own build uses (aarch64, x86_64),
+// not Go's, so the manifest reads the same as the file names beside it.
+func PlatformKey(goos, goarch string) string {
+	arch := goarch
+	switch goarch {
+	case "amd64":
+		arch = "x86_64"
+	case "arm64":
+		arch = "aarch64"
+	case "386":
+		arch = "i686"
+	}
+	return goos + "-" + arch
+}
+
+// ResolveBase applies the override order: an explicit --base, then
+// SONAR_DESKTOP_BASE, then desktop.download_base from the user's config, then
+// the built-in default.
+func ResolveBase(flag, env, cfg string) string {
+	for _, candidate := range []string{flag, env, cfg} {
+		if v := strings.TrimSpace(candidate); v != "" {
+			return strings.TrimSuffix(v, "/")
+		}
+	}
+	return DefaultBase
+}
+
+// ManifestURL is where the manifest for a version lives under a base.
+//
+// With no --version it is simply <base>/desktop.json, which for the default
+// base is the latest release's asset. With one, the shape depends on the base:
+// a GitHub "latest release" URL has no room for a version segment, so the URL
+// moves to that repository's sibling tag download path; any other base gets
+// the plain <base>/<version>/desktop.json a static site can lay out.
+func ManifestURL(base, version string) string {
+	base = strings.TrimSuffix(strings.TrimSpace(base), "/")
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return base + "/" + ManifestName
+	}
+	if prefix, ok := strings.CutSuffix(base, githubLatestSuffix); ok {
+		tag := version
+		if !strings.HasPrefix(tag, "v") {
+			tag = "v" + tag
+		}
+		return prefix + "/releases/download/" + tag + "/" + ManifestName
+	}
+	return base + "/" + version + "/" + ManifestName
+}
+
+// SameVersion compares two version strings the way a user means it: a leading
+// v is decoration, not part of the version.
+func SameVersion(a, b string) bool {
+	a = strings.TrimPrefix(strings.TrimSpace(a), "v")
+	b = strings.TrimPrefix(strings.TrimSpace(b), "v")
+	return a != "" && a == b
+}

--- a/internal/desktop/manifest_test.go
+++ b/internal/desktop/manifest_test.go
@@ -1,0 +1,186 @@
+package desktop
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const sampleManifest = `{
+  "version": "0.1.0-beta.1",
+  "published_at": "2026-09-07T12:00:00Z",
+  "notes_url": "https://example.com/notes",
+  "platforms": {
+    "darwin-aarch64": {
+      "url": "https://example.com/Sonar_0.1.0-beta.1_aarch64-apple-darwin.app.tar.gz",
+      "sha256": "aa",
+      "size": 41234567
+    },
+    "darwin-x86_64": {"url": "Sonar_x86_64.app.tar.gz", "sha256": "bb", "size": 2},
+    "linux-x86_64": {
+      "url": "https://example.com/Sonar_x86_64.AppImage",
+      "sha256": "cc",
+      "size": 3,
+      "deb": {"url": "https://example.com/sonar-desktop_amd64.deb", "sha256": "dd", "size": 4}
+    }
+  }
+}`
+
+func TestParseManifest(t *testing.T) {
+	m, err := ParseManifest([]byte(sampleManifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Version != "0.1.0-beta.1" {
+		t.Errorf("version = %q", m.Version)
+	}
+	if m.NotesURL != "https://example.com/notes" {
+		t.Errorf("notes_url = %q", m.NotesURL)
+	}
+	want := []string{"darwin-aarch64", "darwin-x86_64", "linux-x86_64"}
+	got := m.PlatformKeys()
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("keys = %v, want %v", got, want)
+	}
+}
+
+func TestParseManifestRejectsNonsense(t *testing.T) {
+	cases := map[string]string{
+		"not json":     `<html>404</html>`,
+		"no version":   `{"platforms":{"darwin-aarch64":{"url":"u","sha256":"s"}}}`,
+		"no platforms": `{"version":"1.0.0","platforms":{}}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseManifest([]byte(body)); err == nil {
+				t.Fatal("want an error")
+			}
+		})
+	}
+}
+
+func TestPickResolvesRelativeURLsAndTheDeb(t *testing.T) {
+	m, err := ParseManifest([]byte(sampleManifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const manifestURL = "https://cdn.example.com/desktop/desktop.json"
+
+	p, err := m.Pick("darwin-x86_64", manifestURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.URL != "https://cdn.example.com/desktop/Sonar_x86_64.app.tar.gz" {
+		t.Errorf("relative url resolved to %q", p.URL)
+	}
+
+	linux, err := m.Pick("linux-x86_64", manifestURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linux.Deb == nil || linux.Deb.SHA256 != "dd" {
+		t.Errorf("deb = %+v, want the sub-key parsed", linux.Deb)
+	}
+	// An absolute url is left exactly as published.
+	if linux.URL != "https://example.com/Sonar_x86_64.AppImage" {
+		t.Errorf("absolute url rewritten to %q", linux.URL)
+	}
+}
+
+func TestPickNamesWhatIsAvailable(t *testing.T) {
+	m, _ := ParseManifest([]byte(sampleManifest))
+	_, err := m.Pick("windows-x86_64", "https://example.com/desktop.json")
+	var unsupported *UnsupportedPlatformError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("err = %v, want an UnsupportedPlatformError", err)
+	}
+	for _, key := range []string{"darwin-aarch64", "darwin-x86_64", "linux-x86_64"} {
+		if !strings.Contains(err.Error(), key) {
+			t.Errorf("error %q does not list %s", err, key)
+		}
+	}
+}
+
+func TestPlatformKey(t *testing.T) {
+	cases := map[[2]string]string{
+		{"darwin", "arm64"}:  "darwin-aarch64",
+		{"darwin", "amd64"}:  "darwin-x86_64",
+		{"linux", "amd64"}:   "linux-x86_64",
+		{"linux", "arm64"}:   "linux-aarch64",
+		{"windows", "amd64"}: "windows-x86_64",
+	}
+	for in, want := range cases {
+		if got := PlatformKey(in[0], in[1]); got != want {
+			t.Errorf("PlatformKey(%s, %s) = %q, want %q", in[0], in[1], got, want)
+		}
+	}
+}
+
+func TestManifestURL(t *testing.T) {
+	cases := []struct {
+		name, base, version, want string
+	}{
+		{
+			name: "default base, latest",
+			base: DefaultBase,
+			want: DefaultBase + "/desktop.json",
+		},
+		{
+			name:    "default base, pinned version moves to the tag",
+			base:    DefaultBase,
+			version: "0.1.0-beta.1",
+			want:    "https://github.com/raskrebs/sonar-desktop-releases/releases/download/v0.1.0-beta.1/desktop.json",
+		},
+		{
+			name:    "a leading v is not doubled",
+			base:    DefaultBase,
+			version: "v0.2.0",
+			want:    "https://github.com/raskrebs/sonar-desktop-releases/releases/download/v0.2.0/desktop.json",
+		},
+		{
+			name: "a website base",
+			base: "https://example.com/desktop/",
+			want: "https://example.com/desktop/desktop.json",
+		},
+		{
+			name:    "a website base with a version",
+			base:    "https://example.com/desktop",
+			version: "0.1.0",
+			want:    "https://example.com/desktop/0.1.0/desktop.json",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ManifestURL(tc.base, tc.version); got != tc.want {
+				t.Errorf("got  %s\nwant %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveBaseOverrideOrder(t *testing.T) {
+	cases := []struct{ flag, env, cfg, want string }{
+		{flag: "https://flag", env: "https://env", cfg: "https://cfg", want: "https://flag"},
+		{env: "https://env", cfg: "https://cfg", want: "https://env"},
+		{cfg: "https://cfg", want: "https://cfg"},
+		{want: DefaultBase},
+		{cfg: "https://cfg/", want: "https://cfg"},
+	}
+	for _, tc := range cases {
+		if got := ResolveBase(tc.flag, tc.env, tc.cfg); got != tc.want {
+			t.Errorf("ResolveBase(%q, %q, %q) = %q, want %q", tc.flag, tc.env, tc.cfg, got, tc.want)
+		}
+	}
+}
+
+func TestSameVersionIgnoresTheV(t *testing.T) {
+	if !SameVersion("v1.2.3", "1.2.3") {
+		t.Error("v1.2.3 and 1.2.3 are the same version")
+	}
+	if SameVersion("", "") {
+		t.Error("two unknown versions are not a match")
+	}
+	if SameVersion("1.2.3", "1.2.4") {
+		t.Error("different versions matched")
+	}
+}

--- a/internal/desktop/state.go
+++ b/internal/desktop/state.go
@@ -1,0 +1,45 @@
+package desktop
+
+import (
+	"github.com/raskrebs/sonar/internal/config"
+)
+
+// State is what the CLI remembers about an install between runs: enough for
+// `--check` and `--update` to answer without opening the bundle, and enough
+// for `sonar tray` and the doctor's desktop_installed check to find an app
+// that was installed somewhere non-standard with --dir.
+type State struct {
+	Version string `json:"version"`
+	Path    string `json:"path"`
+}
+
+// StateStore is where that lives. It is an interface for one reason: a test
+// should be able to assert what was recorded without reading YAML back.
+type StateStore interface {
+	Load() (State, error)
+	Save(State) error
+}
+
+// ConfigStore keeps the state in the user's config.yaml, under
+// desktop.installed_version and desktop.installed_path.
+type ConfigStore struct{}
+
+func (ConfigStore) Load() (State, error) {
+	cfg, _ := config.Load()
+	return State{Version: cfg.Desktop.InstalledVersion, Path: cfg.Desktop.InstalledPath}, nil
+}
+
+func (ConfigStore) Save(s State) error {
+	_, err := config.Apply(map[string]any{"desktop": map[string]any{
+		"installed_version": s.Version,
+		"installed_path":    s.Path,
+	}})
+	return err
+}
+
+// MemoryStore is a StateStore that forgets, for tests and for a run that must
+// not touch the config at all.
+type MemoryStore struct{ State State }
+
+func (m *MemoryStore) Load() (State, error) { return m.State, nil }
+func (m *MemoryStore) Save(s State) error   { m.State = s; return nil }

--- a/internal/desktop/state_test.go
+++ b/internal/desktop/state_test.go
@@ -1,0 +1,82 @@
+package desktop
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/raskrebs/sonar/internal/testenv"
+)
+
+// The config this writes is the isolated one testenv gave this binary; the
+// assertion that it really is isolated is testenv's own, and this test only
+// exists to prove the two keys survive a round trip through YAML.
+func TestConfigStoreRoundTrip(t *testing.T) {
+	testenv.RequireIsolated(t, config.Path())
+
+	store := ConfigStore{}
+	got, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != (State{}) {
+		t.Fatalf("a machine with no install loaded %+v", got)
+	}
+
+	want := State{Version: "0.1.0-beta.1", Path: filepath.Join(t.TempDir(), "Sonar.app")}
+	if err := store.Save(want); err != nil {
+		t.Fatal(err)
+	}
+	if got, err = store.Load(); err != nil || got != want {
+		t.Fatalf("loaded %+v (%v), want %+v", got, err, want)
+	}
+
+	// The keys are the ones the contract names, not whatever Go would have
+	// picked from the field names.
+	body, err := os.ReadFile(config.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"desktop:", "installed_version:", "installed_path:"} {
+		if !strings.Contains(string(body), key) {
+			t.Errorf("config.yaml has no %s:\n%s", key, body)
+		}
+	}
+
+	// Saving does not disturb a neighbouring setting.
+	if _, err := config.Apply(map[string]any{"list": map[string]any{"sort": "pid"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(State{Version: "0.2.0", Path: want.Path}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, warnings := config.Load()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v", warnings)
+	}
+	if cfg.List.Sort != "pid" {
+		t.Errorf("list.sort = %q, want it untouched", cfg.List.Sort)
+	}
+	if cfg.Desktop.InstalledVersion != "0.2.0" {
+		t.Errorf("desktop.installed_version = %q", cfg.Desktop.InstalledVersion)
+	}
+}
+
+// The download_base key is read, not written: an installer must honour it and
+// never rewrite what the user typed.
+func TestDownloadBaseIsReadFromTheConfig(t *testing.T) {
+	if _, err := config.Apply(map[string]any{"desktop": map[string]any{
+		"download_base": "https://example.com/desktop",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := config.Load()
+	if got := ResolveBase("", "", cfg.Desktop.DownloadBase); got != "https://example.com/desktop" {
+		t.Errorf("ResolveBase = %q", got)
+	}
+	if got := ResolveBase("", "https://env", cfg.Desktop.DownloadBase); got != "https://env" {
+		t.Errorf("the environment should win over the config, got %q", got)
+	}
+}

--- a/internal/doctor/checks_desktop.go
+++ b/internal/doctor/checks_desktop.go
@@ -1,0 +1,82 @@
+package doctor
+
+import (
+	"context"
+	"github.com/raskrebs/sonar/internal/config"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/desktop"
+	"github.com/raskrebs/sonar/internal/tray"
+)
+
+// checkDesktopInstalled answers the question `sonar tray` asks at launch: is
+// the app on this machine, and which one.
+//
+// It reads the config first, because that is the only source that knows the
+// *version* — the record `sonar install desktop` leaves behind — and falls
+// back to the same lookup tray does, so an app installed by some other means
+// (a .deb, a drag into /Applications) is still reported as installed rather
+// than as missing. A recorded path that no longer exists is the interesting
+// third case: the config says one thing and the disk says another, and the
+// same one command fixes it.
+func checkDesktopInstalled(_ context.Context, env *Env) rpc.DoctorCheck {
+	if !desktop.Supported(env.GOOS) {
+		return rpc.DoctorCheck{
+			Status:  StatusSkip,
+			Summary: "no desktop app for " + env.GOOS + " yet",
+			Detail:  "`sonar install desktop` publishes macOS and Linux builds so far",
+		}
+	}
+
+	cfg, _ := config.LoadFrom(env.ConfigPath)
+	recorded := cfg.Desktop
+	if recorded.InstalledPath != "" && exists(recorded.InstalledPath) {
+		version := recorded.InstalledVersion
+		if version == "" {
+			version = "an unrecorded version"
+		}
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: "Sonar " + version + " is installed",
+			Detail:  recorded.InstalledPath,
+		}
+	}
+
+	if path, ok := installedElsewhere(env); ok {
+		return rpc.DoctorCheck{
+			Status:  StatusOK,
+			Summary: "the desktop app is installed",
+			Detail:  path + " — sonar did not install it, so there is no version on record",
+		}
+	}
+
+	if recorded.InstalledPath != "" {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: "the recorded desktop app is gone",
+			Detail:  recorded.InstalledPath + " no longer exists",
+			Fix:     "sonar install desktop",
+		}
+	}
+	return rpc.DoctorCheck{
+		Status:  StatusWarn,
+		Summary: "the desktop app is not installed",
+		Detail:  "`sonar tray` has nothing to launch",
+		Fix:     "sonar install desktop",
+	}
+}
+
+// installedElsewhere runs tray's own lookup against the doctor's seams, so the
+// two never disagree about what counts as installed.
+func installedElsewhere(env *Env) (string, bool) {
+	d := tray.Decide(tray.Env{
+		GOOS:     env.GOOS,
+		Home:     env.Home,
+		Getenv:   func(string) string { return "" },
+		Exists:   exists,
+		LookPath: env.LookPath,
+	})
+	if d.Kind == tray.KindDesktopApp {
+		return d.Path, true
+	}
+	return "", false
+}

--- a/internal/doctor/checks_desktop_test.go
+++ b/internal/doctor/checks_desktop_test.go
@@ -1,0 +1,106 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeDesktopConfig puts the two keys `sonar install desktop` records into
+// the fake env's config file.
+func writeDesktopConfig(t *testing.T, env *Env, version, path string) {
+	t.Helper()
+	body := "desktop:\n"
+	if version != "" {
+		body += "  installed_version: " + version + "\n"
+	}
+	if path != "" {
+		body += "  installed_path: " + path + "\n"
+	}
+	write(t, env.ConfigPath, body)
+}
+
+func TestDesktopInstalled(t *testing.T) {
+	t.Run("recorded and present", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.GOOS = "darwin"
+		app := filepath.Join(t.TempDir(), "Sonar.app")
+		if err := os.MkdirAll(app, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeDesktopConfig(t, env, "0.1.0-beta.1", app)
+
+		got := run(t, env, checkDesktopInstalled)
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Summary, "0.1.0-beta.1") {
+			t.Errorf("summary = %q, want the version", got.Summary)
+		}
+		if got.Detail != app {
+			t.Errorf("detail = %q, want %q", got.Detail, app)
+		}
+	})
+
+	t.Run("nothing installed", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.GOOS = "darwin"
+		got := run(t, env, checkDesktopInstalled)
+		wantStatus(t, got, StatusWarn)
+		if got.Fix != "sonar install desktop" {
+			t.Errorf("fix = %q", got.Fix)
+		}
+	})
+
+	t.Run("recorded but gone", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.GOOS = "darwin"
+		gone := filepath.Join(t.TempDir(), "Sonar.app")
+		writeDesktopConfig(t, env, "0.1.0", gone)
+
+		got := run(t, env, checkDesktopInstalled)
+		wantStatus(t, got, StatusWarn)
+		if !strings.Contains(got.Detail, gone) {
+			t.Errorf("detail = %q, want it to name the missing path", got.Detail)
+		}
+		if got.Fix != "sonar install desktop" {
+			t.Errorf("fix = %q", got.Fix)
+		}
+	})
+
+	t.Run("installed by something else on linux", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.GOOS = "linux"
+		// The AppImage location `sonar install desktop` uses, with nothing in
+		// the config: an app the user installed by hand still counts.
+		appImage := filepath.Join(env.Home, ".local", "opt", "sonar-desktop", "Sonar.AppImage")
+		write(t, appImage, "#!/bin/sh\n")
+
+		got := run(t, env, checkDesktopInstalled)
+		wantStatus(t, got, StatusOK)
+		if !strings.Contains(got.Detail, appImage) {
+			t.Errorf("detail = %q, want it to name the AppImage", got.Detail)
+		}
+	})
+
+	t.Run("skips on windows", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.GOOS = "windows"
+		got := run(t, env, checkDesktopInstalled)
+		wantStatus(t, got, StatusSkip)
+		if !strings.Contains(got.Summary, "windows") {
+			t.Errorf("summary = %q", got.Summary)
+		}
+	})
+}
+
+func TestDesktopInstalledIsInTheCheckList(t *testing.T) {
+	var found bool
+	for _, id := range IDs() {
+		if id == "desktop_installed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("desktop_installed is not in %v", IDs())
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -147,6 +147,7 @@ func checks() []check {
 		check{id: "hooks_installed", run: checkHooksInstalled},
 		check{id: "project_config", run: checkProjectConfig},
 		check{id: "docker", run: checkDocker},
+		check{id: "desktop_installed", run: checkDesktopInstalled},
 		check{id: "tray", run: checkTray},
 	)
 }

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/raskrebs/sonar/internal/config"
 )
 
 // DownloadURL is where the desktop app is published. It is a placeholder until
@@ -52,12 +54,17 @@ type Decision struct {
 // Env is the slice of the world the decision depends on, injected so the whole
 // table can be exercised on one host against a fake filesystem.
 type Env struct {
-	GOOS     string
-	Home     string
-	SelfDir  string // directory holding the sonar binary
-	Getenv   func(string) string
-	Exists   func(string) bool
-	LookPath func(string) (string, error)
+	GOOS    string
+	Home    string
+	SelfDir string // directory holding the sonar binary
+	// Configured is desktop.installed_path from the user's config: what
+	// `sonar install desktop` recorded. It is checked before the standard
+	// locations, so an app installed with --dir is still what `sonar tray`
+	// launches.
+	Configured string
+	Getenv     func(string) string
+	Exists     func(string) bool
+	LookPath   func(string) (string, error)
 }
 
 // osEnv is the real environment.
@@ -67,11 +74,13 @@ func osEnv() Env {
 	if self, err := os.Executable(); err == nil {
 		selfDir = filepath.Dir(self)
 	}
+	cfg, _ := config.Load()
 	return Env{
-		GOOS:    runtime.GOOS,
-		Home:    home,
-		SelfDir: selfDir,
-		Getenv:  os.Getenv,
+		GOOS:       runtime.GOOS,
+		Home:       home,
+		SelfDir:    selfDir,
+		Configured: cfg.Desktop.InstalledPath,
+		Getenv:     os.Getenv,
 		Exists: func(path string) bool {
 			_, err := os.Stat(path)
 			return err == nil
@@ -114,6 +123,14 @@ func findDesktopApp(env Env) (string, bool) {
 }
 
 func desktopCandidates(env Env) []string {
+	var configured []string
+	if env.Configured != "" {
+		configured = []string{env.Configured}
+	}
+	return append(configured, standardDesktopCandidates(env)...)
+}
+
+func standardDesktopCandidates(env Env) []string {
 	switch env.GOOS {
 	case "darwin":
 		out := []string{"/Applications/Sonar.app"}
@@ -143,7 +160,11 @@ func desktopCandidates(env Env) []string {
 	default:
 		out := []string{"/opt/Sonar/sonar-desktop", "/usr/bin/sonar-desktop", "/usr/local/bin/sonar-desktop"}
 		if env.Home != "" {
-			out = append(out, filepath.Join(env.Home, ".local", "bin", "sonar-desktop"))
+			// Where `sonar install desktop` puts the AppImage, and the symlink
+			// it points at it.
+			out = append(out,
+				filepath.Join(env.Home, ".local", "bin", "sonar-desktop"),
+				filepath.Join(env.Home, ".local", "opt", "sonar-desktop", "Sonar.AppImage"))
 		}
 		return out
 	}
@@ -212,7 +233,7 @@ func (e Env) getenv(key string) string {
 type NotInstalledError struct{ GOOS string }
 
 func (e *NotInstalledError) Error() string {
-	return fmt.Sprintf("the Sonar desktop app is not installed — download it from %s", DownloadURL)
+	return fmt.Sprintf("the Sonar desktop app is not installed — run `sonar install desktop` to get it (%s)", DownloadURL)
 }
 
 // Run launches whatever Decide found. detach only affects the Swift tray: the


### PR DESCRIPTION
Adds `sonar install desktop` for macOS and Linux: reads `desktop.json` from the public artifacts repo (or `desktop.download_base`), verifies sha256 and size, installs atomically without touching quarantine attributes, records the install in the config, and launches. Adds the `desktop_installed` doctor check and points `sonar tray` at the recorded path. Contract §49.