### PR TITLE
feat: ports per worktree (worktree_ports in .sonar.yaml)

### DIFF
--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -1041,13 +1041,24 @@
             "type": "integer"
           },
           "type": "array"
+        },
+        "worktree_ports": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "type": "object",
       "required": [
         "name",
         "services",
-        "ports"
+        "ports",
+        "worktree_ports"
       ]
     },
     "GroupsAssignParams": {
@@ -1182,6 +1193,16 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "worktree_ports": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "type": "object",

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/raskrebs/sonar/internal/groups"
 	"github.com/raskrebs/sonar/internal/state"
 	"github.com/raskrebs/sonar/internal/store"
 )
@@ -16,8 +17,9 @@ import (
 const DefaultTTL = 24 * time.Hour
 
 // MaxCount caps how many ports one key may hold, so a typo in `count` cannot
-// reserve a whole range.
-const MaxCount = 64
+// reserve a whole range. It is the same cap `.sonar.yaml` puts on
+// worktree_ports, so a block a config asks for is always one Acquire grants.
+const MaxCount = groups.MaxWorktreePorts
 
 // acquireAttempts is how often Acquire re-derives its ports when the table
 // changed underneath it. Inside one daemon the mutex makes a second attempt
@@ -56,22 +58,30 @@ type Options struct {
 	Listening func() (map[int]bool, error)
 	// DefaultTTL overrides DefaultTTL for callers that pass no ttl.
 	DefaultTTL time.Duration
+	// DefaultCount is how many ports a request that names no count takes for
+	// a project: the daemon answers it from the project's `.sonar.yaml`
+	// worktree_ports. A result of zero, or a nil func, means one port.
+	DefaultCount func(project string) int
 }
 
 // Manager is the claims book. One lives in the daemon, per database.
 type Manager struct {
-	table Table
-	rng   Range
-	now   func() time.Time
-	ttl   time.Duration
-	live  func() (map[int]bool, error)
+	table        Table
+	rng          Range
+	now          func() time.Time
+	ttl          time.Duration
+	live         func() (map[int]bool, error)
+	defaultCount func(project string) int
 
 	mu sync.Mutex
 }
 
 // New builds a manager over a claims table.
 func New(t Table, o Options) *Manager {
-	m := &Manager{table: t, rng: o.Range, now: o.Now, ttl: o.DefaultTTL, live: o.Listening}
+	m := &Manager{
+		table: t, rng: o.Range, now: o.Now, ttl: o.DefaultTTL, live: o.Listening,
+		defaultCount: o.DefaultCount,
+	}
 	if m.rng.Valid() != nil {
 		m.rng = DefaultRange
 	}
@@ -119,7 +129,11 @@ func (m *Manager) Acquire(req Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	// An explicit count always wins; only an omitted one asks the project.
 	count := req.Count
+	if count == 0 && m.defaultCount != nil {
+		count = m.defaultCount(project)
+	}
 	if count == 0 {
 		count = 1
 	}

--- a/internal/claims/claims_test.go
+++ b/internal/claims/claims_test.go
@@ -3,6 +3,7 @@ package claims_test
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -94,6 +95,53 @@ func TestProbeSkipsPortsAnotherKeyHolds(t *testing.T) {
 	}
 	if len(res.Ports) != 2 {
 		t.Fatalf("ports = %v, want two", res.Ports)
+	}
+}
+
+// TestAnOmittedCountTakesTheProjectDefault: a request with no count asks
+// DefaultCount for its project (recovered from the key when only a key was
+// sent); an explicit count never asks; a project with no default gets one.
+func TestAnOmittedCountTakesTheProjectDefault(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "sonar.db"))
+	if err != nil {
+		t.Fatalf("opening the store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	var asked []string
+	m := claims.New(st.Claims(), claims.Options{DefaultCount: func(project string) int {
+		asked = append(asked, project)
+		if project == "shop" {
+			return 4
+		}
+		return 0
+	}})
+
+	if res := acquire(t, m, claims.Request{Project: "shop", Worktree: "feature-x"}); len(res.Ports) != 4 {
+		t.Errorf("omitted count: ports = %v, want the project's block of 4", res.Ports)
+	}
+	if res := acquire(t, m, claims.Request{Key: "shop/feature-y"}); len(res.Ports) != 4 {
+		t.Errorf("key only: ports = %v, want 4 from the project in the key", res.Ports)
+	}
+	if res := acquire(t, m, claims.Request{Project: "shop", Worktree: "feature-z", Count: 2}); len(res.Ports) != 2 {
+		t.Errorf("explicit count: ports = %v, want the 2 asked for", res.Ports)
+	}
+	if res := acquire(t, m, claims.Request{Project: "other"}); len(res.Ports) != 1 {
+		t.Errorf("no default: ports = %v, want one", res.Ports)
+	}
+	if got := strings.Join(asked, ","); got != "shop,shop,other" {
+		t.Errorf("DefaultCount was asked for %q, want shop,shop,other (never for an explicit count)", got)
+	}
+}
+
+// TestTheCountCapFitsTheLargestWorktreeBlock: `.sonar.yaml` allows
+// worktree_ports up to 100, so the manager must grant 100 and refuse 101.
+func TestTheCountCapFitsTheLargestWorktreeBlock(t *testing.T) {
+	m, _ := newManager(t, nil, nil)
+	if res := acquire(t, m, claims.Request{Key: "big/main", Count: 100}); len(res.Ports) != 100 {
+		t.Fatalf("ports = %d, want 100", len(res.Ports))
+	}
+	if _, err := m.Acquire(claims.Request{Key: "bigger/main", Count: claims.MaxCount + 1}); err == nil {
+		t.Fatal("a count above MaxCount should be refused")
 	}
 }
 

--- a/internal/cmd/claim.go
+++ b/internal/cmd/claim.go
@@ -70,7 +70,7 @@ var claimsCmd = &cobra.Command{
 func init() {
 	claimCmd.Flags().StringVar(&claimProject, "project", "", "Project name (default: the git checkout's name)")
 	claimCmd.Flags().StringVar(&claimWorktree, "worktree", "", "Worktree name (default: this checkout's, or main)")
-	claimCmd.Flags().IntVarP(&claimCount, "count", "n", 1, "How many ports to claim")
+	claimCmd.Flags().IntVarP(&claimCount, "count", "n", 0, "How many ports to claim (default: the project's worktree_ports from .sonar.yaml, else 1)")
 	claimCmd.Flags().StringVar(&claimTTLFlag, "ttl", "24h", "How long the claim lives (e.g. 2h, 30m)")
 	claimCmd.Flags().BoolVar(&claimRelease, "release", false, "Release this key's ports instead of claiming")
 	claimCmd.Flags().BoolVar(&claimListFlag, "list", false, "List live claims instead of claiming")
@@ -85,7 +85,9 @@ func claimRun(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	if claimCount < 1 {
+	// An unset --count sends no count, so the daemon can apply the project's
+	// worktree_ports; only a count the user typed is checked here.
+	if cmd.Flags().Changed("count") && claimCount < 1 {
 		return fmt.Errorf("--count must be at least 1")
 	}
 

--- a/internal/daemon/groups_config.go
+++ b/internal/daemon/groups_config.go
@@ -54,11 +54,13 @@ func handleGroupsConfigSet(_ context.Context, req *Request) (any, error) {
 		Rename:   p.Rename,
 		Add:      p.Add,
 		Services: p.Services,
+
+		WorktreePorts: p.WorktreePortsChange(),
 	}
 	if edit.Empty() {
-		return nil, rpc.NewError(rpc.CodeInvalidParams, "services, add, rename or remove is required",
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "services, add, rename, remove or worktree_ports is required",
 			`send {"path": "…", "add": [{"name": "worker", "port": 9000}]}, or a rename, a remove, `+
-				`or {"services": [{"name": "api", "patch": {...}}]}`)
+				`{"services": [{"name": "api", "patch": {...}}]} or {"worktree_ports": 4}`)
 	}
 	if err := checkEditNames(edit); err != nil {
 		return nil, err
@@ -231,6 +233,11 @@ func configRow(rt *Runtime, cfg *groups.Config) rpc.GroupConfig {
 	}
 	if out.Ports == nil {
 		out.Ports = []int{}
+	}
+	if cfg.WorktreePorts != nil {
+		// A copy, so the row never aliases the index's config.
+		n := *cfg.WorktreePorts
+		out.WorktreePorts = &n
 	}
 	live := liveServices(rt, cfg.Name)
 	for i := range out.Services {

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/raskrebs/sonar/internal/claims"
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
 	"github.com/raskrebs/sonar/internal/scanner"
 	"github.com/raskrebs/sonar/internal/state"
 	"github.com/raskrebs/sonar/internal/store"
@@ -40,8 +41,61 @@ func claimsManager(rt *Runtime) (*claims.Manager, error) {
 		return nil, errNoStore()
 	}
 	return claims.New(st.Claims(), claims.Options{
-		Listening: func() (map[int]bool, error) { return listeningPorts(rt) },
+		Listening:    func() (map[int]bool, error) { return listeningPorts(rt) },
+		DefaultCount: func(project string) int { return worktreePorts(rt, project) },
 	}), nil
+}
+
+// worktreePorts answers claims.Options.DefaultCount: the worktree_ports of the
+// `.sonar.yaml` belonging to a claim's project, or zero when no config says
+// (step 5A.7).
+//
+// A claim names its project the way claims.Identity does — the main
+// checkout's directory name, which every linked worktree of it shares — so a
+// config belongs to the project when claims.Identity of the config's own
+// directory gives the same name. A config whose group name is the project
+// matches too, for a caller that passed the group name as project.
+//
+// Several configs can match: the main checkout's file and each worktree's
+// checked-out copy of it, or a monorepo's nested files. The main checkout's
+// repository-root file wins, because that is the file the desktop's group page
+// edits; see configRank.
+func worktreePorts(rt *Runtime, project string) int {
+	if rt.Scanner == nil || project == "" {
+		return 0
+	}
+	best, bestRank := 0, -1
+	for _, cfg := range rt.Scanner.Configs() {
+		if cfg.WorktreePorts == nil {
+			continue
+		}
+		if r := configRank(cfg, project); r > bestRank {
+			best, bestRank = *cfg.WorktreePorts, r
+		}
+	}
+	return best
+}
+
+// configRank orders the configs that could answer for a project: -1 is no
+// match, 0 a match by group name only, and 1-4 a match by checkout, higher for
+// the main checkout over a linked worktree and for the repository root over a
+// nested directory.
+func configRank(cfg *groups.Config, project string) int {
+	if name, _ := claims.Identity(cfg.Dir, "", ""); name != project {
+		if cfg.Name == project {
+			return 0
+		}
+		return -1
+	}
+	root, linked, inRepo := groups.Find(cfg.Dir)
+	rank := 1
+	if !inRepo || linked == "" {
+		rank += 2
+	}
+	if !inRepo || cfg.Dir == root {
+		rank++
+	}
+	return rank
 }
 
 // listeningPorts is the live scan as a set, which is how the claim probe skips

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -412,6 +412,10 @@ type GroupConfig struct {
 	Name     string          `json:"name"`
 	Services []state.Service `json:"services"`
 	Ports    []int           `json:"ports"`
+	// WorktreePorts is the file's worktree_ports: how many ports a claim for
+	// this project takes when it names no count (step 5A.7). Null when the
+	// file has no such key.
+	WorktreePorts *int `json:"worktree_ports" jsonschema:"nullable"`
 }
 
 type GroupsConfigGetParams struct {
@@ -446,6 +450,45 @@ type GroupsConfigSetParams struct {
 	// Remove deletes services and drops them from every other service's
 	// depends_on. An unknown name is `not_found`.
 	Remove []string `json:"remove,omitempty"`
+	// WorktreePorts edits the top-level worktree_ports key (step 5A.7):
+	// omitted leaves it alone, a number (1-100) writes it, and null removes
+	// it. A value out of range is `invalid_config`, like any edit that would
+	// leave the file invalid.
+	WorktreePorts *int `json:"worktree_ports,omitempty" jsonschema:"nullable"`
+
+	// WorktreePortsSent records that worktree_ports was present, null
+	// included, because a pointer alone cannot tell null from absent.
+	// UnmarshalJSON fills it; a Go caller sets it by hand.
+	WorktreePortsSent bool `json:"-" jsonschema:"-"`
+}
+
+// UnmarshalJSON decodes the params and remembers whether worktree_ports was
+// sent at all.
+func (p *GroupsConfigSetParams) UnmarshalJSON(data []byte) error {
+	type plain GroupsConfigSetParams
+	var v plain
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return err
+	}
+	*p = GroupsConfigSetParams(v)
+	_, p.WorktreePortsSent = keys[groups.FieldWorktreePorts]
+	return nil
+}
+
+// WorktreePortsChange is the edit the worktree_ports field asks for.
+func (p GroupsConfigSetParams) WorktreePortsChange() groups.IntChange {
+	switch {
+	case !p.WorktreePortsSent:
+		return groups.IntChange{}
+	case p.WorktreePorts == nil:
+		return groups.ClearInt()
+	default:
+		return groups.SetInt(*p.WorktreePorts)
+	}
 }
 
 // GroupsConfigSetResult is the file after the write. Affected carries the
@@ -573,6 +616,10 @@ type RunsSpawnResult struct {
 // TTLSeconds is the spec's field and wins; TTLMs is kept because the generated
 // schema has always carried it and every other duration on this wire is in
 // milliseconds. Neither set means DefaultTTL (24h).
+//
+// An omitted Count takes the worktree_ports of the project's `.sonar.yaml`
+// when the daemon knows one that sets it, and one port otherwise; an explicit
+// Count always wins (step 5A.7).
 type ClaimsAcquireParams struct {
 	HostParams
 	Project    string `json:"project,omitempty"`

--- a/internal/daemon/worktree_ports_test.go
+++ b/internal/daemon/worktree_ports_test.go
@@ -1,0 +1,221 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+)
+
+// Step 5A.7: `.sonar.yaml` carries worktree_ports, groups.config.get/set read
+// and write it, and claims.acquire uses it when the caller names no count.
+
+// mainCheckout makes a git checkout named repo under parent, with a
+// `.sonar.yaml` holding body, and returns the checkout directory.
+func mainCheckout(t *testing.T, parent, repo, body string) string {
+	t.Helper()
+	dir := filepath.Join(parent, repo)
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, dir, body)
+	return dir
+}
+
+// linkedWorktree makes a linked worktree of the checkout at mainDir: a `.git`
+// file pointing into mainDir/.git/worktrees/<name>, which is how groups.Find
+// tells one apart. A non-empty body is written as its `.sonar.yaml`.
+func linkedWorktree(t *testing.T, parent, mainDir, name, body string) string {
+	t.Helper()
+	dir := filepath.Join(parent, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitdir := filepath.Join(mainDir, ".git", "worktrees", name)
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if body != "" {
+		writeConfig(t, dir, body)
+	}
+	return dir
+}
+
+func writeConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, groups.ConfigName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func acquireCount(t *testing.T, c *testClient, p rpc.ClaimsAcquireParams) int {
+	t.Helper()
+	var res rpc.ClaimsAcquireResult
+	if e := c.call("claims.acquire", p, &res); e != nil {
+		t.Fatalf("claims.acquire %+v: %v", p, e)
+	}
+	return len(res.Ports)
+}
+
+// TestClaimCountDefaultsToWorktreePorts: an omitted count takes the
+// project's worktree_ports; an explicit count wins; a project without the key
+// or without a config gets one port. The main checkout's file is the one that
+// counts when a linked worktree carries a different copy.
+func TestClaimCountDefaultsToWorktreePorts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := storeHarness(t, ctx)
+	c := h.dial(ctx)
+
+	parent := resolvedDir(t, t.TempDir())
+	shop := mainCheckout(t, parent, "shop", "# the shop\nname: shop\nworktree_ports: 3\n")
+	shopWT := linkedWorktree(t, parent, shop, "shop-feature", "name: shop\nworktree_ports: 5\n")
+	plain := mainCheckout(t, parent, "plain", "name: plain\n")
+	// A repository whose main checkout the daemon has never indexed: its
+	// worktree's copy is all there is, and it still answers.
+	solo := filepath.Join(parent, "solo")
+	soloWT := linkedWorktree(t, parent, solo, "solo-feature", "name: solo\nworktree_ports: 2\n")
+	for _, dir := range []string{shopWT, shop, plain, soloWT} {
+		if err := h.loop.LoadConfig(filepath.Join(dir, groups.ConfigName)); err != nil {
+			t.Fatalf("indexing %s: %v", dir, err)
+		}
+	}
+
+	cases := []struct {
+		name string
+		p    rpc.ClaimsAcquireParams
+		want int
+	}{
+		{"omitted count takes the main checkout's worktree_ports", rpc.ClaimsAcquireParams{Project: "shop", Worktree: "feature"}, 3},
+		{"a key alone names the project", rpc.ClaimsAcquireParams{Key: "shop/other"}, 3},
+		{"an explicit count wins", rpc.ClaimsAcquireParams{Project: "shop", Worktree: "one", Count: 1}, 1},
+		{"a config without the key", rpc.ClaimsAcquireParams{Project: "plain", Worktree: "feature"}, 1},
+		{"no config at all", rpc.ClaimsAcquireParams{Project: "nowhere", Worktree: "feature"}, 1},
+		{"only a worktree's config is known", rpc.ClaimsAcquireParams{Project: "solo", Worktree: "feature"}, 2},
+	}
+	for _, tc := range cases {
+		if got := acquireCount(t, c, tc.p); got != tc.want {
+			t.Errorf("%s: %d ports, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestGroupsConfigWorktreePortsRoundTrip: set writes the key without
+// disturbing comments, get reads it back, a claim picks up the new value at
+// once, an edit that does not mention the key leaves it alone, and null
+// removes it.
+func TestGroupsConfigWorktreePortsRoundTrip(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _ := storeHarness(t, ctx)
+	c := h.dial(ctx)
+
+	parent := resolvedDir(t, t.TempDir())
+	dir := mainCheckout(t, parent, "demo", configFixture)
+	path := filepath.Join(dir, groups.ConfigName)
+
+	get := func() json.RawMessage {
+		t.Helper()
+		var res struct {
+			Config map[string]json.RawMessage `json:"config"`
+		}
+		if e := c.call("groups.config.get", rpc.GroupsConfigGetParams{Path: &path}, &res); e != nil {
+			t.Fatalf("groups.config.get: %v", e)
+		}
+		v, ok := res.Config["worktree_ports"]
+		if !ok {
+			t.Fatalf("config has no worktree_ports key: %v", res.Config)
+		}
+		return v
+	}
+	set := func(params map[string]any) *rpc.GroupsConfigSetResult {
+		t.Helper()
+		params["path"] = path
+		var res rpc.GroupsConfigSetResult
+		if e := c.call("groups.config.set", params, &res); e != nil {
+			t.Fatalf("groups.config.set %v: %v", params, e)
+		}
+		return &res
+	}
+
+	if got := string(get()); got != "null" {
+		t.Fatalf("worktree_ports before any edit = %s, want null", got)
+	}
+
+	res := set(map[string]any{"worktree_ports": 4})
+	if res.Config.WorktreePorts == nil || *res.Config.WorktreePorts != 4 {
+		t.Fatalf("set result worktree_ports = %v, want 4", res.Config.WorktreePorts)
+	}
+	if len(res.Affected) != 0 {
+		t.Errorf("affected = %v, want no service names", res.Affected)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"# demo project", "# the database goes first", "worktree_ports: 4"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("file lost %q after the write:\n%s", want, data)
+		}
+	}
+	if got := string(get()); got != "4" {
+		t.Errorf("get after set = %s, want 4", got)
+	}
+	// The write reloads the index, so the very next claim sees the block.
+	if got := acquireCount(t, c, rpc.ClaimsAcquireParams{Project: "demo", Worktree: "feature"}); got != 4 {
+		t.Errorf("claim after set = %d ports, want 4", got)
+	}
+
+	// An edit that does not mention worktree_ports leaves it alone.
+	set(map[string]any{"services": []any{map[string]any{"name": "api", "patch": map[string]any{"icon": "server"}}}})
+	if got := string(get()); got != "4" {
+		t.Errorf("get after an unrelated edit = %s, want 4 kept", got)
+	}
+
+	res = set(map[string]any{"worktree_ports": nil})
+	if res.Config.WorktreePorts != nil {
+		t.Errorf("set result after null = %d, want nil", *res.Config.WorktreePorts)
+	}
+	if data, _ := os.ReadFile(path); strings.Contains(string(data), "worktree_ports") {
+		t.Errorf("null did not remove the key:\n%s", data)
+	}
+	if got := string(get()); got != "null" {
+		t.Errorf("get after null = %s, want null", got)
+	}
+}
+
+// TestGroupsConfigWorktreePortsErrors: an out-of-range value is
+// invalid_config and leaves the file byte-identical; a call carrying nothing
+// to change is still invalid_params.
+func TestGroupsConfigWorktreePortsErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h, _, path := configHarness(t, ctx)
+	c := h.dial(ctx)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, n := range []int{0, 101} {
+		e := c.call("groups.config.set", map[string]any{"path": path, "worktree_ports": n}, nil)
+		if e == nil {
+			t.Fatalf("worktree_ports %d should fail", n)
+		}
+		if e.Code != rpc.CodeInvalidConfig || !strings.Contains(e.Data.Detail, "worktree_ports") {
+			t.Errorf("worktree_ports %d: error = %+v, want invalid_config naming the key", n, e)
+		}
+	}
+	if after, _ := os.ReadFile(path); string(after) != string(before) {
+		t.Errorf("a failed write changed the file:\n%s", after)
+	}
+
+	if e := c.call("groups.config.set", map[string]any{"path": path}, nil); e == nil || e.Data.Code != "invalid_params" {
+		t.Errorf("an empty edit: error = %+v, want invalid_params", e)
+	}
+}

--- a/internal/groups/config.go
+++ b/internal/groups/config.go
@@ -34,12 +34,25 @@ type Service struct {
 	DependsOn   []string `yaml:"depends_on,omitempty"`
 }
 
+// MaxWorktreePorts is the largest block `worktree_ports` may ask for. It is
+// also the cap on a claim's explicit count, so a config can never ask for a
+// block the claims manager would refuse.
+const MaxWorktreePorts = 100
+
+// FieldWorktreePorts is the top-level key naming the block size a worktree
+// claims.
+const FieldWorktreePorts = "worktree_ports"
+
 // Config is a parsed `.sonar.yaml`. Path and Dir are filled by Load and are
 // not part of the file format.
 type Config struct {
 	Name     string    `yaml:"name"`
 	Services []Service `yaml:"services,omitempty"`
 	Ports    []int     `yaml:"ports,omitempty"`
+	// WorktreePorts is how many ports a claim for this project takes when the
+	// caller does not name a count (step 5A.7). Nil means the key is absent
+	// and the claims default applies.
+	WorktreePorts *int `yaml:"worktree_ports,omitempty"`
 
 	Path string `yaml:"-"` // absolute path of the file it was read from
 	Dir  string `yaml:"-"` // directory containing the file
@@ -127,6 +140,9 @@ func (c *Config) validate() []string {
 		if p < 1 || p > 65535 {
 			problems = append(problems, fmt.Sprintf("ports: %d is out of range 1-65535", p))
 		}
+	}
+	if n := c.WorktreePorts; n != nil && (*n < 1 || *n > MaxWorktreePorts) {
+		problems = append(problems, fmt.Sprintf("%s: %d is out of range 1-%d", FieldWorktreePorts, *n, MaxWorktreePorts))
 	}
 
 	seen := map[string]bool{}

--- a/internal/groups/config_test.go
+++ b/internal/groups/config_test.go
@@ -1,6 +1,7 @@
 package groups
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -91,6 +92,21 @@ func TestLoadValidationProblems(t *testing.T) {
 			name: "port out of range",
 			body: "name: p\nservices:\n  - name: api\n    port: 70000\n",
 			want: "port 70000 is out of range",
+		},
+		{
+			name: "worktree_ports of zero",
+			body: "name: p\nworktree_ports: 0\n",
+			want: "worktree_ports: 0 is out of range 1-100",
+		},
+		{
+			name: "worktree_ports above the cap",
+			body: "name: p\nworktree_ports: 101\n",
+			want: "worktree_ports: 101 is out of range 1-100",
+		},
+		{
+			name: "worktree_ports that is not a number",
+			body: "name: p\nworktree_ports: lots\n",
+			want: "lots",
 		},
 		{
 			name: "zero port in the ports list",
@@ -207,5 +223,31 @@ func TestServiceRowLeavesMetadataNull(t *testing.T) {
 	row := ServiceRow(Service{Name: "db"})
 	if row.Description != nil || row.Icon != nil || row.Color != nil || row.Health != nil {
 		t.Fatalf("expected null metadata, got %+v", row)
+	}
+}
+
+// TestLoadWorktreePorts: the key is optional, and absent is nil rather than a
+// zero that would read as "claim nothing".
+func TestLoadWorktreePorts(t *testing.T) {
+	cfg, err := loadString(t, "shop", "name: shop\nworktree_ports: 5\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.WorktreePorts == nil || *cfg.WorktreePorts != 5 {
+		t.Fatalf("worktree_ports = %v, want 5", cfg.WorktreePorts)
+	}
+
+	cfg, err = loadString(t, "plain", "name: plain\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.WorktreePorts != nil {
+		t.Fatalf("worktree_ports = %d, want nil for a file without the key", *cfg.WorktreePorts)
+	}
+
+	for _, n := range []int{1, MaxWorktreePorts} {
+		if _, err := loadString(t, "edge", fmt.Sprintf("name: edge\nworktree_ports: %d\n", n)); err != nil {
+			t.Errorf("worktree_ports %d should be valid: %v", n, err)
+		}
 	}
 }

--- a/internal/groups/edit.go
+++ b/internal/groups/edit.go
@@ -13,7 +13,21 @@ import (
 // rootKeyOrder is where a top-level key belongs in a `.sonar.yaml`. It is the
 // same idea as keyOrder one level up: a `services:` list this package has to
 // create lands where a hand-written file would put it.
-var rootKeyOrder = []string{"name", "services", "ports"}
+var rootKeyOrder = []string{"name", "services", "ports", FieldWorktreePorts}
+
+// IntChange is an edit to one optional integer key. The zero value leaves the
+// key alone; Set with a nil Value removes it; Set with a Value writes it. It
+// is how the wire's three states — absent, null, a number — reach the file.
+type IntChange struct {
+	Set   bool
+	Value *int
+}
+
+// SetInt is the change that writes n.
+func SetInt(n int) IntChange { return IntChange{Set: true, Value: &n} }
+
+// ClearInt is the change that removes the key.
+func ClearInt() IntChange { return IntChange{Set: true} }
 
 // ServiceAdd is a service to append to a `.sonar.yaml`. It is the whole
 // editable service, not a patch: an added service does not exist yet, so
@@ -92,11 +106,15 @@ type ConfigEdit struct {
 	Rename   []ServiceRename `json:"rename,omitempty"`
 	Add      []ServiceAdd    `json:"add,omitempty"`
 	Services []ServiceEdit   `json:"services,omitempty"`
+	// WorktreePorts sets or removes the top-level worktree_ports key. It is
+	// applied last and touches no service, so it never shows in Affected.
+	WorktreePorts IntChange `json:"-"`
 }
 
 // Empty reports whether the edit asks for nothing at all.
 func (e ConfigEdit) Empty() bool {
-	return len(e.Remove) == 0 && len(e.Rename) == 0 && len(e.Add) == 0 && len(e.Services) == 0
+	return len(e.Remove) == 0 && len(e.Rename) == 0 && len(e.Add) == 0 && len(e.Services) == 0 &&
+		!e.WorktreePorts.Set
 }
 
 // Affected is the service names the edit touched, in the order it applied
@@ -222,6 +240,16 @@ func applyEdit(abs string, root *yaml.Node, edit ConfigEdit) error {
 			continue
 		}
 		applyPatch(svc, e.Patch)
+	}
+	if c := edit.WorktreePorts; c.Set {
+		if c.Value == nil {
+			removeKey(root, FieldWorktreePorts)
+		} else {
+			// setKeyIn edits an existing value in place, so a comment beside
+			// `worktree_ports:` stays on that line.
+			setKeyIn(root, FieldWorktreePorts,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(*c.Value)}, rootKeyOrder)
+		}
 	}
 	return nil
 }

--- a/internal/groups/edit_test.go
+++ b/internal/groups/edit_test.go
@@ -496,3 +496,103 @@ func TestAddsFromRoundTrips(t *testing.T) {
 		t.Errorf("round trip = %+v, want the whole service back", got)
 	}
 }
+
+// TestWorktreePortsAddKeepsCommentsAndOrder: a file with no worktree_ports
+// grows the key at the end, and every other line stays where it was.
+func TestWorktreePortsAddKeepsCommentsAndOrder(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+
+	cfg, err := EditServices(path, ConfigEdit{WorktreePorts: SetInt(4)})
+	if err != nil {
+		t.Fatalf("EditServices: %v", err)
+	}
+	if cfg.WorktreePorts == nil || *cfg.WorktreePorts != 4 {
+		t.Fatalf("returned worktree_ports = %v, want 4", cfg.WorktreePorts)
+	}
+	out := read(t, path)
+	requireComments(t, out)
+	if got := strings.Join(topLevelKeys(out), ","); got != "ports,services,name,worktree_ports" {
+		t.Errorf("top-level keys = %s, want the author's order with worktree_ports last:\n%s", got, out)
+	}
+	if got := serviceNamesInFile(t, path); strings.Join(got, ",") != "db,api,cache" {
+		t.Errorf("services = %v, want them untouched", got)
+	}
+	reloaded, err := Load(path)
+	if err != nil || reloaded.WorktreePorts == nil || *reloaded.WorktreePorts != 4 {
+		t.Fatalf("reloaded worktree_ports = %v, %v; want 4", reloaded, err)
+	}
+}
+
+// TestWorktreePortsReplaceAndRemove: an existing value is edited in place, so
+// its comment and position survive; a clear removes the key and nothing else.
+func TestWorktreePortsReplaceAndRemove(t *testing.T) {
+	path := writePatchable(t, `name: shop
+worktree_ports: 3 # api, web and the worker
+# the services
+services:
+  - name: api
+    port: 8000
+`)
+
+	if _, err := EditServices(path, ConfigEdit{WorktreePorts: SetInt(6)}); err != nil {
+		t.Fatalf("setting worktree_ports: %v", err)
+	}
+	out := read(t, path)
+	if !strings.Contains(out, "worktree_ports: 6 # api, web and the worker") {
+		t.Errorf("the line comment did not stay with the value:\n%s", out)
+	}
+	if got := strings.Join(topLevelKeys(out), ","); got != "name,worktree_ports,services" {
+		t.Errorf("top-level keys = %s, want the key kept where it was", got)
+	}
+
+	cfg, err := EditServices(path, ConfigEdit{WorktreePorts: ClearInt()})
+	if err != nil {
+		t.Fatalf("clearing worktree_ports: %v", err)
+	}
+	if cfg.WorktreePorts != nil {
+		t.Errorf("worktree_ports = %d after a clear, want nil", *cfg.WorktreePorts)
+	}
+	out = read(t, path)
+	if strings.Contains(out, "worktree_ports") {
+		t.Errorf("the key survived a clear:\n%s", out)
+	}
+	if !strings.Contains(out, "# the services") || !strings.Contains(out, "name: api") {
+		t.Errorf("a clear touched more than its own key:\n%s", out)
+	}
+
+	// Clearing a key that is not there changes nothing and is not an error.
+	if _, err := EditServices(path, ConfigEdit{WorktreePorts: ClearInt()}); err != nil {
+		t.Errorf("clearing an absent worktree_ports: %v", err)
+	}
+}
+
+// TestWorktreePortsOutOfRangeLeavesTheFile: a value the file would not
+// validate with is a ConfigError and the file stays byte-identical.
+func TestWorktreePortsOutOfRangeLeavesTheFile(t *testing.T) {
+	path := writePatchable(t, oddlyOrdered)
+	for _, n := range []int{0, MaxWorktreePorts + 1} {
+		_, err := EditServices(path, ConfigEdit{WorktreePorts: SetInt(n)})
+		var bad *ConfigError
+		if !errors.As(err, &bad) {
+			t.Fatalf("worktree_ports %d: err = %v, want a *ConfigError", n, err)
+		}
+		if got := read(t, path); got != oddlyOrdered {
+			t.Fatalf("worktree_ports %d changed the file:\n%s", n, got)
+		}
+	}
+}
+
+func TestWorktreePortsChangeIsNotEmpty(t *testing.T) {
+	for _, c := range []IntChange{SetInt(2), ClearInt()} {
+		e := ConfigEdit{WorktreePorts: c}
+		if e.Empty() {
+			t.Errorf("%+v reads as an empty edit", c)
+		}
+		if len(e.Affected()) != 0 {
+			t.Errorf("affected = %v, want no service names", e.Affected())
+		}
+	}
+	if !(ConfigEdit{}).Empty() {
+		t.Error("the zero edit should be empty")
+	}
+}

--- a/internal/mcpserver/tools_query.go
+++ b/internal/mcpserver/tools_query.go
@@ -90,7 +90,7 @@ type NextFreePortOutput = rpc.PortsNextResult
 type ClaimPortInput struct {
 	Project    string `json:"project,omitempty" jsonschema:"The project the ports belong to. Defaults to the git checkout containing this server's working directory."`
 	Worktree   string `json:"worktree,omitempty" jsonschema:"The worktree the ports belong to. Defaults to this checkout's worktree, or main for a primary checkout."`
-	Count      int    `json:"count,omitempty" jsonschema:"How many ports to reserve. Defaults to 1."`
+	Count      int    `json:"count,omitempty" jsonschema:"How many ports to reserve. Defaults to the project's worktree_ports from .sonar.yaml, or 1 when it sets none."`
 	TTLSeconds int64  `json:"ttl_seconds,omitempty" jsonschema:"How long the reservation lives, in seconds. Defaults to 86400 (one day). Claiming again refreshes it."`
 	Release    bool   `json:"release,omitempty" jsonschema:"Give this key's ports back instead of claiming. Do this when the work is finished."`
 }


### PR DESCRIPTION
Roadmap step 5A.7: ports per worktree. The owner sets how many ports each worktree claims, in `.sonar.yaml`, from the desktop group page.

## What changed

- **`.sonar.yaml`** gains an optional top-level `worktree_ports: <int>` (1-100). It is parsed in `internal/groups/config.go`. A value that is out of range or not a number is a `ConfigError`, reported the same way as other invalid config.
- **`groups.config.get`/`groups.config.set`** read and write the key. Writes go through the existing comment-preserving node edit, so comments, key order and an inline comment on the value all survive. After a write, the index reloads the file.
- **`claims.acquire`**: when `count` is omitted, the claim takes the project's `worktree_ports`. An explicit `count` always wins. With no config, or a config without the key, the default stays at 1 port. MCP `claim_port` already sends `count` only when the agent passes one, so it inherits this through the same daemon path. `next_free_port` calls `ports.next`, not claims, so it is unchanged.
- **`sonar claim`**: `--count` now defaults to unset instead of 1, so the CLI inherits the setting too. No new flags or commands. This is a separate commit (`f1ba4dc`) so it can be dropped if the CLI should keep sending 1.
- **`claims.MaxCount`** goes from 64 to 100 and is now defined as `groups.MaxWorktreePorts`. Without this, a valid `worktree_ports: 80` would be refused at claim time.

## Wire shape

```ts
// GroupConfig (config of groups.config.get / groups.config.set results)
worktree_ports: number | null      // required; null when the key is absent

// GroupsConfigSetParams
worktree_ports?: number | null     // omitted = unchanged, number = set, null = remove the key
```

Generated schema (both are `"oneOf": [{"type": "integer"}, {"type": "null"}]`; `GroupConfig` lists `worktree_ports` in `required`).

A `groups.config.set` call carrying only `worktree_ports` is valid. It returns `affected: []`, because no service was touched. A value out of range returns `1006 invalid_config` and leaves the file byte-identical.

## How a claim finds its config

`claims.acquire` gets a `project` string, sent directly or recovered from `key`. That string is what `claims.Identity` derives: the main checkout's directory name, which every linked worktree of it shares.

The daemon checks each `.sonar.yaml` in its index that sets `worktree_ports`. A config belongs to the project when `claims.Identity(cfg.Dir)` gives the same name; a config whose group `name:` equals the project also matches, at the lowest rank. When several configs match, the one used is chosen in this order:
1. The main checkout's file at the repository root.
2. A nested file in the main checkout.
3. A linked worktree's root file.
4. A nested file in a linked worktree.

The main checkout's root file wins because that is the file the desktop edits. The lookup is `worktreePorts`/`configRank` in `internal/daemon/handlers_claims.go`, wired in through a new `claims.Options.DefaultCount`.

The lookup only sees configs the daemon has indexed: seen through a process cwd, remembered in the store, or loaded by `groups.config.get`/`set`. If none of a project's configs is indexed, the claim falls back to 1 port.

## Tests

- `internal/groups`: parse/validate (0, 101, non-number, and valid 1 and 100); set on a file with no key, where comments survive and the key lands last; replace in place, where the inline comment survives; null removal; clearing an absent key is a no-op; out-of-range writes leave the file byte-identical; `Empty`/`Affected`.
- `internal/claims`: omitted count uses `DefaultCount`, including key-only requests; an explicit count never consults it; no default gives 1; 100 is granted and 101 refused.
- `internal/daemon` (`worktree_ports_test.go`): the main checkout's value beats a linked worktree's copy; key-only; explicit count; config without the key; no config; only a worktree's config indexed. The config get/set round trip checks raw JSON `null`, `4`, a claim picking up the new value right after the write, an unrelated edit leaving the key alone, and null removal. Also checks the `invalid_config` and `invalid_params` errors.

Run with a temp `HOME`, `SONAR_SOCKET` and `GOTMPDIR`:

- `go build ./... && go vet ./...`: clean, and gofmt is clean.
- `go test ./...`: all packages pass except `internal/testenv`. Its `TestChildrenInheritTheRunRootAsTMPDIR` fails only when `GOTMPDIR` is set, and passes when run without it.
- `go generate ./... && git diff --exit-code docs/schema`: passes.
- `go test -tags integration` for groups, claims, daemon/..., mcpserver/fakedaemon and cmd: pass.
- `internal/mcpserver -tags integration` fails 3 tests (`TestQueryToolsAgainstARealDaemon`, `TestListPortsEqualsSonarListJSON`, `TestInspectPortNotFoundOverStdio`) with 10s daemon timeouts on `ports.list`/`ports.inspect`/`claims.acquire`. **Untouched `origin/main` (945ca22) fails the same three tests the same way on this machine**, so this comes from the environment, not this branch. Worth a re-run in CI.
