### PR TITLE
fix: a stale container list must not claim a native process's port (5A.9)

### DIFF
--- a/internal/daemon/docker_integration_test.go
+++ b/internal/daemon/docker_integration_test.go
@@ -155,7 +155,9 @@ func TestAHealthyDockerStillEnrichesAndGroups(t *testing.T) {
 	defer cancel()
 	c := e.connect(ctx)
 
-	startListener(t, listener, e.home, port)
+	// Since 5A.9 only a port Docker's forwarder holds takes container data,
+	// so the listener runs under the forwarder's name.
+	startListener(t, forwarderCopy(t, listener), e.home, port)
 
 	var row *state.Port
 	deadline := time.Now().Add(20 * time.Second)
@@ -187,5 +189,123 @@ func TestAHealthyDockerStillEnrichesAndGroups(t *testing.T) {
 	}
 	if row.Group == nil || *row.Group != "itestproj" {
 		t.Errorf("group = %v, want the compose project itestproj", deref(row.Group))
+	}
+}
+
+// forwarderCopy copies the listener helper under the name of this platform's
+// Docker port forwarder, so the scanner reports it the way it reports a real
+// published container port: "com.docke" through lsof on macOS, "docker-proxy"
+// through ss on Linux.
+func forwarderCopy(t *testing.T, listener string) string {
+	t.Helper()
+	name := "com.docker.backend"
+	if runtime.GOOS == "linux" {
+		name = "docker-proxy"
+	}
+	b, err := os.ReadFile(listener)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(bin, b, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// TestAStaleContainerListDoesNotClaimANativePort is step 5A.9's regression
+// test (issue #95). Docker answers once, publishing the port as itest-web-1,
+// then wedges, so the watcher keeps serving that list. A native process then
+// takes the port. The row must not carry the container, and `ports.kill` must
+// signal the process instead of running `docker stop`.
+func TestAStaleContainerListDoesNotClaimANativePort(t *testing.T) {
+	listener, err := buildListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := freePort(t)
+	wedge := filepath.Join(t.TempDir(), "wedged")
+	ps := "itest-web-1\tnginx:itest\t0.0.0.0:" + strconv.Itoa(port) + "->80/tcp\tweb\titestproj\t" + t.TempDir()
+	path, calls := fakeDockerOnPath(t, "case \"$1\" in\nps)\n"+
+		"  if [ -e '"+wedge+"' ]; then exec sleep 60; fi\n"+
+		"  cat <<'EOF'\n"+ps+"\nEOF\n;;\n*) exit 1 ;;\nesac\n")
+
+	e := newEnv(t)
+	e.extra = []string{path}
+	e.serve()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	c := e.connect(ctx)
+
+	snapshot := func() state.Snapshot {
+		t.Helper()
+		var snap state.Snapshot
+		if err := c.Call(ctx, "state.snapshot", rpc.StateSnapshotParams{}, &snap); err != nil {
+			t.Fatalf("state.snapshot: %v", err)
+		}
+		return snap
+	}
+
+	// Let the watcher cache the list: the second `docker ps` only starts
+	// once the first has answered. Snapshots keep the scanner (and so the
+	// watcher) running.
+	deadline := time.Now().Add(20 * time.Second)
+	for dockerCalls(calls, "ps") < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("docker ps ran %d times, want 2 before wedging it", dockerCalls(calls, "ps"))
+		}
+		snapshot()
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	// Docker wedges; from here the cached list can only go stale.
+	if err := os.WriteFile(wedge, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	startListener(t, listener, e.home, port)
+
+	var row *state.Port
+	deadline = time.Now().Add(20 * time.Second)
+	for row == nil {
+		if time.Now().After(deadline) {
+			t.Fatalf("port %d never showed up", port)
+		}
+		time.Sleep(250 * time.Millisecond)
+		snap := snapshot()
+		for i := range snap.Ports {
+			if snap.Ports[i].Port == port {
+				row = &snap.Ports[i]
+			}
+		}
+	}
+	t.Logf("row: process=%q type=%s docker=%+v", row.Process, row.Type, row.Docker)
+	if row.Docker != nil || row.Type == state.TypeDocker {
+		t.Errorf("the native listener's row carries the cached container: type=%s docker=%+v", row.Type, row.Docker)
+	}
+
+	begin := time.Now()
+	var killed rpc.KillEnvelope
+	if err := c.Call(ctx, "ports.kill", rpc.PortsKillParams{
+		Targets: []rpc.Selector{{Port: &port}},
+	}, &killed); err != nil {
+		t.Fatalf("ports.kill: %v", err)
+	}
+	t.Logf("ports.kill took %s: %+v", time.Since(begin), killed.Results)
+	if len(killed.Results) == 0 {
+		t.Fatal("ports.kill returned no rows")
+	}
+	if r := killed.Results[0]; !r.OK || r.Method == state.MethodDockerStop {
+		t.Errorf("ports.kill row = %+v, want the listener signalled", r)
+	}
+	if n := dockerCalls(calls, "stop"); n != 0 {
+		t.Errorf("docker stop ran %d times for a port a native process held", n)
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for portOpen(port) {
+		if time.Now().After(deadline) {
+			t.Fatalf("port %d is still open after the kill", port)
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -60,6 +60,9 @@ func publishedPorts(containers []container) map[int]bool {
 // enrichFrom marks every port a container publishes as Docker's and copies the
 // container's name, image and compose labels onto it. It only reads
 // containers, so a Watcher can hand it the cached list without copying.
+//
+// A port the list claims but some other process holds is left alone: see
+// heldByForwarder.
 func enrichFrom(pp []ports.ListeningPort, containers []container) {
 	if len(containers) == 0 {
 		return
@@ -80,6 +83,15 @@ func enrichFrom(pp []ports.ListeningPort, containers []container) {
 	for i := range pp {
 		c, ok := hostPortMap[pp[i].Port]
 		if !ok {
+			continue
+		}
+		if !heldByForwarder(&pp[i]) {
+			// The list says a container publishes this port, but a native
+			// process holds it. The list can be stale — the watcher keeps
+			// serving its last good one while Docker is not answering — and
+			// stamping the row would make `ports.kill` run `docker stop`
+			// against the wrong thing instead of signalling the real owner
+			// (issue #95).
 			continue
 		}
 		pp[i].Type = ports.PortTypeDocker

--- a/internal/docker/export_test.go
+++ b/internal/docker/export_test.go
@@ -1,0 +1,10 @@
+package docker
+
+import "github.com/raskrebs/sonar/internal/ports"
+
+// EnrichFromPS stamps pp from `docker ps --format psFormat` output, as a scan
+// does from the watcher's cached list. It lets the external test package drive
+// enrichment into the killer, which it cannot import from inside the package.
+func EnrichFromPS(pp []ports.ListeningPort, out []byte) {
+	enrichFrom(pp, parsePS(out))
+}

--- a/internal/docker/forwarder.go
+++ b/internal/docker/forwarder.go
@@ -1,0 +1,111 @@
+package docker
+
+import (
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+// Docker does not hand a host port to the container: a helper process on the
+// host holds the listening socket and forwards what arrives into the VM or the
+// container's network namespace. That helper is the only honest sign, without
+// asking Docker anything, that a host port really is a container's — which is
+// what step 5A.9 needs, because the check has to hold while Docker is wedged
+// and the cached container list cannot be refreshed (issue #95).
+//
+// The names are what a port scanner reports as the process: lsof's COMMAND on
+// macOS, ss's comm on Linux, tasklist's image name on Windows. Both lsof and
+// comm truncate (lsof to 9 characters by default, comm to 15), so a name is
+// also matched as a prefix of a full name — see forwarderProcess.
+var forwarderNames = []string{
+	// Docker Desktop's backend holds every published port on macOS and
+	// Windows; it is `com.docker.backend.exe` there. Verified on macOS with
+	// Docker Engine 29.2.1 (Docker Desktop): a container published with `-p 47311:80`
+	// is held by /Applications/Docker.app/Contents/MacOS/com.docker.backend,
+	// which lsof reports as the truncated "com.docke".
+	"com.docker.backend",
+	// Older Docker Desktop builds forwarded through vpnkit, either as its own
+	// binary or under the com.docker prefix.
+	"vpnkit",
+	"com.docker.vpnkit",
+	"com.docker.proxy",
+	// The Linux engine's userland proxy. With `userland-proxy: false` nothing
+	// listens on the host at all — the port is DNAT'd — so such a port never
+	// reaches a scan and never needs this check.
+	"docker-proxy",
+	// Rootless Docker forwards through RootlessKit's port driver instead.
+	"rootlesskit",
+	"rootlessport",
+	"slirp4netns",
+}
+
+// minTruncatedName is the shortest prefix accepted as a truncated forwarder
+// name. lsof truncates to 9 characters by default, so every name a scanner can
+// report is at least that long; requiring 8 keeps a short native process name
+// from matching one of the longer forwarders by accident.
+const minTruncatedName = 8
+
+// heldByForwarder reports whether the cached container list may speak for this
+// port: true when Docker's own forwarder holds it, false when some other
+// process does.
+//
+// A port whose owner the scan could not name at all is not evidence either
+// way, so the container list still applies to it. That is the case on Windows,
+// where `netstat -ano` reports pids without names and ports.Enrich only fills
+// the names in after this pass — the check is inert there, and the behaviour
+// is exactly what it was before 5A.9.
+func heldByForwarder(p *ports.ListeningPort) bool {
+	name := p.Process
+	if name == "" {
+		name = firstWord(p.Command)
+	}
+	if name == "" {
+		return true
+	}
+	return isForwarderProcess(name)
+}
+
+// isForwarderProcess reports whether a process name is one of Docker's port
+// forwarders, allowing for the truncation lsof and comm apply.
+func isForwarderProcess(name string) bool {
+	name = normalizeProcess(name)
+	if name == "" {
+		return false
+	}
+	for _, want := range forwarderNames {
+		if name == want {
+			return true
+		}
+		if len(name) >= minTruncatedName && len(name) < len(want) && strings.HasPrefix(want, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeProcess reduces a scanner's process name to something comparable:
+// lower case, no directory, no Windows executable suffix.
+func normalizeProcess(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if i := strings.LastIndexAny(name, `/\`); i >= 0 {
+		name = name[i+1:]
+	}
+	return strings.TrimSuffix(name, ".exe")
+}
+
+// firstWord is the executable of a command line, used only as a fallback when
+// the scanner reported no process name. A quoted executable (a Windows path
+// with spaces in it) is read up to its closing quote.
+func firstWord(command string) string {
+	command = strings.TrimSpace(command)
+	if rest, ok := strings.CutPrefix(command, `"`); ok {
+		if i := strings.IndexByte(rest, '"'); i >= 0 {
+			return rest[:i]
+		}
+		return rest
+	}
+	if i := strings.IndexAny(command, " \t"); i >= 0 {
+		command = command[:i]
+	}
+	return command
+}

--- a/internal/docker/forwarder_test.go
+++ b/internal/docker/forwarder_test.go
@@ -1,0 +1,89 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/ports"
+)
+
+func TestIsForwarderProcess(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		// What the scanners really report for Docker's forwarders.
+		{"com.docke", true},              // macOS lsof, truncated to 9 (verified)
+		{"com.docker.backend", true},     // lsof +c 0, ps comm basename
+		{"com.docker.back", true},        // Linux comm, truncated to 15
+		{"com.docker.backend.exe", true}, // Windows tasklist
+		{"COM.DOCKER.BACKEND.EXE", true}, // Windows is case-insensitive
+		{"vpnkit", true},                 // older Docker Desktop
+		{"vpnkit.exe", true},             // older Docker Desktop on Windows
+		{"docker-proxy", true},           // Linux userland proxy
+		{"docker-pr", true},              // docker-proxy through lsof
+		{"rootlesskit", true},            // rootless Docker
+		{"rootlessport", true},           // rootless Docker
+		{"slirp4netns", true},            // rootless Docker
+		{"/usr/bin/docker-proxy", true},  // a path, not a bare name
+		{`C:\Docker\vpnkit.exe`, true},   // a Windows path
+		{"node", false},                  // the native processes #95 is about
+		{"python3", false},               // ...
+		{"postgres", false},              // ...
+		{"docker", false},                // the CLI never holds a published port
+		{"dockerd", false},               // nor does the engine on Linux
+		{"com.docker.backendx", false},   // longer than a real name is not a truncation
+		{"vpn", false},                   // a short prefix is not a truncation
+		{"docker-", false},               // under minTruncatedName
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isForwarderProcess(c.name); got != c.want {
+			t.Errorf("isForwarderProcess(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestHeldByForwarder(t *testing.T) {
+	cases := []struct {
+		label string
+		row   ports.ListeningPort
+		want  bool
+	}{
+		{"forwarder by name", ports.ListeningPort{Process: "com.docke"}, true},
+		{"native by name", ports.ListeningPort{Process: "node"}, false},
+		{"the name wins over the command", ports.ListeningPort{Process: "node", Command: "/usr/bin/docker-proxy -proto tcp"}, false},
+		{"forwarder by command", ports.ListeningPort{Command: "/Applications/Docker.app/Contents/MacOS/com.docker.backend services"}, true},
+		{"forwarder by quoted command", ports.ListeningPort{Command: `"C:\Program Files\Docker\Docker\resources\com.docker.backend.exe" --x`}, true},
+		{"native by command", ports.ListeningPort{Command: "node server.js"}, false},
+		// Windows' netstat names nothing before ports.Enrich: no evidence, so
+		// the cached list keeps applying.
+		{"owner unknown", ports.ListeningPort{PID: 4242}, true},
+	}
+	for _, c := range cases {
+		if got := heldByForwarder(&c.row); got != c.want {
+			t.Errorf("%s: heldByForwarder = %v, want %v", c.label, got, c.want)
+		}
+	}
+}
+
+// TestEnrichSkipsAPortANativeProcessHolds is issue #95 at the enrichment step:
+// the cached list says itest-web-1 publishes 3000, but node holds 3000 now.
+func TestEnrichSkipsAPortANativeProcessHolds(t *testing.T) {
+	containers := parsePS([]byte("itest-web-1\tnginx:itest\t0.0.0.0:3000->80/tcp\tweb\titestproj\t/src/app\n"))
+
+	native := []ports.ListeningPort{{Port: 3000, PID: 501, Process: "node", Type: ports.PortTypeUser}}
+	enrichFrom(native, containers)
+	if p := native[0]; p.Type == ports.PortTypeDocker || p.DockerContainer != "" || p.DockerImage != "" ||
+		p.DockerComposeProject != "" || p.DockerComposeService != "" || p.DockerContainerPort != 0 {
+		t.Errorf("a port node holds was stamped from the cached list: %+v", p)
+	}
+
+	forwarded := []ports.ListeningPort{{Port: 3000, PID: 77, Process: "com.docke"}}
+	enrichFrom(forwarded, containers)
+	p := forwarded[0]
+	if p.Type != ports.PortTypeDocker || p.DockerContainer != "itest-web-1" || p.DockerImage != "nginx:itest" ||
+		p.DockerComposeService != "web" || p.DockerComposeProject != "itestproj" ||
+		p.DockerComposeWorkingDir != "/src/app" || p.DockerContainerPort != 80 {
+		t.Errorf("the forwarder's port lost its container data: %+v", p)
+	}
+}

--- a/internal/docker/stale_kill_test.go
+++ b/internal/docker/stale_kill_test.go
@@ -1,0 +1,65 @@
+package docker_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/docker"
+	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/ports"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// cachedPS is a container list the watcher could still be serving after
+// Docker stopped answering: itest-web-1 published 3000.
+const cachedPS = "itest-web-1\tnginx:itest\t0.0.0.0:3000->80/tcp\tweb\titestproj\t/src/app\n"
+
+// planKill is what `ports.kill` on port 3000 would do with rows, without doing
+// it.
+func planKill(t *testing.T, rows []ports.ListeningPort) killer.Result {
+	t.Helper()
+	results := killer.KillPorts(context.Background(), []killer.Target{{Port: 3000}},
+		killer.Options{Ports: rows, DryRun: true})
+	if len(results) != 1 {
+		t.Fatalf("results = %+v, want one row", results)
+	}
+	return results[0]
+}
+
+// TestAStaleContainerPortHeldByANativeProcessKillsTheProcess is issue #95: the
+// cached list still says a container publishes 3000, but a native process
+// took the port over. The kill must signal that process, not `docker stop`
+// the container.
+func TestAStaleContainerPortHeldByANativeProcessKillsTheProcess(t *testing.T) {
+	// A real pid, so the dry run can resolve it; nothing is signalled.
+	pid := os.Getpid()
+	rows := []ports.ListeningPort{{Port: 3000, PID: pid, Process: "node", BindAddress: "127.0.0.1", Type: ports.PortTypeUser}}
+	docker.EnrichFromPS(rows, []byte(cachedPS))
+
+	if rows[0].DockerContainer != "" || rows[0].Type == ports.PortTypeDocker {
+		t.Fatalf("the native row was stamped with the cached container: %+v", rows[0])
+	}
+	r := planKill(t, rows)
+	if r.Method == state.MethodDockerStop {
+		t.Fatalf("the kill would docker-stop a container for a port node holds: %+v", r)
+	}
+	if r.Method != state.MethodSIGTERM || r.PID != pid || !r.OK {
+		t.Errorf("row = %+v, want SIGTERM to pid %d", r, pid)
+	}
+}
+
+// TestAContainerPortHeldByTheForwarderStopsTheContainer is the other half: the
+// same port held by Docker's forwarder still stops the container.
+func TestAContainerPortHeldByTheForwarderStopsTheContainer(t *testing.T) {
+	rows := []ports.ListeningPort{{Port: 3000, PID: os.Getpid(), Process: "com.docke", BindAddress: "127.0.0.1"}}
+	docker.EnrichFromPS(rows, []byte(cachedPS))
+
+	if rows[0].DockerContainer != "itest-web-1" || rows[0].Type != ports.PortTypeDocker {
+		t.Fatalf("the forwarder's row was not stamped: %+v", rows[0])
+	}
+	r := planKill(t, rows)
+	if r.Method != state.MethodDockerStop || r.PID != 0 || !r.OK {
+		t.Errorf("row = %+v, want docker_stop", r)
+	}
+}


### PR DESCRIPTION
Roadmap step 5A.9. Fixes #95.

## What was wrong
Since #94 a scan stamps container data from the watcher's **cached** `docker ps` list, and keeps serving the last good list while Docker isn't answering. If a native process took over a host port that a cached container used to publish, the scan still stamped the port as that container's. The row showed container data that wasn't true, and `ports.kill` took the container path (`docker stop <name>`) against a Docker that wasn't answering. The kill failed and the real process kept the port.

## What changed
- **`heldByForwarder`** (`internal/docker/forwarder.go`): cached container data goes onto a port only when the process holding it is Docker's own port forwarder. A port held by any other process is native, whatever the list says. The check reads only what the scanner already has (the process name, or the executable from the command line), so it needs no Docker call and still works while Docker is wedged.
- **`enrichFrom`** calls it before stamping. `enrichFrom` is the single place both the daemon's watcher (`Watcher.Enrich`) and the one-shot CLI path (`EnrichPorts`, used by `sonar list --no-daemon` and `killer.scanPorts`) stamp container data, so both follow the same rule.
- `ports.kill` needs no change. The killer already takes the container path only for a row with `DockerContainer` set, so a native row is signalled.
- No wire, schema or CLI changes (`go generate ./... && git diff --exit-code docs/schema` is clean).

### How the forwarder is identified
One name list for every platform, compared case-insensitively, with the directory and `.exe` stripped:

| Name | Where |
|---|---|
| `com.docker.backend` | Docker Desktop, macOS and Windows (`.exe`), and Docker Desktop for Linux |
| `vpnkit`, `com.docker.vpnkit`, `com.docker.proxy` | older Docker Desktop forwarders |
| `docker-proxy` | Linux engine, userland proxy |
| `rootlesskit`, `rootlessport`, `slirp4netns` | rootless Docker port drivers |

lsof truncates COMMAND to 9 characters and Linux comm to 15, so a name of 8 or more characters that is a prefix of a listed name also matches. `com.docke` matches, `vpn` does not.

**Verified on this Mac** (Docker Desktop, engine 29.2.1): `docker run -p 47311:80 caddy` is held by `/Applications/Docker.app/Contents/MacOS/com.docker.backend`, which `lsof` reports as `com.docke`. With this branch, `sonar list --no-daemon --json -a` shows that port as `type: docker`, container `sonar-5a9-probe`, and `sonar kill --no-daemon --dry-run 47311` plans `docker_stop`. On Linux, `docker-proxy` is what the existing test fixtures use (`internal/mcpserver/fakedaemon`). With `userland-proxy: false` nothing listens on the host (the port is DNAT'd), so such a port never reaches a scan.

### Where the owner can't be named
On **Windows**, `netstat -ano` gives pids only, and `ports.Enrich` fills in names *after* the Docker pass. A row with no process name and no command is not evidence either way, so the cached list still applies to it. The check does nothing there, and Windows behaves exactly as before. I chose this over treating the row as native, because treating it as native would remove container data from every published port on Docker Desktop for Windows, even with Docker healthy. Making the check work on Windows would mean naming processes before the Docker pass (a `tasklist` per scan); that belongs in a follow-up.

**Not recognised:** runtimes whose host forwarder isn't one of Docker's. Colima/Lima forward through `ssh`, and OrbStack's helper isn't in the list. Their published ports now read as native. The Docker CLI works against them, but nothing in sonar supported them specifically before. If they need support, it is one more entry in the list, except `ssh`, which is too generic.

## Tests
- **Unit** (`internal/docker/forwarder_test.go`): name matching (real and truncated names, paths, `.exe`, case, native names, short prefixes); `heldByForwarder` by name, by command line (including a quoted Windows path), and with an unknown owner; `enrichFrom` does not stamp a port `node` holds and fully stamps the same port held by `com.docke`.
- **Unit, down to the kill** (`internal/docker/stale_kill_test.go`, `killer.KillPorts` with `DryRun`): with a cached container claiming 3000, a native holder plans `sigterm` to its pid, and the forwarder holder plans `docker_stop`.
- **Integration** (`-tags integration`, `internal/daemon/docker_integration_test.go`):
  - New `TestAStaleContainerListDoesNotClaimANativePort`: a fake `docker` answers `ps` twice with the port published as `itest-web-1`, then wedges (`exec sleep 60`). A native listener then takes the port. The row comes back `type=user docker=<nil>`, and `ports.kill` sends **SIGTERM** to the listener in **0.55 s**. `docker stop` never runs, and the port closes.
  - **Red check**, same test with `heldByForwarder` forced to true: the row is `type=docker` with `itest-web-1`, `ports.kill` runs `docker_stop` → `failed to stop container itest-web-1: exit status 1`, and the port stays open. That is #95 exactly. The three new unit tests also fail.
  - `TestAHealthyDockerStillEnrichesAndGroups` now runs its listener under the forwarder's name (`com.docker.backend` → lsof `com.docke`; `docker-proxy` on Linux). It still gets the container, image, compose service/project, container port and `group: itestproj`.
  - `TestAHungDockerDoesNotStallKillOrSnapshot` is unchanged and green (kill 0.55 s, snapshots 1 ms / 211 ms / 214 ms, `docker ps` ran once).
- **Gates:**
  - `go build ./... && go vet ./... && gofmt -l .`: clean
  - `go test ./...`: green apart from the known `TestChildrenInheritTheRunRootAsTMPDIR` (fails only with GOTMPDIR set, #93)
  - `go test -tags integration ./internal/docker/ ./internal/daemon/`: green
  - `go test -race ./internal/docker/`: green
  - `go generate ./... && git diff --exit-code docs/schema`: clean
