### PR TITLE
fix: a slow Docker must not stall the daemon (5A.8)

### DIFF
--- a/internal/daemon/docker_integration_test.go
+++ b/internal/daemon/docker_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+
+package daemon_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// replyBudget is what "does not wait on Docker" means below: far under the
+// fake docker's hang, and far under the 10 s a client gives up after.
+const replyBudget = 2 * time.Second
+
+// fakeDockerOnPath writes a `docker` shell script that logs its arguments to
+// calls and then runs body, and returns the PATH entry that puts it first.
+func fakeDockerOnPath(t *testing.T, body string) (path, calls string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake docker is a shell script")
+	}
+	dir := t.TempDir()
+	calls = filepath.Join(dir, "calls.log")
+	script := "#!/bin/sh\necho \"$*\" >> '" + calls + "'\n" + body
+	if err := os.WriteFile(filepath.Join(dir, "docker"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return "PATH=" + dir + string(os.PathListSeparator) + os.Getenv("PATH"), calls
+}
+
+// dockerCalls is how many times the fake docker ran with first argument verb.
+func dockerCalls(calls, verb string) int {
+	b, err := os.ReadFile(calls)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, line := range strings.Split(string(b), "\n") {
+		if line == verb || strings.HasPrefix(line, verb+" ") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestAHungDockerDoesNotStallKillOrSnapshot is step 5A.8's regression test.
+// With a Docker whose backend never answers, `docker ps` hangs; the daemon's
+// scans used to wait out the CLI timeout on every call, so a `ports.kill` took
+// over 25 s and the `state.snapshot` calls queued behind it timed out.
+func TestAHungDockerDoesNotStallKillOrSnapshot(t *testing.T) {
+	path, calls := fakeDockerOnPath(t, "exec sleep 60\n")
+	listener, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := newEnv(t)
+	e.extra = []string{path}
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	port := freePort(t)
+	startListener(t, listener, e.home, port)
+
+	// The kill should land while a `docker ps` is hanging: give the daemon a
+	// moment to ask the fake. A daemon that only asks Docker from inside a
+	// scan (the bug) has not asked yet, and its kill pays for the hang itself.
+	deadline := time.Now().Add(5 * time.Second)
+	for dockerCalls(calls, "ps") == 0 && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	begin := time.Now()
+	var killed rpc.KillEnvelope
+	if err := c.Call(ctx, "ports.kill", rpc.PortsKillParams{
+		Targets: []rpc.Selector{{Port: &port}},
+	}, &killed); err != nil {
+		t.Fatalf("ports.kill: %v", err)
+	}
+	killTook := time.Since(begin)
+	if len(killed.Results) == 0 || !killed.Results[0].OK {
+		t.Fatalf("ports.kill did not kill the listener: %+v", killed.Results)
+	}
+	if m := killed.Results[0].Method; m == state.MethodDockerStop {
+		t.Errorf("the listener was stopped with %s", m)
+	}
+	t.Logf("ports.kill took %s", killTook)
+	if killTook > replyBudget {
+		t.Errorf("ports.kill took %s with docker hanging, want under %s", killTook, replyBudget)
+	}
+
+	// Three snapshots, spaced past the RPC cache so each one scans.
+	for i := 0; i < 3; i++ {
+		if i > 0 {
+			time.Sleep(2100 * time.Millisecond)
+		}
+		begin := time.Now()
+		var snap state.Snapshot
+		if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{}, &snap); err != nil {
+			t.Fatalf("state.snapshot %d: %v", i+1, err)
+		}
+		took := time.Since(begin)
+		t.Logf("state.snapshot %d took %s", i+1, took)
+		if took > replyBudget {
+			t.Errorf("state.snapshot %d took %s with docker hanging, want under %s", i+1, took, replyBudget)
+		}
+		for _, p := range snap.Ports {
+			if p.Port == port {
+				t.Errorf("snapshot %d still lists the killed port %d", i+1, port)
+			}
+		}
+	}
+
+	// Backoff: one hung attempt, then 5 s before the next. Scans poked the
+	// watcher dozens of times meanwhile; none of them may have reached Docker.
+	n := dockerCalls(calls, "ps")
+	t.Logf("docker ps ran %d times in the %s since the kill began", n, time.Since(begin))
+	if n == 0 {
+		t.Error("the daemon never ran docker ps, so this test proved nothing")
+	}
+	if n > 3 {
+		t.Errorf("docker ps ran %d times against a hung Docker; the watcher is not backing off", n)
+	}
+}
+
+// TestAHealthyDockerStillEnrichesAndGroups is the other half: with a Docker
+// that answers, a port it publishes still carries the container, the compose
+// labels and the compose project's group — now from the watcher's cache.
+func TestAHealthyDockerStillEnrichesAndGroups(t *testing.T) {
+	listener, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := freePort(t)
+	composeDir := t.TempDir()
+	ps := "itest-web-1\tnginx:itest\t0.0.0.0:" + strconv.Itoa(port) + "->80/tcp\tweb\titestproj\t" + composeDir
+	path, calls := fakeDockerOnPath(t, "case \"$1\" in\nps) cat <<'EOF'\n"+ps+"\nEOF\n;;\n*) exit 1 ;;\nesac\n")
+
+	e := newEnv(t)
+	e.extra = []string{path}
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	startListener(t, listener, e.home, port)
+
+	var row *state.Port
+	deadline := time.Now().Add(20 * time.Second)
+	for row == nil || row.Docker == nil {
+		if time.Now().After(deadline) {
+			t.Fatalf("port %d was never enriched from docker (docker ps ran %d times); last row: %+v",
+				port, dockerCalls(calls, "ps"), row)
+		}
+		time.Sleep(250 * time.Millisecond)
+		var snap state.Snapshot
+		if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{}, &snap); err != nil {
+			t.Fatalf("state.snapshot: %v", err)
+		}
+		row = nil
+		for i := range snap.Ports {
+			if snap.Ports[i].Port == port {
+				row = &snap.Ports[i]
+			}
+		}
+	}
+
+	d := row.Docker
+	if row.Type != state.TypeDocker {
+		t.Errorf("type = %s, want docker", row.Type)
+	}
+	if d.Container != "itest-web-1" || d.Image != "nginx:itest" || d.ComposeService != "web" ||
+		d.ComposeProject != "itestproj" || d.ContainerPort != 80 {
+		t.Errorf("docker = %+v", *d)
+	}
+	if row.Group == nil || *row.Group != "itestproj" {
+		t.Errorf("group = %v, want the compose project itestproj", deref(row.Group))
+	}
+}

--- a/internal/daemon/integration_test.go
+++ b/internal/daemon/integration_test.go
@@ -77,6 +77,9 @@ type env struct {
 	bin    string
 	home   string
 	socket string
+	// extra is appended to every command's environment, after everything
+	// else, so it wins: a test puts a fake tool first on PATH with it.
+	extra []string
 }
 
 func newEnv(t *testing.T) *env {
@@ -169,6 +172,7 @@ func (e *env) command(args ...string) *exec.Cmd {
 		// that drive its autostart on purpose.
 		testenv.ChildEnv(),
 	)
+	cmd.Env = append(cmd.Env, e.extra...)
 	return cmd
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,9 +35,33 @@ type portMapping struct {
 
 // EnrichPorts queries Docker for running containers and enriches any ports
 // that match Docker-published host ports. Fails silently if Docker is unavailable.
+//
+// It asks Docker inline, bounded by CLITimeout, which suits a one-shot CLI
+// command. The daemon uses a Watcher instead, so no scan waits on Docker.
 func EnrichPorts(pp []ports.ListeningPort) {
 	containers, err := listContainers()
-	if err != nil || len(containers) == 0 {
+	if err != nil {
+		return
+	}
+	enrichFrom(pp, containers)
+}
+
+// publishedPorts is the set of host ports the containers publish.
+func publishedPorts(containers []container) map[int]bool {
+	out := make(map[int]bool)
+	for i := range containers {
+		for _, pm := range containers[i].portMappings {
+			out[pm.hostPort] = true
+		}
+	}
+	return out
+}
+
+// enrichFrom marks every port a container publishes as Docker's and copies the
+// container's name, image and compose labels onto it. It only reads
+// containers, so a Watcher can hand it the cached list without copying.
+func enrichFrom(pp []ports.ListeningPort, containers []container) {
+	if len(containers) == 0 {
 		return
 	}
 
@@ -112,7 +137,12 @@ type apiInspectState struct {
 
 // AllContainerStatsAsEntries returns stats for all containers as ports.DockerStatsEntry map.
 func AllContainerStatsAsEntries() map[string]*ports.DockerStatsEntry {
-	allStats := AllContainerStats()
+	return statsEntries(AllContainerStats())
+}
+
+// statsEntries converts per-container stats to the shape ports.EnrichStats
+// takes. No stats is nil.
+func statsEntries(allStats map[string]*ContainerStats) map[string]*ports.DockerStatsEntry {
 	if len(allStats) == 0 {
 		return nil
 	}
@@ -133,10 +163,18 @@ func AllContainerStatsAsEntries() map[string]*ports.DockerStatsEntry {
 // Engine API via Unix socket. Stats are fetched in parallel (~1s for CPU sampling).
 // Falls back to `docker stats` CLI if the socket is unavailable.
 func AllContainerStats() map[string]*ContainerStats {
-	result := make(map[string]*ContainerStats)
-
 	containers, err := listContainers()
-	if err != nil || len(containers) == 0 {
+	if err != nil {
+		return make(map[string]*ContainerStats)
+	}
+	return statsFor(containers)
+}
+
+// statsFor fetches stats for the given containers, as AllContainerStats does
+// once it has listed them.
+func statsFor(containers []container) map[string]*ContainerStats {
+	result := make(map[string]*ContainerStats)
+	if len(containers) == 0 {
 		return result
 	}
 
@@ -385,15 +423,28 @@ func StopContainer(name string) error {
 	return nil
 }
 
-// listContainers runs `docker ps` and parses the output.
+// psFormat is the `docker ps --format` template parsePS reads.
+const psFormat = "{{.Names}}\t{{.Image}}\t{{.Ports}}\t{{.Label \"com.docker.compose.service\"}}" +
+	"\t{{.Label \"com.docker.compose.project\"}}\t{{.Label \"com.docker.compose.project.working_dir\"}}"
+
+// listContainers runs `docker ps` under CLITimeout and parses the output.
 func listContainers() ([]container, error) {
-	format := "{{.Names}}\t{{.Image}}\t{{.Ports}}\t{{.Label \"com.docker.compose.service\"}}" +
-		"\t{{.Label \"com.docker.compose.project\"}}\t{{.Label \"com.docker.compose.project.working_dir\"}}"
-	out, err := output("ps", "--format", format)
+	ctx, cancel := context.WithTimeout(context.Background(), CLITimeout)
+	defer cancel()
+	return listContainersCtx(ctx)
+}
+
+// listContainersCtx runs `docker ps` bound to ctx and parses the output.
+func listContainersCtx(ctx context.Context) ([]container, error) {
+	out, err := command(ctx, "ps", "--format", psFormat).Output()
 	if err != nil {
 		return nil, err
 	}
+	return parsePS(out), nil
+}
 
+// parsePS parses `docker ps --format psFormat` output, one container a line.
+func parsePS(out []byte) []container {
 	var containers []container
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
 	for scanner.Scan() {
@@ -414,7 +465,7 @@ func listContainers() ([]container, error) {
 		containers = append(containers, c)
 	}
 
-	return containers, nil
+	return containers
 }
 
 // parsePorts parses Docker port strings like "0.0.0.0:3000->80/tcp, 0.0.0.0:3001->443/tcp".

--- a/internal/docker/exec.go
+++ b/internal/docker/exec.go
@@ -10,19 +10,32 @@ import (
 //
 // The docker CLI talks to a daemon over a socket and has no timeout of its
 // own: when Docker Desktop is starting, paused or wedged, `docker stats` does
-// not fail, it waits. Every call here runs inside a scan, and a scan is what a
-// `ports.kill` or a `.sonar.yaml` write is queued behind (contract §38), so an
-// unbounded docker call is an unbounded reply. Ten seconds is far longer than
-// a healthy `docker stats --no-stream` (about two) and short enough that a
-// wedged daemon degrades to "no container stats this tick" instead of hanging
-// the scan lock (contract §44).
+// not fail, it waits. Ten seconds is far longer than a healthy
+// `docker stats --no-stream` (about two) and short enough that a wedged daemon
+// degrades to "no container data" instead of a hung command (contract §44).
+//
+// The daemon's scans no longer pay it: they read the container list a Watcher
+// keeps in the background (step 5A.8). It still bounds the one-shot CLI paths
+// and explicit actions such as `docker stop`.
 const CLITimeout = 10 * time.Second
+
+// waitDelay bounds how long a killed `docker` may keep its output pipe open.
+// A timed-out command is killed, but anything it started that inherited the
+// pipe would otherwise keep Output waiting after the deadline.
+const waitDelay = time.Second
 
 // cli builds a `docker` command that cannot outlive CLITimeout. The returned
 // stop must be called once the output has been read.
 func cli(args ...string) (cmd *exec.Cmd, stop func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), CLITimeout)
-	return exec.CommandContext(ctx, "docker", args...), cancel
+	return command(ctx, args...), cancel
+}
+
+// command builds a `docker` command bound to ctx.
+func command(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.WaitDelay = waitDelay
+	return cmd
 }
 
 // output runs one `docker` command under CLITimeout and returns its stdout.

--- a/internal/docker/watch.go
+++ b/internal/docker/watch.go
@@ -1,0 +1,325 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+// Watcher timing (step 5A.8).
+const (
+	// DefaultRefreshInterval is the least time between two routine
+	// `docker ps` calls. Refreshes are driven by scans, so this only caps
+	// how often scans ask; the daemon passes its base scan interval.
+	DefaultRefreshInterval = 2 * time.Second
+	// PSTimeout bounds one background `docker ps`. Healthy, it answers in
+	// tens of milliseconds; nothing waits on it, so the timeout only decides
+	// how soon a wedged Docker is noticed.
+	PSTimeout = 5 * time.Second
+	// MinBackoff is the wait after the first failed `docker ps`. Each further
+	// failure doubles it, up to MaxBackoff; one success resets it.
+	MinBackoff = 5 * time.Second
+	// MaxBackoff caps the wait between attempts on a Docker that keeps
+	// failing.
+	MaxBackoff = 5 * time.Minute
+	// statsWindow is how long after the last Stats call the watcher keeps
+	// collecting container stats. Stats cost a second of sampling per
+	// refresh, so they are only fetched while a scan wants them.
+	statsWindow = 30 * time.Second
+)
+
+// health is what the watcher last learnt about Docker.
+type health int
+
+const (
+	healthUnknown health = iota // no attempt has finished yet
+	healthOK                    // the last `docker ps` answered
+	healthDown                  // installed, but the last `docker ps` failed or timed out
+	healthAbsent                // no docker on PATH
+)
+
+// WatcherOptions configures a Watcher. Every field may be zero.
+type WatcherOptions struct {
+	// Interval is the least time between routine refreshes. Zero means
+	// DefaultRefreshInterval.
+	Interval time.Duration
+	// Logger receives the debug lines on health changes. Nil discards them.
+	Logger *slog.Logger
+	// OnChange is called after a refresh that changed the container list,
+	// so the caller can scan again instead of waiting for its next tick.
+	OnChange func()
+	// Now overrides the clock, for tests.
+	Now func() time.Time
+}
+
+// Watcher keeps the daemon's view of Docker off the scan path.
+//
+// A scan used to run `docker ps` inline, under the gate every `ports.kill`
+// and `state.snapshot` queue behind, so a wedged Docker Desktop that never
+// answered cost each scan the whole CLITimeout (step 5A.8). Now a scan only
+// reads the list the watcher cached (Enrich, Stats) and pokes it; the watcher
+// refreshes in its own goroutine, at most once per Interval, and backs off
+// exponentially while Docker fails. A scan's container data is therefore at
+// most one refresh old, and never waited for.
+type Watcher struct {
+	interval time.Duration
+	timeout  time.Duration
+	logger   *slog.Logger
+	onChange func()
+	now      func() time.Time
+
+	// Seams for tests; production runs the real CLI.
+	lookPath func(string) (string, error)
+	list     func(ctx context.Context) ([]container, error)
+	stats    func([]container) map[string]*ContainerStats
+
+	poke chan struct{}
+
+	mu sync.Mutex
+	// containers is the last good list. It is replaced, never modified, so
+	// a reader may keep the slice after dropping the mutex.
+	containers    []container
+	statsCache    map[string]*ports.DockerStatsEntry
+	statsWantedAt time.Time
+	// seen is the port set of the last Enrich, for spotting new ports.
+	seen map[int]bool
+	// urgent asks for a refresh before Interval is up: a scan saw a port it
+	// had not seen before and no container publishes it, or stats were just
+	// asked for. Backoff still wins over it.
+	urgent      bool
+	lastAttempt time.Time
+	retryAt     time.Time
+	failures    int
+	state       health
+	lastErr     error
+}
+
+// NewWatcher builds a Watcher. It does nothing until Run.
+func NewWatcher(o WatcherOptions) *Watcher {
+	w := &Watcher{
+		interval: o.Interval,
+		timeout:  PSTimeout,
+		logger:   o.Logger,
+		onChange: o.OnChange,
+		now:      o.Now,
+		lookPath: exec.LookPath,
+		list:     listContainersCtx,
+		stats:    statsFor,
+		poke:     make(chan struct{}, 1),
+	}
+	if w.interval <= 0 {
+		w.interval = DefaultRefreshInterval
+	}
+	if w.logger == nil {
+		w.logger = slog.New(slog.DiscardHandler)
+	}
+	if w.now == nil {
+		w.now = time.Now
+	}
+	return w
+}
+
+// Run refreshes whenever a scan pokes and a refresh is due, until ctx ends.
+// The first refresh starts at once, so the list is primed before most first
+// scans need it.
+func (w *Watcher) Run(ctx context.Context) {
+	for {
+		if w.due() {
+			w.refresh(ctx)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.poke:
+		}
+	}
+}
+
+// Poke asks for a refresh. It never blocks; the refresh happens only if one
+// is due.
+func (w *Watcher) Poke() {
+	select {
+	case w.poke <- struct{}{}:
+	default:
+	}
+}
+
+// Enrich stamps container data from the cached list onto pp and pokes the
+// watcher. It never runs a docker command.
+func (w *Watcher) Enrich(pp []ports.ListeningPort) {
+	w.mu.Lock()
+	containers := w.containers
+	published := publishedPorts(containers)
+	seen := make(map[int]bool, len(pp))
+	for i := range pp {
+		port := pp[i].Port
+		seen[port] = true
+		if w.seen != nil && !w.seen[port] && !published[port] {
+			// A port no container is known to publish: maybe a container
+			// that started since the last refresh.
+			w.urgent = true
+		}
+	}
+	w.seen = seen
+	w.mu.Unlock()
+
+	enrichFrom(pp, containers)
+	w.Poke()
+}
+
+// Stats returns the container stats cached by the last refresh, keyed by
+// container name, and keeps the watcher collecting them for statsWindow. It
+// never runs a docker command; nil means none are cached yet.
+func (w *Watcher) Stats() map[string]*ports.DockerStatsEntry {
+	w.mu.Lock()
+	now := w.now()
+	if w.statsWantedAt.IsZero() || now.Sub(w.statsWantedAt) >= statsWindow {
+		w.urgent = true
+	}
+	w.statsWantedAt = now
+	st := w.statsCache
+	w.mu.Unlock()
+	w.Poke()
+	return st
+}
+
+// Healthy reports whether the last `docker ps` answered. Callers use it to
+// skip optional docker calls, such as the container graph, while Docker is
+// not answering.
+func (w *Watcher) Healthy() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.state == healthOK
+}
+
+// due reports whether a refresh should run now.
+func (w *Watcher) due() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	now := w.now()
+	if now.Before(w.retryAt) {
+		return false
+	}
+	return w.urgent || w.lastAttempt.IsZero() || now.Sub(w.lastAttempt) >= w.interval
+}
+
+// refresh runs one `docker ps` (and the stats, when wanted) and records the
+// outcome. It is only ever called from Run, so two never overlap.
+func (w *Watcher) refresh(ctx context.Context) {
+	w.mu.Lock()
+	w.urgent = false // a request arriving during this refresh asks for another
+	now := w.now()
+	w.lastAttempt = now
+	wantStats := !w.statsWantedAt.IsZero() && now.Sub(w.statsWantedAt) < statsWindow
+	w.mu.Unlock()
+
+	// Not installed is not a failure: no exec, no backoff, no noise. LookPath
+	// is a few stat calls, so it is cheap to repeat, and a docker installed
+	// later is picked up on the next refresh.
+	if _, err := w.lookPath("docker"); err != nil {
+		w.absent()
+		return
+	}
+
+	lctx, cancel := context.WithTimeout(ctx, w.timeout)
+	containers, err := w.list(lctx)
+	timedOut := errors.Is(lctx.Err(), context.DeadlineExceeded)
+	cancel()
+	if ctx.Err() != nil {
+		return // shutting down; this attempt says nothing about Docker
+	}
+	if err != nil {
+		if timedOut {
+			err = fmt.Errorf("`docker ps` did not answer within %s", w.timeout)
+		}
+		w.fail(err)
+		return
+	}
+
+	var st map[string]*ports.DockerStatsEntry
+	if wantStats {
+		st = statsEntries(w.stats(containers))
+	}
+	w.succeed(containers, st)
+}
+
+// fail records a failed attempt: keep the last good list, stop serving stats
+// and wait out the next backoff step.
+func (w *Watcher) fail(err error) {
+	w.mu.Lock()
+	w.failures++
+	wait := backoffFor(w.failures)
+	w.retryAt = w.now().Add(wait)
+	was := w.state
+	w.state = healthDown
+	w.lastErr = err
+	w.statsCache = nil
+	w.mu.Unlock()
+
+	if was != healthDown {
+		w.logger.Debug("docker is not answering; scans keep the last container list",
+			"error", err, "retry_in", wait)
+	}
+}
+
+// succeed records a good list and resets the backoff.
+func (w *Watcher) succeed(containers []container, st map[string]*ports.DockerStatsEntry) {
+	w.mu.Lock()
+	was, failures := w.state, w.failures
+	w.state = healthOK
+	w.failures = 0
+	w.retryAt = time.Time{}
+	w.lastErr = nil
+	changed := !reflect.DeepEqual(w.containers, containers)
+	w.containers = containers
+	w.statsCache = st
+	w.mu.Unlock()
+
+	if was == healthDown {
+		w.logger.Debug("docker is answering again", "failed_attempts", failures)
+	}
+	if changed && w.onChange != nil {
+		w.onChange()
+	}
+}
+
+// absent records that there is no docker on PATH.
+func (w *Watcher) absent() {
+	w.mu.Lock()
+	was := w.state
+	changed := len(w.containers) > 0
+	w.state = healthAbsent
+	w.failures = 0
+	w.retryAt = time.Time{}
+	w.lastErr = nil
+	w.containers = nil
+	w.statsCache = nil
+	w.mu.Unlock()
+
+	if was != healthAbsent {
+		w.logger.Debug("docker CLI not found; container enrichment is off")
+	}
+	if changed && w.onChange != nil {
+		w.onChange()
+	}
+}
+
+// backoffFor is the wait after the n-th consecutive failure: MinBackoff,
+// doubling, capped at MaxBackoff.
+func backoffFor(n int) time.Duration {
+	d := MinBackoff
+	for i := 1; i < n; i++ {
+		d *= 2
+		if d >= MaxBackoff {
+			return MaxBackoff
+		}
+	}
+	return d
+}

--- a/internal/docker/watch_test.go
+++ b/internal/docker/watch_test.go
@@ -1,0 +1,394 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+// fakeDocker is a scripted `docker ps` for a Watcher under test.
+type fakeDocker struct {
+	mu    sync.Mutex
+	calls int
+	stats int
+	// next is what the next `docker ps` returns.
+	containers []container
+	err        error
+}
+
+func (f *fakeDocker) list(context.Context) ([]container, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.containers, f.err
+}
+
+func (f *fakeDocker) set(cs []container, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.containers, f.err = cs, err
+}
+
+func (f *fakeDocker) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// clock is a manual clock.
+type clock struct{ t time.Time }
+
+func (c *clock) now() time.Time          { return c.t }
+func (c *clock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// harness is a Watcher wired to a fake docker, a manual clock and a captured
+// debug log. step does what one pass of Run does: refresh if due.
+type harness struct {
+	w       *Watcher
+	docker  *fakeDocker
+	clock   *clock
+	log     *bytes.Buffer
+	changes int
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	h := &harness{
+		docker: &fakeDocker{},
+		clock:  &clock{t: time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)},
+		log:    &bytes.Buffer{},
+	}
+	logger := slog.New(slog.NewTextHandler(h.log, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	h.w = NewWatcher(WatcherOptions{
+		Interval: 2 * time.Second,
+		Logger:   logger,
+		OnChange: func() { h.changes++ },
+		Now:      h.clock.now,
+	})
+	h.w.lookPath = func(string) (string, error) { return "/usr/local/bin/docker", nil }
+	h.w.list = h.docker.list
+	h.w.stats = func(cs []container) map[string]*ContainerStats {
+		h.docker.stats++
+		out := map[string]*ContainerStats{}
+		for _, c := range cs {
+			out[c.name] = &ContainerStats{CPUPercent: 1.5, State: "running"}
+		}
+		return out
+	}
+	return h
+}
+
+// step runs one refresh if one is due and reports whether it did.
+func (h *harness) step() bool {
+	if !h.w.due() {
+		return false
+	}
+	h.w.refresh(context.Background())
+	return true
+}
+
+var web = container{
+	name: "shop-web-1", image: "nginx:1.27",
+	portMappings:   []portMapping{{hostPort: 8080, containerPort: 80}},
+	composeService: "web", composeProject: "shop", composeWorkingDir: "/src/shop",
+}
+
+func TestBackoffScheduleDoublesToTheCap(t *testing.T) {
+	want := []time.Duration{
+		5 * time.Second, 10 * time.Second, 20 * time.Second, 40 * time.Second,
+		80 * time.Second, 160 * time.Second, 5 * time.Minute, 5 * time.Minute,
+	}
+	for i, w := range want {
+		if got := backoffFor(i + 1); got != w {
+			t.Errorf("backoffFor(%d) = %s, want %s", i+1, got, w)
+		}
+	}
+	if got := backoffFor(1000); got != MaxBackoff {
+		t.Errorf("backoffFor(1000) = %s, want the cap", got)
+	}
+}
+
+// A failing Docker is asked again only once each backoff step has passed,
+// however often scans poke, and one success resets the schedule.
+func TestFailingDockerBacksOffAndASuccessResets(t *testing.T) {
+	h := newHarness(t)
+	h.docker.set(nil, errors.New("Cannot connect to the Docker daemon"))
+
+	if !h.step() {
+		t.Fatal("the first refresh did not run")
+	}
+	for n := 1; n <= 8; n++ {
+		wait := backoffFor(n)
+		// Scans poke every second meanwhile; none of them may reach Docker.
+		for elapsed := time.Second; elapsed < wait; elapsed += time.Second {
+			h.clock.advance(time.Second)
+			h.w.Enrich([]ports.ListeningPort{{Port: 9000 + int(elapsed/time.Second)}})
+			if h.step() {
+				t.Fatalf("after failure %d a refresh ran %s in, before the %s backoff", n, elapsed, wait)
+			}
+		}
+		h.clock.advance(time.Second)
+		if !h.step() {
+			t.Fatalf("after failure %d no refresh ran once the %s backoff was up", n, wait)
+		}
+	}
+	if got := h.docker.count(); got != 9 {
+		t.Errorf("docker ps ran %d times, want 9", got)
+	}
+
+	h.docker.set([]container{web}, nil)
+	h.clock.advance(MaxBackoff)
+	if !h.step() {
+		t.Fatal("no refresh after the cap")
+	}
+	if !h.w.Healthy() {
+		t.Error("a successful docker ps did not mark the watcher healthy")
+	}
+	// Reset: the next refresh is one interval away, not a backoff step.
+	h.clock.advance(2 * time.Second)
+	if !h.step() {
+		t.Error("after a success the watcher still waited out a backoff")
+	}
+}
+
+// While Docker fails, scans keep enriching from the last list that answered.
+func TestFailingDockerServesTheLastGoodList(t *testing.T) {
+	h := newHarness(t)
+	h.docker.set([]container{web}, nil)
+	h.step()
+
+	h.docker.set(nil, errors.New("boom"))
+	h.clock.advance(2 * time.Second)
+	h.step()
+	if h.w.Healthy() {
+		t.Fatal("a failed docker ps left the watcher healthy")
+	}
+
+	pp := []ports.ListeningPort{{Port: 8080, Type: ports.PortTypeUser}}
+	h.w.Enrich(pp)
+	if pp[0].Type != ports.PortTypeDocker || pp[0].DockerContainer != "shop-web-1" ||
+		pp[0].DockerComposeProject != "shop" || pp[0].DockerComposeWorkingDir != "/src/shop" {
+		t.Errorf("port 8080 = %+v, want it enriched from the last good list", pp[0])
+	}
+}
+
+// No docker on PATH: never exec, never back off, say so once.
+func TestNoDockerInstalledStaysSilentAndCheap(t *testing.T) {
+	h := newHarness(t)
+	h.w.lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+
+	for i := 0; i < 50; i++ {
+		h.w.Enrich([]ports.ListeningPort{{Port: 3000 + i}})
+		h.step()
+		h.clock.advance(2 * time.Second)
+	}
+	if got := h.docker.count(); got != 0 {
+		t.Errorf("docker ps ran %d times with no docker installed", got)
+	}
+	if !h.w.retryAt.IsZero() || h.w.failures != 0 {
+		t.Errorf("not installed was treated as a failure: failures=%d retryAt=%s", h.w.failures, h.w.retryAt)
+	}
+	if n := strings.Count(h.log.String(), "\n"); n != 1 {
+		t.Errorf("logged %d lines, want exactly one:\n%s", n, h.log.String())
+	}
+}
+
+// The debug log names the transitions, not every tick.
+func TestLogsOnlyOnHealthChanges(t *testing.T) {
+	h := newHarness(t)
+	h.docker.set([]container{web}, nil)
+	h.step()
+	h.clock.advance(2 * time.Second)
+	h.step()
+	if h.log.Len() != 0 {
+		t.Fatalf("healthy refreshes logged:\n%s", h.log.String())
+	}
+
+	h.docker.set(nil, errors.New("`docker ps` did not answer within 5s"))
+	for i := 0; i < 4; i++ {
+		h.clock.advance(MaxBackoff)
+		h.step()
+	}
+	out := h.log.String()
+	if n := strings.Count(out, "docker is not answering"); n != 1 {
+		t.Errorf("logged the failure %d times, want once:\n%s", n, out)
+	}
+	if !strings.Contains(out, "did not answer within 5s") {
+		t.Errorf("the failure line does not carry the error:\n%s", out)
+	}
+
+	h.docker.set([]container{web}, nil)
+	h.clock.advance(MaxBackoff)
+	h.step()
+	h.clock.advance(2 * time.Second)
+	h.step()
+	if n := strings.Count(h.log.String(), "docker is answering again"); n != 1 {
+		t.Errorf("logged the recovery %d times, want once:\n%s", n, h.log.String())
+	}
+}
+
+// Routine refreshes are rate-limited to the interval; a port nobody knew about
+// asks for one early, a port already known or already published does not.
+func TestANewUnattributedPortAsksForAnEarlyRefresh(t *testing.T) {
+	h := newHarness(t)
+	h.docker.set([]container{web}, nil)
+	h.w.Enrich([]ports.ListeningPort{{Port: 3000}, {Port: 8080}})
+	h.step()
+
+	h.clock.advance(500 * time.Millisecond)
+	h.w.Enrich([]ports.ListeningPort{{Port: 3000}, {Port: 8080}})
+	if h.step() {
+		t.Error("an unchanged port set refreshed before the interval")
+	}
+
+	h.clock.advance(100 * time.Millisecond)
+	h.w.Enrich([]ports.ListeningPort{{Port: 3000}, {Port: 8080}, {Port: 5432}})
+	if !h.step() {
+		t.Error("a new port no container publishes did not ask for an early refresh")
+	}
+
+	// A new container arrives with the port: the change wakes the loop.
+	before := h.changes
+	db := container{name: "shop-db-1", portMappings: []portMapping{{hostPort: 5433, containerPort: 5432}}}
+	h.docker.set([]container{web, db}, nil)
+	h.clock.advance(100 * time.Millisecond)
+	h.w.Enrich([]ports.ListeningPort{{Port: 3000}, {Port: 8080}, {Port: 5432}, {Port: 5433}})
+	if !h.step() {
+		t.Fatal("no early refresh for port 5433")
+	}
+	if h.changes != before+1 {
+		t.Errorf("OnChange ran %d times for one changed list, want 1", h.changes-before)
+	}
+
+	// Now 5433 is published by a known container; seeing it again is not news.
+	h.clock.advance(100 * time.Millisecond)
+	h.w.Enrich([]ports.ListeningPort{{Port: 3000}, {Port: 8080}, {Port: 5432}, {Port: 5433}})
+	if h.step() {
+		t.Error("a known port asked for an early refresh")
+	}
+
+	// An unchanged list does not wake anyone.
+	h.clock.advance(2 * time.Second)
+	h.step()
+	if h.changes != before+1 {
+		t.Error("an unchanged list called OnChange")
+	}
+}
+
+// Stats are only collected once a scan asks, and dropped while Docker fails.
+func TestStatsAreCollectedOnDemandAndDroppedOnFailure(t *testing.T) {
+	h := newHarness(t)
+	h.docker.set([]container{web}, nil)
+	h.step()
+	if h.docker.stats != 0 {
+		t.Fatal("stats were collected before anyone asked")
+	}
+	if got := h.w.Stats(); got != nil {
+		t.Errorf("stats before the first collection = %v, want nil", got)
+	}
+	h.clock.advance(100 * time.Millisecond)
+	if !h.step() {
+		t.Fatal("the first Stats call did not ask for a refresh")
+	}
+	st := h.w.Stats()
+	if st["shop-web-1"] == nil || st["shop-web-1"].State != "running" {
+		t.Errorf("stats = %v, want shop-web-1", st)
+	}
+
+	h.docker.set(nil, errors.New("boom"))
+	h.clock.advance(2 * time.Second)
+	h.step()
+	if got := h.w.Stats(); got != nil {
+		t.Errorf("stats after a failure = %v, want none", got)
+	}
+}
+
+// The point of the step: a scan never waits on Docker, even while a
+// `docker ps` hangs, and the hanging one is cut off at the timeout.
+func TestAHangingDockerNeverBlocksAScan(t *testing.T) {
+	w := NewWatcher(WatcherOptions{Interval: time.Hour})
+	w.lookPath = func(string) (string, error) { return "/usr/local/bin/docker", nil }
+	w.timeout = 200 * time.Millisecond
+	started := make(chan struct{}, 1)
+	w.list = func(ctx context.Context) ([]container, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); w.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watcher never asked docker")
+	}
+
+	begin := time.Now()
+	for i := 0; i < 100; i++ {
+		pp := []ports.ListeningPort{{Port: 4000 + i}}
+		w.Enrich(pp)
+		_ = w.Stats()
+	}
+	if took := time.Since(begin); took > 100*time.Millisecond {
+		t.Errorf("100 scans' worth of Enrich took %s while docker ps hung", took)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		w.mu.Lock()
+		state, err := w.state, w.lastErr
+		w.mu.Unlock()
+		if state == healthDown {
+			if err == nil || !strings.Contains(err.Error(), "did not answer within 200ms") {
+				t.Errorf("lastErr = %v, want it to say the call timed out", err)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the hanging docker ps was never cut off")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A healthy docker's `ps` output still enriches a port with the container and
+// its compose labels, exactly as the inline path did.
+func TestParsePSFeedsEnrichment(t *testing.T) {
+	out := "shop-web-1\tnginx:1.27\t0.0.0.0:8080->80/tcp, :::8080->80/tcp\tweb\tshop\t/src/shop\n" +
+		"loose\tredis:7\t\t\t\t\n"
+	cs := parsePS([]byte(out))
+	if len(cs) != 2 {
+		t.Fatalf("parsed %d containers, want 2: %+v", len(cs), cs)
+	}
+
+	h := newHarness(t)
+	h.docker.set(cs, nil)
+	h.step()
+	pp := []ports.ListeningPort{{Port: 8080, BindAddress: "0.0.0.0"}, {Port: 8080, BindAddress: "::"}, {Port: 3000}}
+	h.w.Enrich(pp)
+	for _, p := range pp[:2] {
+		if p.Type != ports.PortTypeDocker || p.DockerContainer != "shop-web-1" || p.DockerImage != "nginx:1.27" ||
+			p.DockerComposeService != "web" || p.DockerComposeProject != "shop" ||
+			p.DockerComposeWorkingDir != "/src/shop" || p.DockerContainerPort != 80 {
+			t.Errorf("port %s:%d = %+v", p.BindAddress, p.Port, p)
+		}
+	}
+	if pp[2].Type == ports.PortTypeDocker {
+		t.Errorf("port 3000 was enriched: %+v", pp[2])
+	}
+}

--- a/internal/doctor/checks_extras.go
+++ b/internal/doctor/checks_extras.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/raskrebs/sonar/internal/daemon/rpc"
@@ -22,6 +23,15 @@ func checkDocker(ctx context.Context, env *Env) rpc.DoctorCheck {
 		}
 	}
 	version, err := env.Docker(ctx)
+	if errors.Is(err, ErrDockerNotAnswering) {
+		return rpc.DoctorCheck{
+			Status:  StatusWarn,
+			Summary: "docker CLI not answering",
+			Detail:  fmt.Sprintf("%s: %v", path, err),
+			Fix: "Docker is running but wedged: restart Docker Desktop (or the docker service); " +
+				"until then the daemon keeps the last container list it saw and retries with backoff",
+		}
+	}
 	if err != nil {
 		return rpc.DoctorCheck{
 			Status:  StatusWarn,

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -484,6 +484,19 @@ func TestDocker(t *testing.T) {
 		wantStatus(t, run(t, env, checkDocker), StatusWarn)
 	})
 
+	t.Run("hanging is reported as not answering, not as not installed", func(t *testing.T) {
+		env := fakeEnv(t)
+		env.LookPath = func(string) (string, error) { return "/usr/local/bin/docker", nil }
+		env.Docker = func(context.Context) (string, error) {
+			return "", fmt.Errorf("%w: `docker info` did not answer within 2s", ErrDockerNotAnswering)
+		}
+		got := run(t, env, checkDocker)
+		wantStatus(t, got, StatusWarn)
+		if got.Summary != "docker CLI not answering" {
+			t.Errorf("summary = %q, want %q", got.Summary, "docker CLI not answering")
+		}
+	})
+
 	t.Run("responding is ok", func(t *testing.T) {
 		env := fakeEnv(t)
 		env.LookPath = func(string) (string, error) { return "/usr/local/bin/docker", nil }

--- a/internal/doctor/probes.go
+++ b/internal/doctor/probes.go
@@ -28,17 +28,24 @@ func ReleaseProbe(ctx context.Context) (string, error) {
 	return tag, nil
 }
 
+// ErrDockerNotAnswering is DockerProbe's error when `docker info` hangs rather
+// than failing: the backend is up but wedged, which is a different fix from a
+// Docker that is simply not running.
+var ErrDockerNotAnswering = errors.New("docker CLI not answering")
+
 // DockerProbe asks the local docker daemon for its server version, within
 // NetworkBudget. An error means the CLI is installed but its daemon is not
 // answering — the state that quietly strips container names off every listing.
+// A timeout wraps ErrDockerNotAnswering.
 func DockerProbe(ctx context.Context) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, NetworkBudget)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
+	cmd.WaitDelay = time.Second
 	out, err := cmd.Output()
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return "", fmt.Errorf("`docker info` did not answer within %s", NetworkBudget)
+			return "", fmt.Errorf("%w: `docker info` did not answer within %s", ErrDockerNotAnswering, NetworkBudget)
 		}
 		var exit *exec.ExitError
 		if errors.As(err, &exit) && len(exit.Stderr) > 0 {

--- a/internal/scanner/loop.go
+++ b/internal/scanner/loop.go
@@ -133,7 +133,9 @@ type Options struct {
 	Remote func() state.Rows
 
 	// Scan overrides the OS scan. Tests inject a fake; production leaves it nil
-	// and gets ports.Scan + docker.EnrichPorts + ports.Enrich.
+	// and gets ports.Scan + ports.Enrich, with container data from a
+	// docker.Watcher's cached list rather than an inline `docker ps`
+	// (step 5A.8).
 	Scan func(include Include) ([]ports.ListeningPort, error)
 
 	// Graph overrides the OS lookup of established connections between
@@ -192,6 +194,12 @@ type Loop struct {
 	statsWake chan struct{}
 
 	attr attribution
+
+	// docker keeps the container list the production scan enriches from,
+	// refreshed in the background so no scan — and so no handler queued
+	// behind one — ever waits on the docker CLI (step 5A.8). Nil when a test
+	// injects its own Scan.
+	docker *docker.Watcher
 
 	// runGate admits one OS scan at a time. It is held from a scan's first
 	// system call to its last, so two scans can never overlap and a slow one
@@ -297,12 +305,6 @@ func New(opts Options) *Loop {
 	if opts.Publish == nil {
 		opts.Publish = func(state.Snapshot, state.Snapshot, []state.Event) {}
 	}
-	if opts.Scan == nil {
-		opts.Scan = osScan
-	}
-	if opts.Graph == nil {
-		opts.Graph = osGraph
-	}
 	if opts.Probe == nil {
 		opts.Probe = ports.ProbeHealth
 	}
@@ -317,7 +319,7 @@ func New(opts Options) *Loop {
 		now = time.Now
 	}
 	base := resolveScanInterval(opts.ScanInterval)
-	return &Loop{
+	l := &Loop{
 		opts:      opts,
 		now:       now,
 		base:      base,
@@ -328,6 +330,22 @@ func New(opts Options) *Loop {
 		orderGate: make(chan struct{}, 1),
 		interval:  base,
 	}
+	if l.opts.Scan == nil {
+		// The refresh cadence is the scan cadence: scans poke the watcher,
+		// and it asks Docker at most once per base interval. A refresh that
+		// changes the list wakes the loop, so a new container's port is
+		// enriched within one tick rather than one backed-off interval.
+		l.docker = docker.NewWatcher(docker.WatcherOptions{
+			Interval: base,
+			Logger:   opts.Logger,
+			OnChange: l.Wake,
+		})
+		l.opts.Scan = l.osScan
+	}
+	if l.opts.Graph == nil {
+		l.opts.Graph = l.osGraph
+	}
+	return l
 }
 
 // resolveScanInterval clamps a configured base scan interval. Zero (the unset
@@ -370,26 +388,36 @@ func lockFor(gate chan struct{}, d time.Duration) bool {
 func unlock(gate chan struct{}) { <-gate }
 
 // osScan is the production scan: the same pipeline `sonar list` runs, so the
-// daemon and the no-daemon path emit byte-identical rows.
-func osScan(include Include) ([]ports.ListeningPort, error) {
+// daemon and the no-daemon path emit the same rows — except that container
+// data and container stats come from the watcher's cache, at most one refresh
+// old, instead of from a `docker ps` this scan would wait on. A wedged Docker
+// used to cost every scan the whole docker.CLITimeout, and every `ports.kill`
+// and `state.snapshot` queued behind it (step 5A.8).
+func (l *Loop) osScan(include Include) ([]ports.ListeningPort, error) {
 	pp, err := ports.Scan()
 	if err != nil {
 		return nil, err
 	}
-	docker.EnrichPorts(pp)
+	l.docker.Enrich(pp)
 	ports.Enrich(pp)
 	if include.Stats {
-		ports.EnrichStats(pp, docker.AllContainerStatsAsEntries())
+		ports.EnrichStats(pp, l.docker.Stats())
 	}
 	return pp, nil
 }
 
 // osGraph is the production connection graph: the established links between
-// listening ports, plus the ones Docker only knows about.
-func osGraph(listening []ports.ListeningPort) ([]ports.Connection, error) {
+// listening ports, plus the ones Docker only knows about. The container half
+// is skipped while the watcher knows Docker is not answering: it is a
+// `docker inspect` and a `docker exec` per container, each of which would
+// wait out the CLI timeout.
+func (l *Loop) osGraph(listening []ports.ListeningPort) ([]ports.Connection, error) {
 	edges, err := ports.BuildGraph(listening)
 	if err != nil {
 		return nil, err
+	}
+	if l.docker != nil && !l.docker.Healthy() {
+		return edges, nil
 	}
 	containerEdges, err := docker.BuildDockerGraph(listening)
 	if err != nil {
@@ -525,13 +553,23 @@ func (l *Loop) Wake() {
 // a 1 s load sample does not have to wait for — or reset — an adaptive port
 // scan that may be 5 s apart.
 func (l *Loop) Run(ctx context.Context) {
-	var stats sync.WaitGroup
-	stats.Add(1)
+	var background sync.WaitGroup
+	background.Add(1)
 	go func() {
-		defer stats.Done()
+		defer background.Done()
 		l.runStats(ctx)
 	}()
-	defer stats.Wait()
+	if l.docker != nil {
+		// The docker watcher refreshes the container list the scans read,
+		// in its own goroutine for the same reason: nothing on the scan
+		// path waits on the docker CLI.
+		background.Add(1)
+		go func() {
+			defer background.Done()
+			l.docker.Run(ctx)
+		}()
+	}
+	defer background.Wait()
 
 	timer := time.NewTimer(time.Hour)
 	defer timer.Stop()


### PR DESCRIPTION
Roadmap step 5A.8: a slow Docker must not stall the daemon.

## What was wrong
On a Mac where Docker Desktop's backend was running but wedged, `docker ps` never answered. Every daemon scan ran `docker ps` inline (`scanLocked` → `osScan` → `docker.EnrichPorts` → `listContainers`), bounded only by `CLITimeout` (10 s), inside the gate that RPC scans (`Rescan`, `SnapshotAll`) queue behind. So `ports.kill` took over 25 s, and the `state.snapshot` calls queued behind it hit the client's 10 s timeout. The desktop's real-daemon e2e suite failed from the kill test onwards, on both v0.6.6 and main. The same daemon with no `docker` on PATH killed in 0.38 s.

## What changed
- **`docker.Watcher`** (`internal/docker/watch.go`) keeps the container list off the scan path. A scan only reads the cached list (`Enrich`, `Stats`) and pokes the watcher; it never runs a docker command. The watcher refreshes in its own goroutine, started and waited for by `Loop.Run`:
  - **Cadence:** tied to scans. Each scan pokes, and a refresh runs at most once per base scan interval (2 s by default). When the loop is parked there are no scans, so no `docker ps` either.
  - **Early refresh:** a scan that sees a port it had not seen before, and that no cached container publishes, asks for a refresh right away.
  - **Wake on change:** a refresh that changes the list calls `Loop.Wake`, so a new container's port is enriched within one tick instead of one backed-off interval.
  - **Timeout:** background `docker ps` has its own 5 s timeout (`PSTimeout`). Nothing waits on it; it only sets how soon a hang is noticed.
  - **Backoff:** a failed or timed-out `ps` backs off 5 s, 10 s, 20 s … capped at 5 min. Meanwhile the watcher keeps serving the last good list (empty if there never was one) and drops container stats. One success resets it.
  - **Not installed:** `LookPath` fails, so there is no exec, no backoff and one debug line.
  - **Logging:** debug lines only on state changes (healthy → not answering with the error and the retry delay; answering again; CLI not found), never per tick.
- **Compose attribution is unchanged:** the watcher stamps the same `ListeningPort` fields as `EnrichPorts` (container, image, compose service, project, working dir, container port). `groups.AttributeWith` → `Index.AddComposeProject` reads those fields exactly as before.
- **Container stats** (`include: ["stats"]`) also come from the watcher. It fetches them after a successful `ps`, only while a scan asked for them in the last 30 s. The loop's own tick used to call `docker ps` plus stats inline too.
- **`ports.graph` / `ports.inspect`:** the container half of the graph (`docker inspect` / `docker exec`) is skipped while the watcher knows Docker is not answering.
- **Unchanged:** the one-shot CLI paths (`docker.EnrichPorts` in `sonar list` without a daemon, `killer.scanPorts`) and explicit actions (`docker stop`, `docker logs`). `docker stop` runs in `killer.KillPorts` after `killSnapshot` has released the gates, so it never held the scan/RPC gate.
- **Doctor:** the `docker` check now reports a `docker info` timeout as **"docker CLI not answering"**, apart from "docker is not installed" (skip) and an erroring daemon (existing wording).
- No wire, schema or CLI changes (`go generate ./... && git diff --exit-code docs/schema` is clean).

## Tests
- Unit (`internal/docker/watch_test.go`), injectable `docker ps` and clock:
  - backoff schedule and cap, with scans poking every second during it
  - reset on success
  - last good list served while failing
  - not installed never execs and logs once
  - logs only on transitions
  - a new unattributed port asks for an early refresh; `OnChange` fires only when the list changes
  - stats collected on demand and dropped on failure
  - a hanging `ps` never blocks `Enrich`/`Stats` (100 calls in well under 100 ms) and is cut off at the timeout
  - healthy `ps` output enriches with container and compose data
- Integration (`-tags integration`, `internal/daemon/docker_integration_test.go`), with a fake `docker` first on PATH:
  - **Hung docker** (`exec sleep 60`), real listener. With this branch: `ports.kill` **0.41 s**; three `state.snapshot` calls spaced past the cache (so each scans) **0.8 ms / 153 ms / 145 ms**; `docker ps` ran **once** in the ~5 s after the kill began (backoff held).
  - **Red check,** same test against main's `internal/scanner/loop.go`: `ports.kill` **20.5 s**, snapshots **10.2 s / 10.2 s**.
  - **Healthy docker:** a fake `ps` publishing the listener's port as `itest-web-1` in compose project `itestproj`. The port comes back `type: docker` with container, image, compose service/project and container port, and `group: itestproj`.
- Gates:
  - `go build ./... && go vet ./... && gofmt -l .`: clean
  - `go test ./...`: green, apart from the known `TestChildrenInheritTheRunRootAsTMPDIR` (fails only with GOTMPDIR set; passes without it, roadmap 1A.18)
  - `go test -tags integration ./internal/daemon/`: green
  - `go test -race ./internal/docker/`: green

## Trade-offs
- A container's data is at most one refresh old. On a daemon's very first scan (before the first `ps` returns) or for a container started a moment ago, the first snapshot can show the port unenriched for one tick before it flips to `docker`.
- While Docker is wedged, the last good list is kept on purpose. If a native process takes over a port a cached container used to publish during that window, it reads as that container until Docker answers again.
