### PR TITLE
feat: checkouts — every worktree its own group, repo/worktree/branch on groups, groups.rename

### DIFF
--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -1012,6 +1012,15 @@
         "name": {
           "type": "string"
         },
+        "repo": {
+          "type": "string"
+        },
+        "worktree": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
         "source": {
           "type": "string",
           "enum": [
@@ -1061,6 +1070,9 @@
       "required": [
         "host",
         "name",
+        "repo",
+        "worktree",
+        "branch",
         "source",
         "root_dir",
         "config_path",
@@ -1361,6 +1373,15 @@
         "name": {
           "type": "string"
         },
+        "repo": {
+          "type": "string"
+        },
+        "worktree": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
         "source": {
           "type": "string",
           "enum": [
@@ -1416,6 +1437,9 @@
       "required": [
         "host",
         "name",
+        "repo",
+        "worktree",
+        "branch",
         "source",
         "root_dir",
         "config_path",

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -1504,6 +1504,46 @@
         "errors"
       ]
     },
+    "GroupsRenameParams": {
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "to"
+      ]
+    },
+    "GroupsRenameResult": {
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "affected": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "ok",
+        "affected",
+        "name"
+      ]
+    },
     "GroupsStartChunk": {
       "properties": {
         "service": {
@@ -4209,6 +4249,14 @@
       },
       "result": {
         "$ref": "#/definitions/GroupsReloadResult"
+      }
+    },
+    "groups.rename": {
+      "params": {
+        "$ref": "#/definitions/GroupsRenameParams"
+      },
+      "result": {
+        "$ref": "#/definitions/GroupsRenameResult"
       }
     },
     "groups.start": {

--- a/internal/claims/store_test.go
+++ b/internal/claims/store_test.go
@@ -37,8 +37,9 @@ func TestMigrationTakesTheStoreToVersionSix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Version: %v", err)
 	}
-	if v != store.VersionClaims {
-		t.Fatalf("version = %d, want %d", v, store.VersionClaims)
+	// Later migrations (007, group aliases) may sit above claims' 006.
+	if v != store.LatestVersion() {
+		t.Fatalf("version = %d, want the latest registered %d", v, store.LatestVersion())
 	}
 
 	var applied []int
@@ -54,8 +55,12 @@ func TestMigrationTakesTheStoreToVersionSix(t *testing.T) {
 		}
 		applied = append(applied, n)
 	}
-	if len(applied) < 3 || applied[len(applied)-1] != store.VersionClaims {
-		t.Fatalf("applied versions = %v, want them to end at %d", applied, store.VersionClaims)
+	hasClaims := false
+	for _, n := range applied {
+		hasClaims = hasClaims || n == store.VersionClaims
+	}
+	if len(applied) < 3 || !hasClaims {
+		t.Fatalf("applied versions = %v, want them to include %d", applied, store.VersionClaims)
 	}
 
 	var name string

--- a/internal/daemon/groups_rename.go
+++ b/internal/daemon/groups_rename.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/scanner"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// `groups.rename` (step 5A.6) renames a project and, with it, every checkout of
+// it: the main checkout's group and each linked worktree's `<project>@<wt>`.
+// The name lives where the project already keeps it — the `name:` of the main
+// checkout's `.sonar.yaml` — or, for a project with no file, in the daemon's
+// store, keyed by the main checkout's root.
+func init() {
+	RegisterHandler("groups.rename", handleGroupsRename)
+}
+
+var (
+	renameHooksMu sync.RWMutex
+	renameHooks   []func(renames map[string]string)
+)
+
+// OnGroupRename registers a function that is told, old name → new, about every
+// group a `groups.rename` renamed. State that recorded a group name when it was
+// created follows the rename through it — a run's group does, from
+// internal/daemon/runsreg — without this package importing its owner
+// (contract §8).
+func OnGroupRename(f func(renames map[string]string)) {
+	if f == nil {
+		return
+	}
+	renameHooksMu.Lock()
+	renameHooks = append(renameHooks, f)
+	renameHooksMu.Unlock()
+}
+
+func notifyGroupRename(renames map[string]string) {
+	if len(renames) == 0 {
+		return
+	}
+	renameHooksMu.RLock()
+	hooks := append([]func(map[string]string){}, renameHooks...)
+	renameHooksMu.RUnlock()
+	for _, f := range hooks {
+		f(renames)
+	}
+}
+
+func handleGroupsRename(_ context.Context, req *Request) (any, error) {
+	var p rpc.GroupsRenameParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	from, to := strings.TrimSpace(p.Name), strings.TrimSpace(p.To)
+	if from == "" {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, "name is required",
+			`send {"name": "<project or checkout group>", "to": "<new project name>"}`)
+	}
+	if err := groups.ValidProjectName(to); err != nil {
+		return nil, rpc.NewError(rpc.CodeInvalidParams, err.Error(),
+			"a project name is one word with no @, / or whitespace; a worktree's group adds @<worktree> to it")
+	}
+
+	rt := req.Runtime
+	snap, err := rt.Scanner.Snapshot(scanner.Include{})
+	if err != nil {
+		return nil, rpc.NewError(rpc.CodeInternal, "scan failed: "+err.Error(),
+			"check `sonar daemon log` for the scanner error")
+	}
+	local := make([]state.Group, 0, len(snap.Groups))
+	for _, g := range snap.Groups {
+		if state.IsLocalhost(g.Host) {
+			local = append(local, g)
+		}
+	}
+	plan, err := rt.Scanner.PlanGroupRename(local, from, to)
+	if err != nil {
+		return nil, renameError(err)
+	}
+	if len(plan.Renames) == 0 {
+		// Already called that: nothing to write and nothing to publish.
+		return rpc.GroupsRenameResult{
+			MutationResult: rpc.MutationResult{OK: true, Affected: []string{}},
+			Name:           plan.Project,
+		}, nil
+	}
+
+	if plan.ConfigPath != "" {
+		cfg, err := groups.SetConfigName(plan.ConfigPath, to)
+		if err != nil {
+			return nil, configError(plan.ConfigPath, err)
+		}
+		if err := rt.Scanner.LoadConfig(cfg.Path); err != nil {
+			rt.Logger.Warn("reloading a config after renaming its project", "path", cfg.Path, "error", err)
+		}
+		// The file names the project from now on. An alias stored before the
+		// file existed would still outrank it, so it goes.
+		if st := rt.Store; st != nil && plan.Main != "" {
+			if err := st.ClearGroupAlias(plan.Main); err != nil {
+				rt.Logger.Warn("clearing a project alias", "root", plan.Main, "error", err)
+			}
+		}
+	} else {
+		st := rt.Store
+		if st == nil {
+			return nil, errNoStore()
+		}
+		if err := st.SetGroupAlias(plan.Main, to); err != nil {
+			return nil, storeError("saving the project name", err)
+		}
+	}
+
+	notifyGroupRename(plan.Renames)
+	rt.Logger.Info("project renamed", "from", from, "to", to, "groups", len(plan.Renames))
+	// Publish before replying, like every other write: the delta that removes
+	// the old names and adds the new ones is queued ahead of this response.
+	republish(rt)
+
+	affected := make([]string, 0, len(plan.Renames))
+	for _, next := range plan.Renames {
+		affected = append(affected, next)
+	}
+	sort.Strings(affected)
+	return rpc.GroupsRenameResult{
+		MutationResult: rpc.MutationResult{OK: true, Affected: affected},
+		Name:           plan.Project,
+	}, nil
+}
+
+// renameError maps a refused rename onto the contract's error registry.
+func renameError(err error) error {
+	var re *groups.RenameError
+	if !errors.As(err, &re) {
+		return rpc.NewError(rpc.CodeInternal, err.Error(), "check `sonar daemon log`")
+	}
+	switch re.Kind {
+	case groups.RenameNotFound:
+		return rpc.NewError(rpc.CodeNotFound, re.Msg, re.Hint)
+	case groups.RenameConflict:
+		return rpc.NewError(rpc.CodeConflict, re.Msg, re.Hint)
+	default:
+		return rpc.NewError(rpc.CodeInvalidParams, re.Msg, re.Hint)
+	}
+}

--- a/internal/daemon/groups_rename_test.go
+++ b/internal/daemon/groups_rename_test.go
@@ -1,0 +1,258 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// renameTree is a project checked out twice — the main checkout and one linked
+// worktree — next to an unrelated repository called "taken".
+type renameTree struct{ main, wt, other string }
+
+func newRenameTree(t *testing.T, withConfig bool) renameTree {
+	t.Helper()
+	base := resolvedDir(t, t.TempDir())
+	tree := renameTree{
+		main:  filepath.Join(base, "shop"),
+		wt:    filepath.Join(base, "wt", "feat"),
+		other: filepath.Join(base, "taken"),
+	}
+	admin := filepath.Join(tree.main, ".git", "worktrees", "feat")
+	for _, dir := range []string{admin, tree.wt, filepath.Join(tree.other, ".git")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		filepath.Join(tree.main, ".git", "HEAD"): "ref: refs/heads/main\n",
+		filepath.Join(admin, "HEAD"):             "ref: refs/heads/feat\n",
+		filepath.Join(tree.wt, ".git"):           "gitdir: " + admin + "\n",
+	}
+	if withConfig {
+		files[filepath.Join(tree.main, groups.ConfigName)] = "# the shop\nname: shop\n"
+		files[filepath.Join(tree.wt, groups.ConfigName)] = "name: shop\n"
+	}
+	for path, body := range files {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return tree
+}
+
+func (tree renameTree) rows() []ports.ListeningPort {
+	return []ports.ListeningPort{
+		{Port: 3000, BindAddress: "127.0.0.1", PID: 501, Process: "node", Cwd: tree.main},
+		{Port: 3001, BindAddress: "127.0.0.1", PID: 502, Process: "node", Cwd: tree.wt},
+		{Port: 4000, BindAddress: "127.0.0.1", PID: 503, Process: "node", Cwd: tree.other},
+	}
+}
+
+// listGroups reads groups.list keyed by name.
+func (c *testClient) listGroups(t *testing.T) map[string]state.Group {
+	t.Helper()
+	var res rpc.GroupsListResult
+	if e := c.call("groups.list", rpc.Empty{}, &res); e != nil {
+		t.Fatalf("groups.list: %v", e)
+	}
+	out := map[string]state.Group{}
+	for _, g := range res.Groups {
+		if _, dup := out[g.Name]; dup {
+			t.Fatalf("groups.list has two groups named %q", g.Name)
+		}
+		out[g.Name] = g
+	}
+	return out
+}
+
+// renameGroupCollectingDelta sends groups.rename and returns its result with
+// the last groups-moving state.delta that arrived before the reply — the
+// delta republish promises is queued ahead of the response.
+func (c *testClient) renameGroupCollectingDelta(t *testing.T, p rpc.GroupsRenameParams) (rpc.GroupsRenameResult, state.Delta) {
+	t.Helper()
+	id := c.send("groups.rename", p)
+	var (
+		res   rpc.GroupsRenameResult
+		delta state.Delta
+		seen  bool
+	)
+	for i := 0; i < 50; i++ {
+		m := c.read()
+		switch {
+		case m.IsNotification() && m.Method == rpc.MethodStateDelta:
+			var d state.Delta
+			if err := json.Unmarshal(m.Params, &d); err != nil {
+				t.Fatalf("decoding state.delta: %v", err)
+			}
+			if len(d.Groups.Added)+len(d.Groups.Removed) == 0 {
+				continue
+			}
+			delta, seen = d, true
+		case m.IsResponse() && string(m.ID) == id:
+			if m.Error != nil {
+				t.Fatalf("groups.rename: %v", m.Error)
+			}
+			if err := json.Unmarshal(m.Result, &res); err != nil {
+				t.Fatalf("decoding the rename result: %v", err)
+			}
+			if !seen {
+				t.Fatal("the reply arrived before any delta carrying the renamed groups")
+			}
+			return res, delta
+		}
+	}
+	t.Fatal("no reply to groups.rename")
+	return res, delta
+}
+
+func sortedNames(gg []state.Group) string {
+	out := make([]string, 0, len(gg))
+	for _, g := range gg {
+		out = append(out, g.Name)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
+}
+
+func TestGroupsRenameStoresAnAliasForAProjectWithoutAFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tree := newRenameTree(t, false)
+	h, st := storeHarness(t, ctx, tree.rows()...)
+	c := h.dial(ctx)
+	c.subscribeAndSettle(rpc.StateSubscribeParams{})
+
+	before := c.listGroups(t)
+	wt, ok := before["shop@feat"]
+	if !ok || wt.Repo != "shop" || wt.Worktree != "feat" || wt.Branch != "feat" {
+		t.Fatalf("worktree group before = %+v (%v)", wt, ok)
+	}
+	if main := before["shop"]; main.Repo != "shop" || main.Worktree != "" || main.Branch != "main" {
+		t.Fatalf("main group before = %+v", main)
+	}
+
+	// Named by a checkout, routed through an explicit localhost.
+	res, delta := c.renameGroupCollectingDelta(t, rpc.GroupsRenameParams{
+		HostParams: rpc.HostParams{Host: "localhost"}, Name: "shop@feat", To: "market",
+	})
+	if !res.OK || res.Name != "market" || strings.Join(res.Affected, ",") != "market,market@feat" {
+		t.Fatalf("result = %+v", res)
+	}
+	removed := append([]string{}, delta.Groups.Removed...)
+	sort.Strings(removed)
+	if strings.Join(removed, ",") != "shop,shop@feat" || sortedNames(delta.Groups.Added) != "market,market@feat" {
+		t.Errorf("delta groups: removed %v, added %s", removed, sortedNames(delta.Groups.Added))
+	}
+
+	aliases, err := st.GroupAliases()
+	if err != nil || aliases[tree.main] != "market" {
+		t.Fatalf("aliases = %v, %v; want the main checkout named market", aliases, err)
+	}
+	after := c.listGroups(t)
+	if _, ok := after["shop"]; ok {
+		t.Error("the old project name is still listed")
+	}
+	if g := after["market@feat"]; g.Repo != "market" || g.Worktree != "feat" || len(g.Members) != 1 || g.Members[0] != 3001 {
+		t.Errorf("renamed worktree = %+v", g)
+	}
+	if g := after["market"]; len(g.Members) != 1 || g.Members[0] != 3000 {
+		t.Errorf("renamed main = %+v", g)
+	}
+	if _, ok := after["taken"]; !ok {
+		t.Error("the unrelated project went missing")
+	}
+}
+
+func TestGroupsRenameWritesTheMainCheckoutsFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tree := newRenameTree(t, true)
+	h, st := storeHarness(t, ctx, tree.rows()...)
+	c := h.dial(ctx)
+
+	if g := c.listGroups(t)["shop@feat"]; g.Source != state.SourceFile ||
+		g.ConfigPath == nil || *g.ConfigPath != filepath.Join(tree.wt, groups.ConfigName) {
+		t.Fatalf("worktree group before = %+v", g)
+	}
+
+	var res rpc.GroupsRenameResult
+	if e := c.call("groups.rename", rpc.GroupsRenameParams{Name: "shop", To: "market"}, &res); e != nil {
+		t.Fatalf("groups.rename: %v", e)
+	}
+	if strings.Join(res.Affected, ",") != "market,market@feat" {
+		t.Fatalf("affected = %v", res.Affected)
+	}
+
+	mainFile, _ := os.ReadFile(filepath.Join(tree.main, groups.ConfigName))
+	if !strings.Contains(string(mainFile), "# the shop") || !strings.Contains(string(mainFile), "name: market") {
+		t.Errorf("main checkout's file =\n%s", mainFile)
+	}
+	// The worktree's copy is not the project's name; it is left alone.
+	if wtFile, _ := os.ReadFile(filepath.Join(tree.wt, groups.ConfigName)); string(wtFile) != "name: shop\n" {
+		t.Errorf("worktree copy was rewritten:\n%s", wtFile)
+	}
+	if aliases, _ := st.GroupAliases(); len(aliases) != 0 {
+		t.Errorf("a file project stored an alias: %v", aliases)
+	}
+	after := c.listGroups(t)
+	for _, name := range []string{"market", "market@feat"} {
+		if _, ok := after[name]; !ok {
+			t.Errorf("%s missing after the rename: %v", name, after)
+		}
+	}
+	if _, ok := after["shop"]; ok {
+		t.Error("the old project name is still listed")
+	}
+
+	// And by name, the renamed project's config is found again.
+	name := "market@feat"
+	var got rpc.GroupsConfigGetResult
+	if e := c.call("groups.config.get", rpc.GroupsConfigGetParams{Name: &name}, &got); e != nil {
+		t.Fatalf("groups.config.get market@feat: %v", e)
+	}
+	if got.Path != filepath.Join(tree.wt, groups.ConfigName) {
+		t.Errorf("config for market@feat = %s, want the worktree's copy", got.Path)
+	}
+}
+
+func TestGroupsRenameRefuses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tree := newRenameTree(t, false)
+	h, _ := storeHarness(t, ctx, tree.rows()...)
+	c := h.dial(ctx)
+
+	tests := []struct {
+		name string
+		p    rpc.GroupsRenameParams
+		want string
+	}{
+		{"no name", rpc.GroupsRenameParams{To: "market"}, "invalid_params"},
+		{"no new name", rpc.GroupsRenameParams{Name: "shop"}, "invalid_params"},
+		{"an @ in the new name", rpc.GroupsRenameParams{Name: "shop", To: "a@b"}, "invalid_params"},
+		{"a slash in the new name", rpc.GroupsRenameParams{Name: "shop", To: "a/b"}, "invalid_params"},
+		{"an unknown group", rpc.GroupsRenameParams{Name: "nope", To: "market"}, "not_found"},
+		{"another project's name", rpc.GroupsRenameParams{Name: "shop", To: "taken"}, "conflict"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := c.call("groups.rename", tt.p, nil)
+			if e == nil || e.Data.Code != tt.want {
+				t.Fatalf("error = %+v, want %s", e, tt.want)
+			}
+		})
+	}
+	if _, ok := c.listGroups(t)["shop"]; !ok {
+		t.Error("a refused rename renamed the project anyway")
+	}
+}

--- a/internal/daemon/groupstart/start.go
+++ b/internal/daemon/groupstart/start.go
@@ -52,12 +52,16 @@ func handleGroupsStart(ctx context.Context, req *daemon.Request) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The group the services run under is the one the file's ports are
+	// published in: `<project>@<worktree>` for a worktree's copy of a
+	// committed file, never the `name:` the copy carries (step 5A.6).
+	group := req.Runtime.Scanner.GroupOf(cfg)
 	plan, err := groups.Plan(cfg, p.Only)
 	if err != nil {
 		var unknown *groups.UnknownServiceError
 		if errors.As(err, &unknown) {
 			return nil, rpc.NewError(rpc.CodeNotFound, unknown.Error(),
-				"`sonar groups "+cfg.Name+"` lists the services this file declares")
+				"`sonar groups "+group+"` lists the services this file declares")
 		}
 		return nil, rpc.NewError(rpc.CodeInternal, err.Error(), "")
 	}
@@ -70,7 +74,7 @@ func handleGroupsStart(ctx context.Context, req *daemon.Request) (any, error) {
 	rt := req.Runtime
 	initial := rpc.GroupsStartResult{MutationResult: rpc.MutationResult{OK: true, Affected: []string{}}}
 	return daemon.StartStream(ctx, req, initial, func(ctx context.Context, s *daemon.Stream) (any, error) {
-		return run(ctx, rt, s, cfg, plan, p.AllowOutsideHome), nil
+		return run(ctx, rt, s, cfg, group, plan, p.AllowOutsideHome), nil
 	})
 }
 
@@ -78,7 +82,7 @@ func handleGroupsStart(ctx context.Context, req *daemon.Request) (any, error) {
 // A service that fails never stops the ones after it: the caller asked for the
 // group, and a partial group is more useful than none.
 func run(ctx context.Context, rt *daemon.Runtime, s *daemon.Stream,
-	cfg *groups.Config, plan []groups.Step, allowOutsideHome bool) rpc.GroupsStartEnd {
+	cfg *groups.Config, group string, plan []groups.Step, allowOutsideHome bool) rpc.GroupsStartEnd {
 
 	end := rpc.GroupsStartEnd{Started: []string{}, Skipped: []string{}, Errors: []string{}}
 
@@ -88,13 +92,13 @@ func run(ctx context.Context, rt *daemon.Runtime, s *daemon.Stream,
 		}
 		svc := step.Service
 
-		if reason, up := alreadyRunning(rt, cfg.Name, svc); up {
+		if reason, up := alreadyRunning(rt, group, svc); up {
 			_ = s.Send(rpc.GroupsStartChunk{Service: svc.Name, Skipped: true, Reason: reason})
 			end.Skipped = append(end.Skipped, svc.Name)
 			continue
 		}
 
-		if err := waitFor(ctx, rt, cfg.Name, step.Waits); err != nil {
+		if err := waitFor(ctx, rt, group, step.Waits); err != nil {
 			if ctx.Err() != nil {
 				return end
 			}
@@ -103,9 +107,9 @@ func run(ctx context.Context, rt *daemon.Runtime, s *daemon.Stream,
 			continue
 		}
 
-		h, err := start(ctx, rt, cfg, svc, allowOutsideHome)
+		h, err := start(ctx, rt, cfg, group, svc, allowOutsideHome)
 		if err != nil {
-			rt.Logger.Warn("starting a service", "group", cfg.Name, "service", svc.Name, "error", err)
+			rt.Logger.Warn("starting a service", "group", group, "service", svc.Name, "error", err)
 			_ = s.Send(rpc.GroupsStartChunk{Service: svc.Name, Error: detail(err)})
 			end.Errors = append(end.Errors, svc.Name)
 			continue
@@ -118,7 +122,7 @@ func run(ctx context.Context, rt *daemon.Runtime, s *daemon.Stream,
 
 // start spawns one service through the run registry, so the ports it opens are
 // attributed to this group and this service name.
-func start(ctx context.Context, rt *daemon.Runtime, cfg *groups.Config,
+func start(ctx context.Context, rt *daemon.Runtime, cfg *groups.Config, group string,
 	svc groups.Service, allowOutsideHome bool) (*spawn.Handle, error) {
 
 	argv := spawn.SplitCmd(svc.Cmd)
@@ -132,10 +136,10 @@ func start(ctx context.Context, rt *daemon.Runtime, cfg *groups.Config,
 	return runsreg.Spawn(ctx, rt, spawn.Request{
 		Argv:     argv,
 		Cwd:      cwd,
-		Group:    cfg.Name,
+		Group:    group,
 		Name:     svc.Name,
 		PortHint: svc.Port,
-		LogPath:  spawn.LogPath(cfg.Name, svc.Name),
+		LogPath:  spawn.LogPath(group, svc.Name),
 	})
 }
 

--- a/internal/daemon/hostroute.go
+++ b/internal/daemon/hostroute.go
@@ -117,6 +117,7 @@ var hostRoutes = map[string]hostRoute{
 	"groups.start":      {nameFields: []string{"name"}, portKeys: true},
 	"groups.inspect":    {nameFields: []string{"name"}},
 	"groups.config.get": {nameFields: []string{"name"}},
+	"groups.rename":     {nameFields: []string{"name"}},
 	"sessions.kill":     {nameFields: []string{"id"}, portKeys: true},
 	"sessions.inspect":  {nameFields: []string{"id"}},
 	"claims.acquire":    {portKeys: true},

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -405,6 +405,33 @@ type GroupsAssignResult struct {
 	Group *string `json:"group" jsonschema:"nullable"`
 }
 
+// GroupsRenameParams renames a project (step 5A.6). Name is the project's name
+// or the name of any of its checkout groups: the rename always applies to the
+// project, so the main checkout's group becomes To and every linked worktree's
+// group becomes `<To>@<worktree>`. A project whose main checkout has a
+// `.sonar.yaml` is renamed by writing `name:` into that file; one without keeps
+// the new name in the daemon.
+//
+// Errors: invalid_params for an empty name or a To that is empty or holds `@`,
+// `/` or whitespace, and for a group whose name is not a project's to change —
+// a manual group (pins name it), a group a `sonar start --group` named, or a
+// Compose project; not_found for an unknown group; conflict when a group
+// outside the project already has a name the rename would give; invalid_config
+// when the edited file would no longer validate.
+type GroupsRenameParams struct {
+	HostParams
+	Name string `json:"name"`
+	To   string `json:"to"`
+}
+
+// GroupsRenameResult carries in Affected the new name of every group the rename
+// changed — the project's and each checkout's — sorted, and in Name the
+// project's new name. Affected is empty when the project already had that name.
+type GroupsRenameResult struct {
+	MutationResult
+	Name string `json:"name"`
+}
+
 // GroupConfig is a `.sonar.yaml` as the protocol carries it: the group name,
 // the services as contract rows, and the extra ports the file claims. It is
 // the `config` of groups.config.get and groups.config.set (contract §13.2).

--- a/internal/daemon/rpc/schema.go
+++ b/internal/daemon/rpc/schema.go
@@ -298,6 +298,7 @@ func init() {
 	Describe("groups.kill", GroupsKillParams{}, KillEnvelope{}, nil, nil)
 	Describe("groups.start", GroupsStartParams{}, GroupsStartResult{}, GroupsStartChunk{}, GroupsStartEnd{})
 	Describe("groups.assign", GroupsAssignParams{}, GroupsAssignResult{}, nil, nil)
+	Describe("groups.rename", GroupsRenameParams{}, GroupsRenameResult{}, nil, nil)
 	Describe("groups.reload", HostParams{}, GroupsReloadResult{}, nil, nil)
 	Describe("groups.config.get", GroupsConfigGetParams{}, GroupsConfigGetResult{}, nil, nil)
 	Describe("groups.config.set", GroupsConfigSetParams{}, GroupsConfigSetResult{}, nil, nil)

--- a/internal/daemon/rpc/schema_test.go
+++ b/internal/daemon/rpc/schema_test.go
@@ -19,7 +19,7 @@ var contractMethods = []string{
 	"ports.list", "ports.inspect", "ports.kill", "ports.rename", "ports.next",
 	"ports.wait", "ports.health", "ports.logs", "ports.graph", "ports.history",
 	"groups.list", "groups.inspect", "groups.kill", "groups.start",
-	"groups.assign", "groups.reload", "groups.init",
+	"groups.assign", "groups.reload", "groups.init", "groups.rename",
 	"runs.register", "runs.unregister", "runs.list", "runs.spawn",
 	"claims.acquire", "claims.release", "claims.list",
 	"sessions.list", "sessions.inspect", "sessions.kill",

--- a/internal/daemon/runsreg/handlers.go
+++ b/internal/daemon/runsreg/handlers.go
@@ -33,6 +33,7 @@ func init() {
 	daemon.RegisterHandler("runs.list", handleList)
 	daemon.RegisterHandler("runs.spawn", handleSpawn)
 	daemon.RegisterCapability("runs")
+	daemon.OnGroupRename(func(renames map[string]string) { Default.RenameGroups(renames) })
 
 	daemon.OnStart(func(rt *daemon.Runtime) {
 		if n := Default.ImportLegacy(); n > 0 {

--- a/internal/daemon/runsreg/registry.go
+++ b/internal/daemon/runsreg/registry.go
@@ -103,6 +103,32 @@ func (r *Registry) Unregister(pid int) bool {
 	return ok
 }
 
+// RenameGroups moves every run recorded under an old group name to its new one
+// (`groups.rename`), so a service started before its project was renamed stays
+// in the project's group instead of keeping a group of the old name to itself.
+// It reports how many runs moved.
+func (r *Registry) RenameGroups(renames map[string]string) int {
+	if len(renames) == 0 {
+		return 0
+	}
+	r.mu.Lock()
+	var moved []Record
+	for pid, rec := range r.runs {
+		next, ok := renames[rec.Group]
+		if !ok || next == "" {
+			continue
+		}
+		rec.Group = next
+		r.runs[pid] = rec
+		moved = append(moved, rec)
+	}
+	r.mu.Unlock()
+	for _, rec := range moved {
+		r.mirrorAdd(rec)
+	}
+	return len(moved)
+}
+
 // List returns the live runs, oldest first, after pruning dead ones.
 func (r *Registry) List() []Record {
 	r.Prune()

--- a/internal/daemon/runsreg/rename_test.go
+++ b/internal/daemon/runsreg/rename_test.go
@@ -1,0 +1,27 @@
+package runsreg
+
+import "testing"
+
+// TestRenameGroupsMovesRunsWithTheProject: a service started before its
+// project was renamed follows the rename instead of keeping a group of the old
+// name to itself.
+func TestRenameGroupsMovesRunsWithTheProject(t *testing.T) {
+	r := New()
+	r.Mirror = false
+	r.Register(Record{PID: 101, Group: "shop", Name: "api"})
+	r.Register(Record{PID: 102, Group: "shop@feat", Name: "api"})
+	r.Register(Record{PID: 103, Group: "other", Name: "job"})
+
+	if n := r.RenameGroups(map[string]string{"shop": "market", "shop@feat": "market@feat"}); n != 2 {
+		t.Fatalf("RenameGroups moved %d runs, want 2", n)
+	}
+	for pid, want := range map[int]string{101: "market", 102: "market@feat", 103: "other"} {
+		rec, ok := r.Lookup(pid)
+		if !ok || rec.Group != want {
+			t.Errorf("pid %d group = %q (%v), want %q", pid, rec.Group, ok, want)
+		}
+	}
+	if n := r.RenameGroups(nil); n != 0 {
+		t.Errorf("an empty rename moved %d runs", n)
+	}
+}

--- a/internal/groups/build.go
+++ b/internal/groups/build.go
@@ -2,6 +2,7 @@ package groups
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/raskrebs/sonar/internal/state"
 )
@@ -47,24 +48,51 @@ func Groups(pp []state.Port, index *Index) []state.Group {
 	}
 
 	for _, cfg := range index.Configs() {
-		g := order(cfg.Name)
+		// Named the way the resolver names the config's ports, so a stopped
+		// worktree with a copy of the main checkout's file is `<repo>@<wt>`
+		// here too, not a second group with the main checkout's name.
+		name := index.GroupOf(cfg)
+		g := order(name)
 		path, dir := cfg.Path, cfg.Dir
 		g.ConfigPath = &path
 		g.RootDir = &dir
 		if rank(state.SourceFile) > rank(g.Source) {
 			g.Source = state.SourceFile
 		}
-		g.Services = services(cfg, members[cfg.Name])
+		g.Services = services(cfg, members[name])
 	}
 
 	out := make([]state.Group, 0, len(byName))
 	for _, g := range byName {
 		sort.Ints(g.Members)
 		g.Status = status(*g)
+		describeCheckout(g, index)
 		out = append(out, *g)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
+}
+
+// describeCheckout fills in which project a group is a checkout of, which
+// linked worktree it is, and the branch checked out there. A group named
+// `<repo>@<worktree>` for the linked worktree it lives in is that worktree of
+// repo; every other group is its own project.
+func describeCheckout(g *state.Group, index *Index) {
+	g.Repo, g.Worktree, g.Branch = g.Name, "", ""
+	if g.RootDir == nil {
+		return
+	}
+	co, ok := Locate(*g.RootDir)
+	if !ok {
+		return
+	}
+	g.Branch = index.Branch(co)
+	if !co.Linked() {
+		return
+	}
+	if repo, found := strings.CutSuffix(g.Name, "@"+co.Worktree); found && repo != "" {
+		g.Repo, g.Worktree = repo, co.Worktree
+	}
 }
 
 // ServiceRow adapts one `.sonar.yaml` service to the published contract row,

--- a/internal/groups/checkout.go
+++ b/internal/groups/checkout.go
@@ -1,0 +1,251 @@
+package groups
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Checkout is where a directory sits in git.
+//
+// A repository can be checked out in several places at once: its main checkout
+// and any number of linked worktrees (`git worktree add`). Each checkout is a
+// group of its own — `<project>` for the main checkout, `<project>@<worktree>`
+// for a linked one — and all of them share the project name, which only the
+// main checkout decides (step 5A.6). A worktree's copy of a committed
+// `.sonar.yaml` describes its services, never its name, so a stale copy cannot
+// fold the worktree back into the main checkout's group.
+type Checkout struct {
+	// Root is the directory holding the `.git` entry.
+	Root string
+	// Main is the main checkout's root: Root itself unless this is a linked
+	// worktree. A submodule, and a `.git` file nothing can parse, are their
+	// own main checkout.
+	Main string
+	// Worktree is a linked worktree's name, the base name of Root. It is
+	// empty for a main checkout.
+	Worktree string
+	// head is the HEAD file the checkout's branch is read from, "" when there
+	// is nothing to read.
+	head string
+}
+
+// Linked reports whether the checkout is a linked worktree.
+func (c Checkout) Linked() bool { return c.Worktree != "" }
+
+// Locate finds the checkout that contains dir. It walks up the way Find does
+// and answers the same root, plus the main checkout a linked worktree belongs
+// to and the HEAD its branch is read from. Paths are canonical.
+func Locate(dir string) (Checkout, bool) {
+	if dir == "" {
+		return Checkout{}, false
+	}
+	cur := Canonical(dir)
+	if cur == "" {
+		return Checkout{}, false
+	}
+	for i := 0; i < maxWalk; i++ {
+		gitPath := filepath.Join(cur, ".git")
+		if info, err := os.Lstat(gitPath); err == nil {
+			return checkoutAt(cur, gitPath, info.Mode().IsRegular()), true
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return Checkout{}, false
+		}
+		cur = parent
+	}
+	return Checkout{}, false
+}
+
+// checkoutAt describes the checkout rooted at root, whose `.git` entry is a
+// directory or, for a linked worktree or a submodule, a file.
+func checkoutAt(root, gitPath string, isFile bool) Checkout {
+	co := Checkout{Root: root, Main: root}
+	if !isFile {
+		co.head = filepath.Join(gitPath, "HEAD")
+		return co
+	}
+	target := gitdirTarget(root, gitPath)
+	if target == "" {
+		return co
+	}
+	co.head = filepath.Join(target, "HEAD")
+	if main := worktreeMain(target); main != "" {
+		co.Main = Canonical(main)
+		co.Worktree = filepath.Base(root)
+	}
+	return co
+}
+
+// headEntry is one HEAD file's branch, with the stamp it was read at.
+type headEntry struct {
+	at     stamp
+	branch string
+}
+
+// Branch is the branch checked out in co: "" when HEAD is detached, when it
+// cannot be read, or when co has none. HEAD is re-read only when its mtime or
+// size moves, so a scan costs one stat per checkout and never runs `git`.
+func (x *Index) Branch(co Checkout) string {
+	if co.head == "" {
+		return ""
+	}
+	info, err := os.Stat(co.head)
+	if err != nil {
+		delete(x.heads, co.head)
+		return ""
+	}
+	now := stamp{mod: info.ModTime(), size: info.Size()}
+	if e, ok := x.heads[co.head]; ok && e.at.mod.Equal(now.mod) && e.at.size == now.size {
+		return e.branch
+	}
+	data, err := os.ReadFile(co.head)
+	if err != nil {
+		return ""
+	}
+	branch := parseHead(data)
+	if x.heads == nil {
+		x.heads = map[string]headEntry{}
+	}
+	x.heads[co.head] = headEntry{at: now, branch: branch}
+	return branch
+}
+
+// parseHead reads the branch out of a HEAD file: `ref: refs/heads/<branch>`.
+// A detached HEAD holds a commit id instead, and a ref outside refs/heads is
+// not a branch; both answer "".
+func parseHead(data []byte) string {
+	ref, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "ref:")
+	if !ok {
+		return ""
+	}
+	branch, ok := strings.CutPrefix(strings.TrimSpace(ref), "refs/heads/")
+	if !ok {
+		return ""
+	}
+	return branch
+}
+
+// SetAliases installs the project names the daemon stores for projects that
+// have no `.sonar.yaml` to write a name into (`groups.rename`), keyed by the
+// main checkout's root. The scanner sets them every tick from the store; a nil
+// map clears them.
+func (x *Index) SetAliases(aliases map[string]string) {
+	x.aliases = make(map[string]string, len(aliases))
+	for root, name := range aliases {
+		if root != "" && name != "" {
+			x.aliases[filepath.Clean(root)] = name
+		}
+	}
+}
+
+// fileProjectName is the project name before any alias: the name the main
+// checkout's `.sonar.yaml` gives it, else the main checkout's directory name.
+// The main checkout is probed here, because a process in a linked worktree is
+// what usually brings a project to the index's attention, and its walk stops
+// at the worktree's own root.
+func (x *Index) fileProjectName(main string) string {
+	x.probeDir(main)
+	if cfg := x.Nearest(main); cfg != nil {
+		return cfg.Name
+	}
+	return filepath.Base(main)
+}
+
+// ProjectName is the name every checkout of one repository shares, decided by
+// the main checkout at main: a stored alias, else the `name:` of the main
+// checkout's `.sonar.yaml`, else its directory name.
+func (x *Index) ProjectName(main string) string {
+	if alias := x.aliases[main]; alias != "" {
+		return alias
+	}
+	return x.fileProjectName(main)
+}
+
+// CheckoutName is a checkout's group name: the project name, qualified as
+// `<project>@<worktree>` for a linked worktree.
+func (x *Index) CheckoutName(co Checkout) string {
+	name := x.ProjectName(co.Main)
+	if co.Linked() {
+		return name + "@" + co.Worktree
+	}
+	return name
+}
+
+// GroupOf is the group a config's services are published under. A config at a
+// checkout's root is that checkout's own, so it takes the checkout's group
+// name rather than its `name:` — which is exactly what keeps a worktree's copy
+// of a committed file from claiming the main checkout's name. A config below
+// the root is a nested project with a name of its own, qualified with the
+// worktree when it sits in one. A config outside any checkout is named by its
+// file.
+func (x *Index) GroupOf(cfg *Config) string {
+	co, ok := Locate(cfg.Dir)
+	if !ok {
+		return cfg.Name
+	}
+	if cfg.Dir == co.Root {
+		return x.CheckoutName(co)
+	}
+	if co.Linked() {
+		return cfg.Name + "@" + co.Worktree
+	}
+	return cfg.Name
+}
+
+// NearestFor is Nearest confined to dir's own checkout when that checkout is a
+// linked worktree. Tools put worktrees inside the main checkout (for example
+// `<repo>/.claude/worktrees/<name>`), and an unconfined walk from one of them
+// climbs straight into the main checkout's `.sonar.yaml`.
+func (x *Index) NearestFor(dir string) *Config {
+	if co, ok := Locate(dir); ok {
+		cfg := x.Nearest(dir)
+		if cfg == nil || !x.within(cfg, co) {
+			return nil
+		}
+		return cfg
+	}
+	return x.Nearest(dir)
+}
+
+// checkoutConfig is the config that makes a checkout's group a `file` group:
+// NearestFor its root, for a checkout already located.
+func (x *Index) checkoutConfig(co Checkout) *Config {
+	cfg := x.Nearest(co.Root)
+	if cfg == nil || !x.within(cfg, co) {
+		return nil
+	}
+	return cfg
+}
+
+// within reports whether cfg may describe something in co: always for a main
+// checkout, and only from inside the worktree for a linked one.
+func (x *Index) within(cfg *Config, co Checkout) bool {
+	return !co.Linked() || under(cfg.Dir, co.Root)
+}
+
+// runGroup is the post-step that keeps a `sonar start` run in its checkout's
+// group. A run records the group its client inferred when it started, and a
+// client knows neither the daemon's aliases nor, if it predates step 5A.6,
+// that a worktree is not its main checkout. So a run group that is the
+// project's own name — with or without the worktree — is the checkout's group
+// under its current name. Any other name was chosen with --group and stays.
+func (x *Index) runGroup(group string, co Checkout) string {
+	base := x.fileProjectName(co.Main)
+	alias := x.aliases[co.Main]
+	if co.Linked() {
+		switch group {
+		case base, base + "@" + co.Worktree:
+			return x.CheckoutName(co)
+		}
+		if alias != "" && (group == alias || group == alias+"@"+co.Worktree) {
+			return x.CheckoutName(co)
+		}
+		return group
+	}
+	if group == base {
+		return x.ProjectName(co.Main)
+	}
+	return group
+}

--- a/internal/groups/checkout_test.go
+++ b/internal/groups/checkout_test.go
@@ -1,0 +1,349 @@
+package groups
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// checkouts is a main checkout with a real-looking .git (HEAD on main) and one
+// linked worktree whose admin directory holds its own HEAD.
+type checkouts struct {
+	main, wt, admin string
+}
+
+func newCheckouts(t *testing.T, mainName, wtName string) checkouts {
+	t.Helper()
+	base := tempTree(t)
+	main := mkdir(t, base, mainName)
+	writeFile(t, filepath.Join(main, ".git", "HEAD"), "ref: refs/heads/main\n")
+	admin := filepath.Join(main, ".git", "worktrees", wtName)
+	writeFile(t, filepath.Join(admin, "HEAD"), "ref: refs/heads/feature/x\n")
+	wt := mkdir(t, base, "wt", wtName)
+	writeFile(t, filepath.Join(wt, ".git"), "gitdir: "+admin+"\n")
+	return checkouts{main: main, wt: wt, admin: admin}
+}
+
+func TestLocate(t *testing.T) {
+	c := newCheckouts(t, "shop", "feat")
+	deep := mkdir(t, c.wt, "web", "src")
+
+	co, ok := Locate(mkdir(t, c.main, "api"))
+	if !ok || co.Root != c.main || co.Main != c.main || co.Linked() {
+		t.Fatalf("main checkout = %+v, %v", co, ok)
+	}
+
+	co, ok = Locate(deep)
+	if !ok || co.Root != c.wt || co.Main != c.main || co.Worktree != "feat" || !co.Linked() {
+		t.Fatalf("worktree = %+v, %v", co, ok)
+	}
+
+	// A relative gitdir resolves against the worktree root.
+	rel := mkdir(t, filepath.Dir(c.wt), "relwt")
+	target, err := filepath.Rel(rel, filepath.Join(c.main, ".git", "worktrees", "relwt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(rel, ".git"), "gitdir: "+target+"\n")
+	if co, ok := Locate(rel); !ok || co.Main != c.main || co.Worktree != "relwt" {
+		t.Fatalf("relative worktree = %+v, %v", co, ok)
+	}
+
+	// A submodule's .git file points into .git/modules: it is its own main
+	// checkout, not a worktree of the superproject.
+	sub := mkdir(t, c.main, "vendor", "lib")
+	writeFile(t, filepath.Join(sub, ".git"), "gitdir: ../../.git/modules/lib\n")
+	if co, ok := Locate(sub); !ok || co.Root != sub || co.Main != sub || co.Linked() {
+		t.Fatalf("submodule = %+v, %v", co, ok)
+	}
+
+	if _, ok := Locate(tempTree(t)); ok {
+		t.Fatal("found a checkout outside any repository")
+	}
+	if _, ok := Locate(""); ok {
+		t.Fatal("found a checkout for an empty path")
+	}
+}
+
+// TestLocateAcceptsEverySpellingOfTheWorktree is the worktree half of the
+// Windows spellings test: with a trailing separator or a redundant `.`, a
+// worktree still names one root and one main checkout.
+func TestLocateAcceptsEverySpellingOfTheWorktree(t *testing.T) {
+	c := newCheckouts(t, "shop", "feat")
+	sep := string(filepath.Separator)
+	for _, dir := range []string{c.wt, c.wt + sep, filepath.Join(c.wt, "."), filepath.Join(c.wt, "x", "..")} {
+		co, ok := Locate(dir)
+		if !ok || co.Root != c.wt || co.Main != c.main || co.Worktree != "feat" {
+			t.Errorf("Locate(%q) = %+v, %v", dir, co, ok)
+		}
+	}
+}
+
+func TestBranch(t *testing.T) {
+	c := newCheckouts(t, "shop", "feat")
+	x := NewIndex()
+	main, _ := Locate(c.main)
+	wt, _ := Locate(c.wt)
+
+	if got := x.Branch(main); got != "main" {
+		t.Errorf("main branch = %q", got)
+	}
+	if got := x.Branch(wt); got != "feature/x" {
+		t.Errorf("worktree branch = %q, want the HEAD in the main .git/worktrees/feat", got)
+	}
+
+	// A checkout switch rewrites HEAD; the cache notices the new size.
+	writeFile(t, filepath.Join(c.admin, "HEAD"), "ref: refs/heads/fix\n")
+	if got := x.Branch(wt); got != "fix" {
+		t.Errorf("after switching, worktree branch = %q", got)
+	}
+	// Detached.
+	writeFile(t, filepath.Join(c.admin, "HEAD"), "4b825dc642cb6eb9a060e54bf8d69288fbee4904\n")
+	if got := x.Branch(wt); got != "" {
+		t.Errorf("detached HEAD branch = %q, want empty", got)
+	}
+
+	// A checkout with no readable HEAD, like the resolver fixtures.
+	bare := mkdir(t, tempTree(t), "nohead")
+	mkdir(t, bare, ".git")
+	co, _ := Locate(bare)
+	if got := x.Branch(co); got != "" {
+		t.Errorf("branch without HEAD = %q", got)
+	}
+}
+
+func TestParseHead(t *testing.T) {
+	for in, want := range map[string]string{
+		"ref: refs/heads/main\n":       "main",
+		"ref:refs/heads/feature/a-b":   "feature/a-b",
+		"ref: refs/remotes/origin/x\n": "",
+		"0123456789abcdef\n":           "",
+		"":                             "",
+	} {
+		if got := parseHead([]byte(in)); got != want {
+			t.Errorf("parseHead(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func resolveOneAt(t *testing.T, x *Index, p state.Port) (string, state.GroupSource) {
+	t.Helper()
+	got := Resolve([]state.Port{p}, NoPins{}, NoRuns{}, x)[0]
+	var source state.GroupSource
+	if got.GroupSource != nil {
+		source = *got.GroupSource
+	}
+	return deref(got.Group), source
+}
+
+// TestWorktreeNaming is the step 5A.6 rule: every linked worktree is
+// `<project>@<worktree>`, and only the main checkout decides the project.
+func TestWorktreeNaming(t *testing.T) {
+	t.Run("no config anywhere", func(t *testing.T) {
+		c := newCheckouts(t, "app", "feat")
+		x := NewIndex()
+		x.Observe(c.wt)
+		if g, s := resolveOneAt(t, x, nativePort(3000, c.main)); g != "app" || s != state.SourceAuto {
+			t.Errorf("main = %q/%s", g, s)
+		}
+		if g, s := resolveOneAt(t, x, nativePort(3001, c.wt)); g != "app@feat" || s != state.SourceAuto {
+			t.Errorf("worktree = %q/%s", g, s)
+		}
+	})
+
+	t.Run("a worktree's stale copy of the config never names it", func(t *testing.T) {
+		c := newCheckouts(t, "shop-dir", "feat")
+		writeFile(t, filepath.Join(c.main, ConfigName), "name: shop\nservices:\n  - name: api\n    port: 8000\n")
+		writeFile(t, filepath.Join(c.wt, ConfigName), "name: old-shop\nservices:\n  - name: api\n    port: 8100\n")
+		x := NewIndex()
+		x.Observe(c.wt)
+
+		if g, s := resolveOneAt(t, x, nativePort(8000, c.main)); g != "shop" || s != state.SourceFile {
+			t.Errorf("main = %q/%s", g, s)
+		}
+		// Claimed by the worktree's own file, named by the main checkout's.
+		if g, s := resolveOneAt(t, x, nativePort(8100, c.wt)); g != "shop@feat" || s != state.SourceFile {
+			t.Errorf("worktree port the copy claims = %q/%s", g, s)
+		}
+		if g, s := resolveOneAt(t, x, nativePort(9999, c.wt)); g != "shop@feat" || s != state.SourceFile {
+			t.Errorf("worktree port nothing claims = %q/%s", g, s)
+		}
+	})
+
+	t.Run("a copy with the same name as main is still its own group", func(t *testing.T) {
+		c := newCheckouts(t, "shop", "feat")
+		cfg := "name: shop\nservices:\n  - name: api\n    port: 8000\n"
+		writeFile(t, filepath.Join(c.main, ConfigName), cfg)
+		writeFile(t, filepath.Join(c.wt, ConfigName), cfg)
+		x := NewIndex()
+		x.Observe(c.main)
+		x.Observe(c.wt)
+		// Both checkouts run the api on 8000; each in its own group.
+		if g, _ := resolveOneAt(t, x, nativePort(8000, c.main)); g != "shop" {
+			t.Errorf("main = %q", g)
+		}
+		if g, _ := resolveOneAt(t, x, nativePort(8000, c.wt)); g != "shop@feat" {
+			t.Errorf("worktree = %q", g)
+		}
+	})
+
+	t.Run("a worktree kept inside the main checkout", func(t *testing.T) {
+		base := tempTree(t)
+		main := mkdir(t, base, "shop")
+		mkdir(t, main, ".git")
+		admin := filepath.Join(main, ".git", "worktrees", "feat")
+		mkdir(t, admin)
+		wt := mkdir(t, main, ".claude", "worktrees", "feat")
+		writeFile(t, filepath.Join(wt, ".git"), "gitdir: "+admin+"\n")
+		writeFile(t, filepath.Join(main, ConfigName), "name: shop\nports: [3000]\n")
+		x := NewIndex()
+		x.Observe(main)
+		x.Observe(wt)
+
+		// The main checkout's file claims 3000 and sits above the worktree,
+		// but it does not reach across into it.
+		if g, s := resolveOneAt(t, x, nativePort(3000, wt)); g != "shop@feat" || s != state.SourceAuto {
+			t.Errorf("worktree port = %q/%s, want shop@feat/auto", g, s)
+		}
+		if g, _ := resolveOneAt(t, x, nativePort(3000, main)); g != "shop" {
+			t.Errorf("main port = %q", g)
+		}
+	})
+
+	t.Run("an alias names the project and every worktree", func(t *testing.T) {
+		c := newCheckouts(t, "app", "feat")
+		x := NewIndex()
+		x.Observe(c.wt)
+		x.SetAliases(map[string]string{c.main: "store"})
+		if g, _ := resolveOneAt(t, x, nativePort(3000, c.main)); g != "store" {
+			t.Errorf("main = %q", g)
+		}
+		if g, _ := resolveOneAt(t, x, nativePort(3001, c.wt)); g != "store@feat" {
+			t.Errorf("worktree = %q", g)
+		}
+		x.SetAliases(nil)
+		if g, _ := resolveOneAt(t, x, nativePort(3001, c.wt)); g != "app@feat" {
+			t.Errorf("worktree after clearing = %q", g)
+		}
+	})
+
+	t.Run("submodules keep their own name", func(t *testing.T) {
+		c := newCheckouts(t, "shop", "feat")
+		sub := mkdir(t, c.main, "vendor", "lib")
+		writeFile(t, filepath.Join(sub, ".git"), "gitdir: ../../.git/modules/lib\n")
+		x := NewIndex()
+		x.Observe(sub)
+		if g, _ := resolveOneAt(t, x, nativePort(4000, sub)); g != "lib" {
+			t.Errorf("submodule = %q, want lib", g)
+		}
+	})
+}
+
+// TestRunGroupFollowsTheCheckout: a run recorded under the project's own name
+// joins its checkout's group; one started with a --group of its own keeps it.
+func TestRunGroupFollowsTheCheckout(t *testing.T) {
+	c := newCheckouts(t, "app", "feat")
+	x := NewIndex()
+	x.Observe(c.wt)
+	runs := fakeRuns{
+		5000: {group: "app", name: "web"},      // a pre-5A.6 client in the worktree
+		5001: {group: "app@feat", name: "api"}, // the current spelling
+		5002: {group: "custom", name: "job"},   // --group custom
+		5003: {group: "app", name: "web"},      // in the main checkout
+	}
+	pp := Resolve([]state.Port{
+		nativePort(5000, c.wt), nativePort(5001, c.wt), nativePort(5002, c.wt), nativePort(5003, c.main),
+	}, NoPins{}, runs, x)
+	want := []string{"app@feat", "app@feat", "custom", "app"}
+	for i, p := range pp {
+		if deref(p.Group) != want[i] {
+			t.Errorf("port %d group = %q, want %q", p.Port, deref(p.Group), want[i])
+		}
+	}
+
+	// After an alias, both spellings of the old name move with the project.
+	x.SetAliases(map[string]string{c.main: "store"})
+	pp = Resolve([]state.Port{nativePort(5001, c.wt), nativePort(5003, c.main)}, NoPins{}, runs, x)
+	if deref(pp[0].Group) != "store@feat" || deref(pp[1].Group) != "store" {
+		t.Errorf("aliased run groups = %q, %q", deref(pp[0].Group), deref(pp[1].Group))
+	}
+}
+
+// TestGroupsPublishEachCheckoutOnce is the groups.list half: the main checkout
+// and the worktree are two groups with distinct names — even stopped ones
+// known only from the index — and each says which project, worktree and branch
+// it is.
+func TestGroupsPublishEachCheckoutOnce(t *testing.T) {
+	c := newCheckouts(t, "shop-dir", "feat")
+	writeFile(t, filepath.Join(c.main, ConfigName), "name: shop\nservices:\n  - name: api\n    port: 8000\n")
+	writeFile(t, filepath.Join(c.wt, ConfigName), "name: shop\nservices:\n  - name: api\n    port: 8000\n")
+
+	for _, running := range []bool{false, true} {
+		x := NewIndex()
+		x.Observe(c.wt)
+		var pp []state.Port
+		if running {
+			pp = Resolve([]state.Port{nativePort(8000, c.wt)}, NoPins{}, NoRuns{}, x)
+		}
+		gg := Groups(pp, x)
+
+		byName := map[string]state.Group{}
+		for _, g := range gg {
+			if _, dup := byName[g.Name]; dup {
+				t.Fatalf("running=%v: two groups named %q in %+v", running, g.Name, gg)
+			}
+			byName[g.Name] = g
+		}
+		main, ok := byName["shop"]
+		if !ok {
+			t.Fatalf("running=%v: no main group in %v", running, groupNames(gg))
+		}
+		wt, ok := byName["shop@feat"]
+		if !ok {
+			t.Fatalf("running=%v: no worktree group in %v", running, groupNames(gg))
+		}
+		if main.Repo != "shop" || main.Worktree != "" || main.Branch != "main" {
+			t.Errorf("main checkout fields = repo %q worktree %q branch %q", main.Repo, main.Worktree, main.Branch)
+		}
+		if wt.Repo != "shop" || wt.Worktree != "feat" || wt.Branch != "feature/x" {
+			t.Errorf("worktree fields = repo %q worktree %q branch %q", wt.Repo, wt.Worktree, wt.Branch)
+		}
+		if wt.ConfigPath == nil || *wt.ConfigPath != filepath.Join(c.wt, ConfigName) {
+			t.Errorf("worktree config_path = %v, want its own copy", wt.ConfigPath)
+		}
+		if running && (len(wt.Services) != 1 || !wt.Services[0].Running || len(main.Members) != 0) {
+			t.Errorf("the worktree's api is the worktree's: main %+v, worktree %+v", main, wt)
+		}
+	}
+}
+
+func TestGroupsFieldsForAGroupThatIsNotACheckout(t *testing.T) {
+	gg := Groups(Resolve([]state.Port{composePort(5433, "loose", "db")}, NoPins{}, NoRuns{}, NewIndex()), NewIndex())
+	if len(gg) != 1 || gg[0].Repo != "loose" || gg[0].Worktree != "" || gg[0].Branch != "" {
+		t.Fatalf("groups = %+v", gg)
+	}
+}
+
+func TestNamedMatchesTheGroupNotTheFile(t *testing.T) {
+	c := newCheckouts(t, "shop", "feat")
+	writeFile(t, filepath.Join(c.main, ConfigName), "name: shop\n")
+	writeFile(t, filepath.Join(c.wt, ConfigName), "name: shop\n")
+	x := NewIndex()
+	x.Observe(c.wt)
+
+	if cfg, ok := x.Named("shop"); !ok || cfg.Dir != c.main {
+		t.Errorf("Named(shop) = %+v, %v; want the main checkout's file", cfg, ok)
+	}
+	if cfg, ok := x.Named("shop@feat"); !ok || cfg.Dir != c.wt {
+		t.Errorf("Named(shop@feat) = %+v, %v; want the worktree's copy", cfg, ok)
+	}
+}
+
+func groupNames(gg []state.Group) []string {
+	out := make([]string, 0, len(gg))
+	for _, g := range gg {
+		out = append(out, g.Name)
+	}
+	return out
+}

--- a/internal/groups/edit.go
+++ b/internal/groups/edit.go
@@ -161,6 +161,30 @@ func (e *ServiceConflictError) Error() string {
 // The returned Config is the file as it would then stand: it is parsed from the
 // rendered bytes, so what a later Load sees is what has been validated here.
 func RenderEdit(path string, edit ConfigEdit) ([]byte, *Config, error) {
+	return render(path, func(abs string, root *yaml.Node) error { return applyEdit(abs, root, edit) })
+}
+
+// SetConfigName writes a new top-level `name:` into a `.sonar.yaml` and returns
+// the file as it then stands. It goes down the same node-level path as every
+// other edit, so comments and formatting survive, and nothing is written
+// unless the result validates. `groups.rename` renames a file project with it.
+func SetConfigName(path, name string) (*Config, error) {
+	out, cfg, err := render(path, func(_ string, root *yaml.Node) error {
+		setKeyIn(root, "name", strNode(name), rootKeyOrder)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := WriteConfigFile(cfg.Path, out); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// render reads the file at path, lets apply change its node tree, and returns
+// the bytes that would be written together with the config they parse to.
+func render(path string, apply func(abs string, root *yaml.Node) error) ([]byte, *Config, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, nil, err
@@ -179,7 +203,7 @@ func RenderEdit(path string, edit ConfigEdit) ([]byte, *Config, error) {
 		return nil, nil, &ConfigError{Path: abs, Problems: []string{"the file is not a YAML mapping"}}
 	}
 
-	if err := applyEdit(abs, root, edit); err != nil {
+	if err := apply(abs, root); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/groups/gitroot.go
+++ b/internal/groups/gitroot.go
@@ -68,6 +68,16 @@ func GroupName(root, worktree string) string {
 // (`…/.git/modules/<name>`) and anything unparseable yield "", so the caller
 // falls back to the checkout's own base name.
 func worktreeName(root, gitFile string) string {
+	main := worktreeMain(gitdirTarget(root, gitFile))
+	if main == "" {
+		return ""
+	}
+	return filepath.Base(main) + "@" + filepath.Base(root)
+}
+
+// gitdirTarget reads the `gitdir:` line of a `.git` file, made absolute against
+// root and cleaned. It is "" when the file cannot be read or has no such line.
+func gitdirTarget(root, gitFile string) string {
 	data, err := os.ReadFile(gitFile)
 	if err != nil {
 		return ""
@@ -86,9 +96,16 @@ func worktreeName(root, gitFile string) string {
 	if !filepath.IsAbs(target) {
 		target = filepath.Join(root, target)
 	}
-	target = filepath.Clean(target)
+	return filepath.Clean(target)
+}
 
-	// …/<repo>/.git/worktrees/<name>  ->  main repo is <repo>.
+// worktreeMain is the main checkout's root when target is a linked worktree's
+// admin directory, `<main>/.git/worktrees/<name>`. A submodule's
+// (`…/.git/modules/<name>`) and anything else yield "".
+func worktreeMain(target string) string {
+	if target == "" {
+		return ""
+	}
 	worktreesDir := filepath.Dir(target)
 	if filepath.Base(worktreesDir) != "worktrees" {
 		return ""
@@ -97,9 +114,10 @@ func worktreeName(root, gitFile string) string {
 	if filepath.Base(gitDir) != ".git" {
 		return ""
 	}
-	repo := filepath.Base(filepath.Dir(gitDir))
+	main := filepath.Dir(gitDir)
+	repo := filepath.Base(main)
 	if repo == "" || repo == "." || repo == string(filepath.Separator) {
 		return ""
 	}
-	return repo + "@" + filepath.Base(root)
+	return main
 }

--- a/internal/groups/index.go
+++ b/internal/groups/index.go
@@ -21,6 +21,8 @@ type Index struct {
 	compose map[string]string  // compose project -> working_dir label
 	probed  map[string]bool    // directories already looked at
 	stamps  map[string]stamp   // config path -> mtime and size when it was read
+	aliases map[string]string  // main checkout root -> project name (groups.rename)
+	heads   map[string]headEntry
 }
 
 // InvalidConfig is one config file that could not be used, reported by
@@ -38,6 +40,8 @@ func NewIndex() *Index {
 		compose: map[string]string{},
 		probed:  map[string]bool{},
 		stamps:  map[string]stamp{},
+		aliases: map[string]string{},
+		heads:   map[string]headEntry{},
 	}
 }
 
@@ -83,7 +87,14 @@ func (x *Index) Observe(dir string) {
 		return
 	}
 	abs := Canonical(dir)
-	root, _, hasRoot := Find(abs)
+	co, hasRoot := Locate(abs)
+	root := co.Root
+	if hasRoot && co.Linked() {
+		// The main checkout names every worktree of it (step 5A.6), so a
+		// worktree coming into view brings the main checkout's config with it
+		// — and with it the main checkout's group, running or not.
+		x.probeDir(co.Main)
+	}
 	cur := abs
 	for i := 0; i < maxWalk; i++ {
 		x.probeDir(cur)

--- a/internal/groups/reload.go
+++ b/internal/groups/reload.go
@@ -64,12 +64,15 @@ func (x *Index) Known() []string {
 	return out
 }
 
-// Named returns the valid config that names this group. The deepest directory
-// wins, matching Configs' ordering, so a nested project shadows the repository
-// it sits in.
+// Named returns the valid config whose services are published as this group
+// (see GroupOf). The deepest directory wins, matching Configs' ordering, so a
+// nested project shadows the repository it sits in. Matching the group rather
+// than the file's `name:` is what keeps a linked worktree's copy of a
+// committed file from answering for the main checkout: the copy is
+// `<project>@<worktree>`, and only the main checkout's file is `<project>`.
 func (x *Index) Named(name string) (*Config, bool) {
 	for _, cfg := range x.Configs() {
-		if cfg.Name == name {
+		if x.GroupOf(cfg) == name {
 			return cfg, true
 		}
 	}

--- a/internal/groups/rename.go
+++ b/internal/groups/rename.go
@@ -1,0 +1,182 @@
+package groups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// RenamePlan is what renaming a project changes (`groups.rename`, step 5A.6).
+//
+// A rename always applies to the project, whichever of its checkouts named it:
+// the main checkout's group becomes Project and every linked worktree's group
+// becomes `<Project>@<worktree>`.
+type RenamePlan struct {
+	// Main is the main checkout's root, the key an alias is stored under. It is
+	// empty for a `.sonar.yaml` project that is not a checkout's root.
+	Main string
+	// ConfigPath is the `.sonar.yaml` to write the new `name:` into. Empty
+	// means the project has no file of its own and the name is stored as an
+	// alias of Main instead.
+	ConfigPath string
+	// Project is the new project name.
+	Project string
+	// Renames maps every group name that changes to its new name. It is empty
+	// when the project already has the name asked for.
+	Renames map[string]string
+}
+
+// RenameErrorKind says why a rename cannot be done.
+type RenameErrorKind int
+
+const (
+	// RenameNotFound: no group has the name the caller gave.
+	RenameNotFound RenameErrorKind = iota
+	// RenameRefused: the group exists but its name is not the project's to
+	// change — a pin or a run's --group names it, or nothing does.
+	RenameRefused
+	// RenameConflict: a group outside the project already has a name the
+	// rename would give.
+	RenameConflict
+)
+
+// RenameError is a rename that cannot be done.
+type RenameError struct {
+	Kind RenameErrorKind
+	Msg  string
+	Hint string
+}
+
+func (e *RenameError) Error() string { return e.Msg }
+
+// ValidProjectName checks a new project name. On top of the rules every group
+// name follows it refuses `@`, which separates the project from the worktree
+// in a checkout's group name.
+func ValidProjectName(name string) error {
+	switch {
+	case name == "":
+		return fmt.Errorf("the new name is empty")
+	case strings.ContainsAny(name, "@"):
+		return fmt.Errorf("%q contains @, which separates a project from its worktree", name)
+	case strings.ContainsAny(name, "/\\ \t\n\r"):
+		return fmt.Errorf("%q contains a slash or whitespace; names are a single word", name)
+	}
+	return nil
+}
+
+// PlanRename works out what renaming the group from to `to` means, against
+// the published groups gg and the index they were built from. It changes
+// nothing: the caller writes the file or the alias and republishes.
+func PlanRename(gg []state.Group, x *Index, from, to string) (*RenamePlan, error) {
+	var g *state.Group
+	for i := range gg {
+		if gg[i].Name == from {
+			g = &gg[i]
+			break
+		}
+	}
+	if g == nil {
+		return nil, &RenameError{Kind: RenameNotFound,
+			Msg: "no group named " + from, Hint: "`sonar groups` lists the names"}
+	}
+	if g.Source == state.SourceManual {
+		return nil, refusedManual(from)
+	}
+
+	var (
+		co     Checkout
+		inRepo bool
+	)
+	if g.RootDir != nil {
+		co, inRepo = Locate(*g.RootDir)
+	}
+	if inRepo && g.Name == x.CheckoutName(co) {
+		return planProject(gg, x, co.Main, to)
+	}
+
+	// Not a checkout's own group: whatever named it is not the project.
+	if g.Source == state.SourceStart {
+		return nil, &RenameError{Kind: RenameRefused,
+			Msg:  from + " is named by the --group of the `sonar start` run in it, not by a project",
+			Hint: "restart the run with `sonar start --group " + to + "`"}
+	}
+	if g.ConfigPath != nil && !(inRepo && co.Linked()) {
+		if cfg, ok := x.ByPath(*g.ConfigPath); ok && x.GroupOf(cfg) == g.Name {
+			// A `.sonar.yaml` project that is not a checkout's root: nested in
+			// one, or outside git altogether. Its file is its name.
+			plan := &RenamePlan{ConfigPath: cfg.Path, Project: to, Renames: map[string]string{}}
+			if from != to {
+				plan.Renames[from] = to
+			}
+			return plan, conflicts(gg, plan)
+		}
+	}
+	if inRepo && co.Linked() {
+		return nil, &RenameError{Kind: RenameRefused,
+			Msg:  from + " is a project nested in the worktree " + co.Worktree,
+			Hint: "rename it in the main checkout's copy of its " + ConfigName}
+	}
+	return nil, &RenameError{Kind: RenameRefused,
+		Msg:  from + " is not a git checkout or a " + ConfigName + " project, so it has no name to change",
+		Hint: "a Compose project is named by Compose; `sonar assign` pins ports to a group of your choosing"}
+}
+
+// planProject renames the project whose main checkout is at main, and with it
+// every checkout group of that project that is published right now.
+func planProject(gg []state.Group, x *Index, main, to string) (*RenamePlan, error) {
+	plan := &RenamePlan{Main: main, Project: to, Renames: map[string]string{}}
+	if cfg := x.At(main); cfg != nil {
+		plan.ConfigPath = cfg.Path
+	}
+	if x.ProjectName(main) == to {
+		return plan, nil
+	}
+	for _, h := range gg {
+		if h.RootDir == nil {
+			continue
+		}
+		hc, ok := Locate(*h.RootDir)
+		if !ok || hc.Main != main || h.Name != x.CheckoutName(hc) {
+			continue
+		}
+		if h.Source == state.SourceManual {
+			return nil, refusedManual(h.Name)
+		}
+		next := to
+		if hc.Linked() {
+			next = to + "@" + hc.Worktree
+		}
+		plan.Renames[h.Name] = next
+	}
+	return plan, conflicts(gg, plan)
+}
+
+// conflicts refuses a rename that would give a group a name some group outside
+// the rename already has. The project name itself is checked even when the
+// main checkout is not published right now, because it will be.
+func conflicts(gg []state.Group, plan *RenamePlan) error {
+	taken := map[string]bool{}
+	for _, h := range gg {
+		if _, moving := plan.Renames[h.Name]; !moving {
+			taken[h.Name] = true
+		}
+	}
+	names := []string{plan.Project}
+	for _, next := range plan.Renames {
+		names = append(names, next)
+	}
+	for _, n := range names {
+		if taken[n] {
+			return &RenameError{Kind: RenameConflict,
+				Msg: "a group named " + n + " already exists", Hint: "pick another name"}
+		}
+	}
+	return nil
+}
+
+func refusedManual(name string) error {
+	return &RenameError{Kind: RenameRefused,
+		Msg:  name + " is a manual group: ports pinned with `sonar assign` name it",
+		Hint: "pin them to the new name with `sonar assign <port> <name>` instead"}
+}

--- a/internal/groups/rename_test.go
+++ b/internal/groups/rename_test.go
@@ -1,0 +1,194 @@
+package groups
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// renameWorld is a project with a main checkout and a worktree, both running,
+// plus an unrelated repository called "store", resolved and built the way the
+// daemon publishes them.
+func renameWorld(t *testing.T, withConfig bool) (checkouts, *Index, []state.Group) {
+	t.Helper()
+	c := newCheckouts(t, "shop", "feat")
+	if withConfig {
+		writeFile(t, filepath.Join(c.main, ConfigName), "# the shop\nname: shop\nports: [8000]\n")
+		writeFile(t, filepath.Join(c.wt, ConfigName), "name: shop\nports: [8000]\n")
+	}
+	other := mkdir(t, filepath.Dir(c.main), "store")
+	mkdir(t, other, ".git")
+
+	x := NewIndex()
+	for _, dir := range []string{c.main, c.wt, other} {
+		x.Observe(dir)
+	}
+	pp := Resolve([]state.Port{
+		nativePort(8000, c.main), nativePort(8001, c.wt), nativePort(9000, other),
+	}, fakePins{7000: "pinned"}, fakeRuns{7100: {group: "started", name: "job"}}, x)
+	pp = append(pp, Resolve([]state.Port{nativePort(7000, c.main), nativePort(7100, c.main)},
+		fakePins{7000: "pinned"}, fakeRuns{7100: {group: "started", name: "job"}}, x)...)
+	return c, x, Groups(pp, x)
+}
+
+func renameKind(err error) (RenameErrorKind, bool) {
+	var re *RenameError
+	if errors.As(err, &re) {
+		return re.Kind, true
+	}
+	return 0, false
+}
+
+func TestPlanRenameFileProject(t *testing.T) {
+	c, x, gg := renameWorld(t, true)
+
+	// Named from the worktree: the rename is still the project's.
+	plan, err := PlanRename(gg, x, "shop@feat", "market")
+	if err != nil {
+		t.Fatalf("PlanRename: %v", err)
+	}
+	if plan.ConfigPath != filepath.Join(c.main, ConfigName) {
+		t.Errorf("config path = %q, want the main checkout's file", plan.ConfigPath)
+	}
+	if plan.Main != c.main || plan.Project != "market" {
+		t.Errorf("plan = %+v", plan)
+	}
+	if len(plan.Renames) != 2 || plan.Renames["shop"] != "market" || plan.Renames["shop@feat"] != "market@feat" {
+		t.Errorf("renames = %v", plan.Renames)
+	}
+}
+
+func TestPlanRenameAutoProject(t *testing.T) {
+	c, x, gg := renameWorld(t, false)
+	plan, err := PlanRename(gg, x, "shop", "market")
+	if err != nil {
+		t.Fatalf("PlanRename: %v", err)
+	}
+	if plan.ConfigPath != "" || plan.Main != c.main {
+		t.Errorf("plan = %+v, want an alias of the main checkout", plan)
+	}
+	if plan.Renames["shop"] != "market" || plan.Renames["shop@feat"] != "market@feat" {
+		t.Errorf("renames = %v", plan.Renames)
+	}
+
+	// Applied as an alias, the resolver agrees with the plan.
+	x.SetAliases(map[string]string{plan.Main: plan.Project})
+	pp := Resolve([]state.Port{nativePort(8000, c.main), nativePort(8001, c.wt)}, NoPins{}, NoRuns{}, x)
+	if deref(pp[0].Group) != "market" || deref(pp[1].Group) != "market@feat" {
+		t.Errorf("after the alias: %q, %q", deref(pp[0].Group), deref(pp[1].Group))
+	}
+}
+
+func TestPlanRenameRefusals(t *testing.T) {
+	_, x, gg := renameWorld(t, false)
+
+	tests := []struct {
+		name, from, to string
+		want           RenameErrorKind
+	}{
+		{"unknown group", "nope", "market", RenameNotFound},
+		{"collides with another project", "shop", "store", RenameConflict},
+		{"a manual group", "pinned", "market", RenameRefused},
+		{"a run's --group", "started", "market", RenameRefused},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PlanRename(gg, x, tt.from, tt.to)
+			kind, ok := renameKind(err)
+			if !ok || kind != tt.want {
+				t.Fatalf("err = %v, want kind %d", err, tt.want)
+			}
+		})
+	}
+
+	// Renaming to the current name is a no-op, not a conflict with itself.
+	plan, err := PlanRename(gg, x, "shop@feat", "shop")
+	if err != nil || len(plan.Renames) != 0 {
+		t.Fatalf("same name = %+v, %v", plan, err)
+	}
+}
+
+func TestPlanRenameConflictsOnAWorktreeName(t *testing.T) {
+	_, x, gg := renameWorld(t, false)
+	gg = append(gg, state.Group{Name: "market@feat", Source: state.SourceManual})
+	if _, err := PlanRename(gg, x, "shop", "market"); err == nil {
+		t.Fatal("renaming onto an existing <project>@<worktree> succeeded")
+	} else if kind, _ := renameKind(err); kind != RenameConflict {
+		t.Fatalf("err = %v, want a conflict", err)
+	}
+}
+
+func TestPlanRenameConfigOutsideACheckout(t *testing.T) {
+	dir := mkdir(t, tempTree(t), "loose")
+	writeFile(t, filepath.Join(dir, ConfigName), "name: loose\nports: [8000]\n")
+	x := NewIndex()
+	x.Observe(dir)
+	gg := Groups(nil, x)
+
+	plan, err := PlanRename(gg, x, "loose", "tidy")
+	if err != nil {
+		t.Fatalf("PlanRename: %v", err)
+	}
+	if plan.ConfigPath != filepath.Join(dir, ConfigName) || plan.Main != "" || plan.Renames["loose"] != "tidy" {
+		t.Fatalf("plan = %+v", plan)
+	}
+}
+
+func TestValidProjectName(t *testing.T) {
+	for _, name := range []string{"", "a@b", "a/b", `a\b`, "a b", "tab\tname"} {
+		if ValidProjectName(name) == nil {
+			t.Errorf("ValidProjectName(%q) accepted it", name)
+		}
+	}
+	for _, name := range []string{"shop", "my-app", "app_2.0"} {
+		if err := ValidProjectName(name); err != nil {
+			t.Errorf("ValidProjectName(%q) = %v", name, err)
+		}
+	}
+}
+
+func TestSetConfigNameKeepsTheFile(t *testing.T) {
+	dir := tempTree(t)
+	path := filepath.Join(dir, ConfigName)
+	writeFile(t, path, "# the shop\nname: shop # short\nservices:\n  # first\n  - name: api\n    port: 8000\n")
+
+	cfg, err := SetConfigName(path, "market")
+	if err != nil {
+		t.Fatalf("SetConfigName: %v", err)
+	}
+	if cfg.Name != "market" {
+		t.Errorf("config name = %q", cfg.Name)
+	}
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	for _, want := range []string{"# the shop", "name: market # short", "# first", "port: 8000"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("file lost %q:\n%s", want, got)
+		}
+	}
+
+	// A file with no name: key gets one, at the top.
+	bare := filepath.Join(tempTree(t), ConfigName)
+	writeFile(t, bare, "services:\n  - name: api\n")
+	if _, err := SetConfigName(bare, "market"); err != nil {
+		t.Fatalf("SetConfigName without a name key: %v", err)
+	}
+	data, _ = os.ReadFile(bare)
+	if !strings.HasPrefix(string(data), "name: market\n") {
+		t.Errorf("name not inserted first:\n%s", data)
+	}
+
+	// A name that does not validate leaves the file alone.
+	before, _ := os.ReadFile(path)
+	if _, err := SetConfigName(path, "bad name"); err == nil {
+		t.Fatal("wrote a name with a space")
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Error("a refused rename changed the file")
+	}
+}

--- a/internal/groups/resolve.go
+++ b/internal/groups/resolve.go
@@ -95,10 +95,17 @@ func MatchKeys(p state.Port) []string {
 //  4. compose — the Compose project, unless its working directory is inside a
 //     git checkout, in which case the container merges into that checkout's
 //     group so a Compose db and a native api are one group
-//  5. gitroot — the checkout containing the process cwd, named `<repo>` or
-//     `<repo>@<worktree>`; a `.sonar.yaml` at that root renames the group and
-//     makes the source `file`
+//  5. gitroot — the checkout containing the process cwd, named `<project>` or
+//     `<project>@<worktree>`, where the project name comes from the main
+//     checkout only: an alias from `groups.rename`, else the `name:` of its
+//     `.sonar.yaml`, else its directory name. A `.sonar.yaml` at the
+//     checkout's root makes the source `file`; a linked worktree's own copy
+//     supplies services but never the name (step 5A.6)
 //  6. none — group stays null
+//
+// A run's group is kept, except that a run recorded under the project's own
+// name is moved to its checkout's current group name (see runGroup), and a
+// config never claims a port across a linked worktree's boundary.
 //
 // pins, runs and index may all be nil.
 func Resolve(pp []state.Port, pins Pins, runs Registry, index *Index) []state.Port {
@@ -114,9 +121,9 @@ func Resolve(pp []state.Port, pins Pins, runs Registry, index *Index) []state.Po
 }
 
 func resolveOne(p *state.Port, pins Pins, runs Registry, index *Index) {
-	root, worktree := projectRoot(p, index)
-	if root != "" {
-		r := root
+	co, inRepo := projectCheckout(p, index)
+	if inRepo {
+		r := co.Root
 		p.ProjectRoot = &r
 	}
 	p.Group, p.GroupSource = nil, nil
@@ -129,20 +136,30 @@ func resolveOne(p *state.Port, pins Pins, runs Registry, index *Index) {
 	}
 	if runs != nil {
 		if run, ok := runs.Run(*p); ok && run.Group != "" {
-			assign(p, run.Group, state.SourceStart)
+			group := run.Group
+			if inRepo {
+				group = index.runGroup(group, co)
+			}
+			assign(p, group, state.SourceStart)
 			return
 		}
 	}
-	if cfg, _, ok := index.MatchPort(*p); ok {
-		assign(p, cfg.Name, state.SourceFile)
+	// The deepest config claiming the port wins. If that one lies outside the
+	// linked worktree the port runs in, none inside it claims the port — they
+	// would be deeper — so the checkout's own group takes it below.
+	if cfg, _, ok := index.MatchPort(*p); ok && (!inRepo || index.within(cfg, co)) {
+		assign(p, index.GroupOf(cfg), state.SourceFile)
 		return
 	}
-	if root != "" {
-		if cfg := index.Nearest(root); cfg != nil {
-			assign(p, cfg.Name, state.SourceFile)
-			return
+	if inRepo {
+		// Name first: naming probes the main checkout, which is where a
+		// main-checkout port's own config may still be waiting to be read.
+		name := index.CheckoutName(co)
+		source := state.SourceAuto
+		if index.checkoutConfig(co) != nil {
+			source = state.SourceFile
 		}
-		assign(p, GroupName(root, worktree), state.SourceAuto)
+		assign(p, name, source)
 		return
 	}
 	if p.Docker != nil && p.Docker.ComposeProject != "" {
@@ -150,23 +167,23 @@ func resolveOne(p *state.Port, pins Pins, runs Registry, index *Index) {
 	}
 }
 
-// projectRoot is the checkout a port belongs to: the git root above the
+// projectCheckout is the checkout a port belongs to: the one containing the
 // process cwd, or — for a Compose container, which has no cwd of its own — the
-// git root above the project's working directory.
-func projectRoot(p *state.Port, index *Index) (root, worktree string) {
+// one containing the project's working directory.
+func projectCheckout(p *state.Port, index *Index) (Checkout, bool) {
 	if p.Cwd != "" {
-		if root, worktree, ok := Find(p.Cwd); ok {
-			return root, worktree
+		if co, ok := Locate(p.Cwd); ok {
+			return co, true
 		}
 	}
 	if p.Docker != nil && p.Docker.ComposeProject != "" {
 		if dir := index.ComposeDir(p.Docker.ComposeProject); dir != "" {
-			if root, worktree, ok := Find(dir); ok {
-				return root, worktree
+			if co, ok := Locate(dir); ok {
+				return co, true
 			}
 		}
 	}
-	return "", ""
+	return Checkout{}, false
 }
 
 func assign(p *state.Port, name string, source state.GroupSource) {

--- a/internal/groups/resolve_test.go
+++ b/internal/groups/resolve_test.go
@@ -141,9 +141,11 @@ func TestResolvePrecedence(t *testing.T) {
 			wantRoot:   "",
 		},
 		{
+			// The project half is the main checkout's name, and the main
+			// checkout's .sonar.yaml names it (step 5A.6).
 			name:       "a worktree is its own group",
 			port:       nativePort(8100, f.worktree),
-			wantGroup:  "sonar@feature-x",
+			wantGroup:  "sonar-cfg@feature-x",
 			wantSource: state.SourceAuto,
 			wantRoot:   f.worktree,
 		},

--- a/internal/scanner/attribute.go
+++ b/internal/scanner/attribute.go
@@ -20,6 +20,7 @@ type Store interface {
 	Roots() ([]string, error)
 	AddRoot(path string) error
 	AppendBatch(events []store.HistoryEvent) error
+	GroupAliases() (map[string]string, error)
 }
 
 // attribution is the per-loop group state: the index of known `.sonar.yaml`
@@ -112,6 +113,7 @@ func (l *Loop) attribute(pp []ports.ListeningPort) ([]state.Port, []state.Group)
 	l.refreshStaleConfigs()
 
 	pins, renames := l.load(st)
+	l.loadAliases(st)
 
 	resolved, index := groups.AttributeWith(pp, pins, l.registry(), l.attr.index)
 	l.attr.index = index
@@ -157,6 +159,24 @@ func (l *Loop) load(st Store) (groups.Pins, map[string]string) {
 		l.opts.Logger.Warn("reading renames", "error", err)
 	}
 	return pinSet(pins), renames
+}
+
+// loadAliases hands the index this tick's project names from `groups.rename`.
+// It runs under the ordering gate like the pin read, so a republish after a
+// rename always resolves with the name it just stored. A failed read keeps the
+// last tick's names rather than flapping every renamed project back to its
+// directory name.
+func (l *Loop) loadAliases(st Store) {
+	if st == nil {
+		l.attr.index.SetAliases(nil)
+		return
+	}
+	aliases, err := st.GroupAliases()
+	if err != nil {
+		l.opts.Logger.Warn("reading project aliases", "error", err)
+		return
+	}
+	l.attr.index.SetAliases(aliases)
 }
 
 // registry is the run registry to attribute with: the one `sonar start`

--- a/internal/scanner/config.go
+++ b/internal/scanner/config.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/state"
 )
 
 // The daemon's `.sonar.yaml` index lives here, on the scan loop, because the
@@ -43,6 +44,14 @@ func (l *Loop) GroupOf(cfg *groups.Config) string {
 	l.attr.mu.Lock()
 	defer l.attr.mu.Unlock()
 	return l.index().GroupOf(cfg)
+}
+
+// PlanGroupRename works out what `groups.rename` changes, against the groups
+// the caller read and the index they were built from.
+func (l *Loop) PlanGroupRename(gg []state.Group, from, to string) (*groups.RenamePlan, error) {
+	l.attr.mu.Lock()
+	defer l.attr.mu.Unlock()
+	return groups.PlanRename(gg, l.index(), from, to)
 }
 
 // ConfigAt returns the config read from this file.

--- a/internal/scanner/config.go
+++ b/internal/scanner/config.go
@@ -36,6 +36,15 @@ func (l *Loop) ConfigNamed(name string) (*groups.Config, bool) {
 	return l.index().Named(name)
 }
 
+// GroupOf returns the group a config's services are published under. For a
+// config at a checkout's root that is the checkout's group, whatever the file's
+// own `name:` says: a linked worktree's copy names `<project>@<worktree>`.
+func (l *Loop) GroupOf(cfg *groups.Config) string {
+	l.attr.mu.Lock()
+	defer l.attr.mu.Unlock()
+	return l.index().GroupOf(cfg)
+}
+
 // ConfigAt returns the config read from this file.
 func (l *Loop) ConfigAt(path string) (*groups.Config, bool) {
 	l.attr.mu.Lock()

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -36,14 +36,27 @@ func row(id string, seen time.Time) store.SessionRow {
 	}
 }
 
+// applied reports whether the database recorded one migration version. Later
+// migrations (007, group aliases) sit above 005, so the highest version alone
+// no longer says whether 005 ran.
+func applied(t *testing.T, s *store.Store, version int) bool {
+	t.Helper()
+	var n int
+	if err := s.DB().QueryRow(`SELECT count(*) FROM schema_version WHERE version = ?`, version).Scan(&n); err != nil {
+		t.Fatalf("reading schema_version: %v", err)
+	}
+	return n == 1
+}
+
 func TestMigration005IsTheReservedVersion(t *testing.T) {
 	s := openStore(t)
 	v, err := s.Version()
 	if err != nil {
 		t.Fatalf("Version: %v", err)
 	}
-	if v != store.VersionSessions {
-		t.Errorf("version = %d, want the reserved sessions version %d", v, store.VersionSessions)
+	if v != store.LatestVersion() || !applied(t, s, store.VersionSessions) {
+		t.Errorf("version = %d, want %d with the reserved sessions version %d applied",
+			v, store.LatestVersion(), store.VersionSessions)
 	}
 	var n int
 	if err := s.DB().QueryRow(
@@ -85,8 +98,9 @@ func TestMigrateFromV2(t *testing.T) {
 	if s.ResetHappened() {
 		t.Fatal("a valid v2 database was treated as corrupt")
 	}
-	if v, err := s.Version(); err != nil || v != store.VersionSessions {
-		t.Fatalf("version after upgrade = %d (%v), want %d", v, err, store.VersionSessions)
+	if v, err := s.Version(); err != nil || v != store.LatestVersion() || !applied(t, s, store.VersionSessions) {
+		t.Fatalf("version after upgrade = %d (%v), want %d with %d applied",
+			v, err, store.LatestVersion(), store.VersionSessions)
 	}
 	if name, ok, err := s.GetRename("cwd:/home/me/code/shop:3000"); err != nil || !ok || name != "storefront" {
 		t.Errorf("the v2 rename did not survive: %q, %v, %v", name, ok, err)

--- a/internal/spawn/resolve.go
+++ b/internal/spawn/resolve.go
@@ -37,7 +37,9 @@ func Resolve(cwd string, argv []string, groupFlag, nameFlag string) Resolution {
 
 	index := groups.NewIndex()
 	index.Observe(cwd)
-	cfg := index.Nearest(cwd)
+	// NearestFor, not Nearest: a worktree kept inside the main checkout must
+	// not pick up the main checkout's file on the way up.
+	cfg := index.NearestFor(cwd)
 
 	res := Resolution{Group: strings.TrimSpace(groupFlag), Name: strings.TrimSpace(nameFlag)}
 	if cfg != nil {
@@ -45,7 +47,7 @@ func Resolve(cwd string, argv []string, groupFlag, nameFlag string) Resolution {
 	}
 
 	if res.Group == "" {
-		res.Group = inferGroup(cwd, cfg)
+		res.Group = inferGroup(index, cwd, cfg)
 	}
 	if res.Name == "" {
 		if svc, ok := matchService(cfg, cwd, argv); ok {
@@ -58,13 +60,16 @@ func Resolve(cwd string, argv []string, groupFlag, nameFlag string) Resolution {
 }
 
 // inferGroup is the group half of the chain, config first, then the checkout,
-// then the directory the command was started in.
-func inferGroup(cwd string, cfg *groups.Config) string {
+// then the directory the command was started in. Both of the first two are
+// named the way the resolver names them, so a run started in a linked worktree
+// lands in `<project>@<worktree>` even when the worktree carries a copy of the
+// main checkout's `.sonar.yaml`.
+func inferGroup(index *groups.Index, cwd string, cfg *groups.Config) string {
 	if cfg != nil && cfg.Name != "" {
-		return cfg.Name
+		return index.GroupOf(cfg)
 	}
-	if root, worktree, ok := groups.Find(cwd); ok {
-		return groups.GroupName(root, worktree)
+	if co, ok := groups.Locate(cwd); ok {
+		return index.CheckoutName(co)
 	}
 	return filepath.Base(cwd)
 }

--- a/internal/spawn/resolve_worktree_test.go
+++ b/internal/spawn/resolve_worktree_test.go
@@ -1,0 +1,33 @@
+package spawn
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveWorktreeWithACopiedConfig: `sonar start` in a linked worktree that
+// carries a copy of the main checkout's committed `.sonar.yaml` records the
+// worktree's own group, named by the main checkout — not the copy's `name:`,
+// and not the main checkout's group (step 5A.6).
+func TestResolveWorktreeWithACopiedConfig(t *testing.T) {
+	main := tempRepo(t, "shop-dir", map[string]string{
+		".git/worktrees/feat/.keep": "x",
+		".sonar.yaml":               "name: shop\nservices:\n  - name: web\n    cmd: npm run dev\n",
+	})
+	wt := tempRepo(t, "feat", map[string]string{
+		".git":        "gitdir: " + filepath.Join(main, ".git", "worktrees", "feat") + "\n",
+		".sonar.yaml": "name: stale\nservices:\n  - name: web\n    cmd: npm run dev\n",
+	})
+
+	got := Resolve(wt, []string{"npm", "run", "dev"}, "", "")
+	if got.Group != "shop@feat" || got.Name != "web" {
+		t.Fatalf("worktree run = %q/%q, want shop@feat/web", got.Group, got.Name)
+	}
+	if got.ConfigPath != filepath.Join(wt, ".sonar.yaml") {
+		t.Errorf("config path = %q, want the worktree's own copy", got.ConfigPath)
+	}
+
+	if got := Resolve(main, []string{"npm", "run", "dev"}, "", ""); got.Group != "shop" {
+		t.Errorf("main checkout run group = %q, want shop", got.Group)
+	}
+}

--- a/internal/state/diff.go
+++ b/internal/state/diff.go
@@ -26,6 +26,7 @@ func diff(prev, next Snapshot, withStats bool) Delta {
 			func(g Group) string { return g.Key() },
 			func(a, b Group) bool {
 				return a.Status == b.Status &&
+					a.Repo == b.Repo && a.Worktree == b.Worktree && a.Branch == b.Branch &&
 					reflect.DeepEqual(a.Members, b.Members) &&
 					reflect.DeepEqual(a.Services, b.Services)
 			}),

--- a/internal/state/diff_group_test.go
+++ b/internal/state/diff_group_test.go
@@ -1,0 +1,24 @@
+package state
+
+import "testing"
+
+// TestDiffPublishesACheckoutChange: a checkout switching branches changes
+// nothing but its group's branch, and that still has to reach subscribers —
+// the group page shows it.
+func TestDiffPublishesACheckoutChange(t *testing.T) {
+	group := func(branch, worktree string) Group {
+		return Group{Name: "shop@feat", Repo: "shop", Worktree: worktree, Branch: branch,
+			Members: []int{}, Services: []Service{}}
+	}
+	prev := Snapshot{Groups: []Group{group("main", "feat")}}
+
+	for _, next := range []Group{group("fix", "feat"), group("main", "")} {
+		d := diff(prev, Snapshot{Groups: []Group{next}}, false)
+		if len(d.Groups.Updated) != 1 {
+			t.Errorf("changing %+v published %+v, want one updated group", next, d.Groups)
+		}
+	}
+	if d := diff(prev, prev, false); len(d.Groups.Updated) != 0 {
+		t.Errorf("an unchanged group published %+v", d.Groups)
+	}
+}

--- a/internal/state/group.go
+++ b/internal/state/group.go
@@ -24,8 +24,19 @@ type Service struct {
 // numbers; clients join them against the ports list.
 type Group struct {
 	// Host names the machine this group lives on (see Port.Host).
-	Host       string      `json:"host"`
-	Name       string      `json:"name"`
+	Host string `json:"host"`
+	Name string `json:"name"`
+	// Repo is the project every checkout of one repository shares: the main
+	// checkout's group name. A group that is not a git checkout's is its own
+	// project, so Repo equals Name.
+	Repo string `json:"repo"`
+	// Worktree is a linked worktree's name, the `<worktree>` half of a
+	// `<repo>@<worktree>` group. It is empty for a main checkout and for a
+	// group that is not a checkout.
+	Worktree string `json:"worktree"`
+	// Branch is the branch checked out in the group's checkout, read from its
+	// HEAD. It is empty when HEAD is detached or cannot be read.
+	Branch     string      `json:"branch"`
 	Source     GroupSource `json:"source" jsonschema:"enum=auto,enum=file,enum=manual,enum=start"`
 	RootDir    *string     `json:"root_dir" jsonschema:"nullable"`
 	ConfigPath *string     `json:"config_path" jsonschema:"nullable"`

--- a/internal/store/aliases.go
+++ b/internal/store/aliases.go
@@ -1,0 +1,44 @@
+package store
+
+import "fmt"
+
+// Group aliases are project names set with `groups.rename` for a project that
+// has no `.sonar.yaml` to write the name into. They are keyed by the root of
+// the project's main checkout, so the main checkout and every linked worktree
+// of it pick the alias up together.
+
+// SetGroupAlias names the project whose main checkout is at root, replacing any
+// earlier alias for it.
+func (s *Store) SetGroupAlias(root, name string) error {
+	clean, err := cleanRoot(root)
+	if err != nil {
+		return err
+	}
+	if err := validName(name); err != nil {
+		return err
+	}
+	return s.exec(
+		`INSERT INTO group_aliases(root, name, created_at) VALUES(?, ?, ?)
+		 ON CONFLICT(root) DO UPDATE SET name = excluded.name, created_at = excluded.created_at`,
+		clean, name, nowString(),
+	)
+}
+
+// ClearGroupAlias forgets the alias for root. Clearing an absent one is not an
+// error.
+func (s *Store) ClearGroupAlias(root string) error {
+	clean, err := cleanRoot(root)
+	if err != nil {
+		return err
+	}
+	return s.exec(`DELETE FROM group_aliases WHERE root = ?`, clean)
+}
+
+// GroupAliases returns every alias as main checkout root → project name.
+func (s *Store) GroupAliases() (map[string]string, error) {
+	out, err := s.allKeyed(`SELECT root, name FROM group_aliases`)
+	if err != nil {
+		return nil, fmt.Errorf("reading group_aliases: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/aliases_test.go
+++ b/internal/store/aliases_test.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGroupAliases(t *testing.T) {
+	s := openTemp(t)
+
+	if err := s.SetGroupAlias("/code/shop", "market"); err != nil {
+		t.Fatalf("SetGroupAlias: %v", err)
+	}
+	if err := s.SetGroupAlias("/code/shop/", "store"); err != nil {
+		t.Fatalf("SetGroupAlias again: %v", err)
+	}
+	got, err := s.GroupAliases()
+	if err != nil {
+		t.Fatalf("GroupAliases: %v", err)
+	}
+	if len(got) != 1 || got["/code/shop"] != "store" {
+		t.Fatalf("aliases = %v, want one cleaned root renamed to store", got)
+	}
+
+	if err := s.SetGroupAlias("/code/other", "a b"); !errors.Is(err, ErrInvalidName) {
+		t.Errorf("an invalid name = %v, want ErrInvalidName", err)
+	}
+	if err := s.SetGroupAlias("", "x"); err == nil {
+		t.Error("an empty root was accepted")
+	}
+
+	if err := s.ClearGroupAlias("/code/shop"); err != nil {
+		t.Fatalf("ClearGroupAlias: %v", err)
+	}
+	if err := s.ClearGroupAlias("/code/never"); err != nil {
+		t.Fatalf("clearing an absent alias: %v", err)
+	}
+	if got, _ := s.GroupAliases(); len(got) != 0 {
+		t.Fatalf("aliases after clearing = %v", got)
+	}
+}

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -42,6 +42,8 @@ const (
 	VersionProxies  = 4 // reserved: spec 3
 	VersionClaims   = 6 // reserved: spec 2
 	VersionSessions = 5 // reserved: spec 2
+
+	VersionGroupAliases = 7 // group_aliases: project names from groups.rename
 )
 
 // ReservedVersions maps the version numbers held for other packages to the

--- a/internal/store/migrations/007_group_aliases.sql
+++ b/internal/store/migrations/007_group_aliases.sql
@@ -1,0 +1,11 @@
+-- 007_group_aliases.sql — project names set with groups.rename (step 5A.6).
+--
+-- A project with a .sonar.yaml is renamed by writing name: into that file.
+-- One without has nowhere to keep a new name, so it is kept here, keyed by the
+-- root of the main checkout every one of its worktrees points back to.
+
+CREATE TABLE IF NOT EXISTS group_aliases (
+    root       TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -100,13 +100,15 @@ func TestOpenIsIdempotent(t *testing.T) {
 		t.Errorf("GetRename after reopen = %q, %v, %v; want api, true, nil", name, ok, err)
 	}
 
-	// Each migration is recorded exactly once, never re-applied.
+	// Each migration is recorded exactly once, never re-applied. Versions
+	// have gaps (003 and 004 are reserved), so count against the registered
+	// set rather than the highest number.
 	var rows int
 	if err := second.DB().QueryRow(`SELECT count(*) FROM schema_version`).Scan(&rows); err != nil {
 		t.Fatalf("counting schema_version: %v", err)
 	}
-	if rows != v2 {
-		t.Errorf("schema_version has %d rows for version %d", rows, v2)
+	if want := len(registeredMigrations()); rows != want {
+		t.Errorf("schema_version has %d rows, want one per registered migration (%d)", rows, want)
 	}
 }
 


### PR DESCRIPTION
Step 5A.6: git worktrees become first-class "checkouts" of a project, which is what the desktop group page lays out side by side.

## What changed

**Every linked worktree is its own group, `<project>@<worktree>`, whatever its source.** Only the main checkout decides the project name: an alias from `groups.rename`, else the `name:` of the main checkout's `.sonar.yaml`, else the main checkout's directory name. A worktree's own copy of a committed `.sonar.yaml` still supplies its services and metadata (source stays `file`, `config_path` points at the copy) but never its name, so a stale copy can no longer fold the worktree into the main checkout's group. Pin and run precedence is unchanged.

- `groups.Locate` / `Checkout` (new, `internal/groups/checkout.go`) finds a checkout's root, its main checkout and the HEAD file its branch lives in. `Find` is unchanged for its other callers.
- The resolver, the group builder (stopped file groups included), `Index.Named`, `sonar start`'s group inference and `groups.start` all name through the same `GroupOf` / `CheckoutName`, so there is never a second group with the main checkout's name, and `groups.config.get {name}` / `groups.start {name}` resolve deterministically.
- A config never claims a port across a linked worktree's boundary. This covers worktrees kept inside the main checkout, e.g. `<repo>/.claude/worktrees/<name>`.
- A run recorded under the project's own name (a pre-5A.6 client, or one that cannot know an alias) joins its checkout's current group. A run with its own `--group` keeps it.
- Observing a worktree also probes its main checkout, so the main checkout's group is published even when only the worktree is running.

**`Group` gains `repo`, `worktree` and `branch`.** The branch is read from HEAD: `.git/HEAD`, or `<main>/.git/worktrees/<name>/HEAD` for a worktree. It is cached by mtime and size, which costs one stat per checkout per scan and never spawns `git`. The group delta equality compares the three fields, so a branch switch reaches subscribers.

**`groups.rename`.** A rename always applies to the project; pass the project or any checkout's name. The main group becomes `to` and every worktree becomes `<to>@<worktree>`.
- Main checkout has a `.sonar.yaml`: `name:` is written through the comment-preserving node editor (`groups.SetConfigName`) and the index reloads the file. A leftover alias for that root is cleared.
- Otherwise the name is stored as an alias in the new `group_aliases` table (migration 007), keyed by the main checkout root. The scanner loads it each tick under the ordering gate, next to the pins.
- Runs recorded under the old names are moved along (`daemon.OnGroupRename` → `runsreg.Registry.RenameGroups`), so already-started services do not split off.
- Publishes through `republish` before replying (the 1A.15/1A.19 ordering), so the delta that removes the old names and adds the new ones is queued ahead of the response.
- Host routing: `{nameFields: ["name"]}`, like the other `groups.*` methods. No CLI command and no MCP tool.

## Wire shape (docs/schema/protocol.schema.json)

`Group` gains three required string fields: `repo`, `worktree`, `branch`.

```
groups.rename
  params: {host?: string, name: string, to: string}
  result: {ok: bool, affected: string[], name: string}
```

- `affected` holds the new name of every group that changed, sorted. It is empty when the project already has that name.
- `name` is the new project name.

Errors:
- `invalid_params` (-32602):
  - `name` is empty
  - `to` is empty, contains `@`, or contains `/`, `\` or whitespace
  - the group is manual, i.e. named by pins
  - the group is named by a `sonar start --group`
  - the group is not a checkout or a `.sonar.yaml` project, e.g. a Compose project
  - the group is a project nested inside a worktree
- `not_found` (1001): unknown group.
- `conflict` (1011): another group already has a name the rename would give.
- `invalid_config` (1006): the edited file would not validate.
- `internal` (1000): no database for an alias rename.

## Behaviour a CLI user will notice

- `sonar groups` / `sonar list` show worktrees of a repo with a committed `.sonar.yaml` as `<project>@<worktree>`; they used to collapse into the main checkout's group. The project half is now the main checkout's `name:`; it used to be the main checkout's directory name.
- `sonar stop <project>` / `sonar kill -g <project>` / MCP `stop_group` now stop only the main checkout. Each worktree is named `<project>@<worktree>`.
- `sonar start` in a worktree records `<project>@<worktree>`; it used to record the `.sonar.yaml` name. `sonar up` from a worktree runs its services under `<project>@<worktree>`, logs included.
- No CLI columns added; the MCP `list_groups` text table is unchanged, and the new fields ride along in its structured output and in `sonar list --json`.

## Tests

- `internal/groups`:
  - checkout tests: `Locate` for main, worktree (absolute and relative gitdir), submodule, outside a repo and path spellings
  - `Branch`: branch, switch, detached, missing HEAD
  - naming: main with and without `.sonar.yaml`, worktree with a copy that has a stale name and one with the same name, worktree inside the main checkout, alias, submodules unaffected
  - run groups following the checkout
  - `Groups` with no duplicate names, running and stopped, with the repo/worktree/branch fields
  - `Named`
- `internal/groups`, rename tests: `PlanRename` for the file and auto paths, conflict on the project and on the `@worktree` name, not found, manual, a run's `--group`, same-name no-op, config outside git; `ValidProjectName`; `SetConfigName` keeps comments and refuses invalid names without writing.
- `internal/daemon`: `groups.rename` end to end:
  - alias path, including the delta arriving before the reply and a localhost host route
  - file path, where the worktree copy is untouched and `groups.config.get` by the new name works
  - refusals, with their error codes
- store aliases; `runsreg.RenameGroups`; spawn worktree naming; group delta on a branch change.
- Existing tests that assumed the newest migration was 005/006, or that versions have no gaps, now check that their own migration was applied.

Run after rebasing onto origin/main (with #84 and #85), temp `HOME`/`SONAR_SOCKET`:

- `go build ./... && go vet ./...`: clean; gofmt clean.
- `go test ./...`: all packages pass. The one exception is `internal/testenv`'s `TestChildrenInheritTheRunRootAsTMPDIR`, which fails only when `GOTMPDIR` redirects `t.TempDir()` and passes without it. It is unrelated to this change.
- `go test -tags integration` for daemon/... (incl. groupstart, runsreg, rpc), groups, scanner, spawn, store, state, claims, sessions: all pass.
- `go generate ./... && git diff --exit-code docs/schema`: clean.
