### PR TITLE
feat: sonar start runs a project in the foreground, -d and sonar down

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,48 @@ sonar completion fish | source                 # fish
 
 ## Sixty seconds
 
-Prefix the commands in your `dev.sh` with `sonar start`:
+Describe how your project runs in a `sonar.yaml` at the repository root, in
+place of a `dev.sh`:
 
-```sh
-#!/usr/bin/env bash
-sonar start --name db       --port 5432 -- docker compose up db &
-sonar start --name api      --port 8000 -- uv run uvicorn app:app &
-sonar start --name frontend --port 5173 -- npm run dev &
-wait
+```yaml
+name: my-app
+services:
+  - name: db
+    cmd: docker compose up db
+    port: 5432
+  - name: api
+    cmd: uv run uvicorn app:app --port ${port}
+    port: auto
+    depends_on: [db]
+  - name: frontend
+    cmd: npm run dev -- --port ${port} --strictPort
+    port: auto
+    depends_on: [api]
+    env:
+      VITE_API_URL: ${api.url}
 ```
 
-The group name comes from the repository, so nothing else needs configuring.
-In another terminal:
+Then start it:
+
+```sh
+sonar start
+```
+
+```
+  ✓ db        port 5432  pid 41022  ~/.config/sonar/logs/my-app/db.log
+  ✓ api       port 21408  pid 41040  ~/.config/sonar/logs/my-app/api.log
+  ✓ frontend  port 21409  pid 41077  ~/.config/sonar/logs/my-app/frontend.log
+
+3 started
+following the logs; Ctrl+C stops the 3 services started here
+api      | INFO:     Uvicorn running on http://127.0.0.1:21408
+frontend | VITE v5.4  ready in 312 ms
+```
+
+Sonar picks a free port for every `port: auto` service and tells each service
+where the others are, so a second worktree runs next to the first without a
+single port clashing. `sonar start -d` does the same in the background, and
+`sonar down` stops it and gives the ports back. In another terminal:
 
 ```sh
 sonar list --tree
@@ -111,16 +141,13 @@ sonar list --tree
 
 ```
 my-app  (3 ports, running)                        ~/code/my-app
-├─ 5432  db          postgres:17                  http://localhost:5432
-├─ 5173  frontend    vite (v5.4)                  http://localhost:5173
-└─ 8000  api         uvicorn app:app              http://localhost:8000
+├─ 5432   db          postgres:17                 http://localhost:5432
+├─ 21408  api         uvicorn app:app             http://localhost:21408
+└─ 21409  frontend    vite (v5.4)                 http://localhost:21409
 ```
 
-And when you are done, stop the whole project — servers, watchers and workers:
-
-```sh
-sonar kill -g my-app
-```
+No `sonar.yaml`? `sonar start -- npm run dev` runs one command as a named
+service, and `sonar list` and `sonar kill` work on anything that is listening.
 
 Examples below marked `# check` are executed against a fresh build by
 `scripts/readme-check.sh` on every CI run.
@@ -162,7 +189,22 @@ hidden unless you pass `-a`.
 
 ### `sonar start`
 
-Run a command as a named service in a group:
+Start a project from its `sonar.yaml`:
+
+```sh
+sonar start                    # every service in the nearest sonar.yaml
+sonar start api frontend       # only these (they still wait for their dependencies)
+sonar start ../other-project   # the sonar.yaml in or above another directory
+sonar start -d                 # in the background, like `sonar up`
+```
+
+In the foreground, sonar starts the services through the daemon, follows their
+logs with the service name in front of every line, and when you press Ctrl+C
+stops the services it started. A service that was already running is left
+alone, and sonar returns by itself once every service it started has exited.
+
+Arguments before `--` name a directory or services; everything after `--` is a
+command. Or run one command as a named service in a group:
 
 ```sh
 sonar start -- npm run dev
@@ -230,7 +272,7 @@ ports: [9229]        # ports that belong to this project without a service
 ```
 
 - `name` — the group name. No slashes, no whitespace.
-- `cmd`, `cwd`, `port` — how `sonar up` starts the service. `cwd` is relative to
+- `cmd`, `cwd`, `port` — how `sonar start` starts the service. `cwd` is relative to
   the file and may not escape its directory.
 - `health` — an HTTP path the daemon polls while the service is up, so a
   service can be *running* but not yet *healthy*. It reports `ok`, `fail` or
@@ -259,7 +301,7 @@ services:
       VITE_API_URL: ${api.url}
 ```
 
-`sonar up` claims a free port for every `port: auto` service it starts: the
+`sonar start` claims a free port for every `port: auto` service it starts: the
 same one each time in the same checkout, and a different one in every other
 checkout, so a worktree never collides with the main one. The service gets it
 as `PORT`, `SONAR_PORT` and `${port}`, and it has to use it — read `PORT`, or
@@ -296,7 +338,9 @@ sonar up --only api,frontend
 sonar up --json
 ```
 
-Starts every service the group's `sonar.yaml` declares, in `depends_on` order:
+`sonar up` is `sonar start -d`, which can also name a group from anywhere and
+start it on another host. It starts every service the group's `sonar.yaml`
+declares, in `depends_on` order:
 a service waits for the ports its dependencies declare before it is started, and
 one that is already listening is skipped. Each runs detached in its own process
 group, with its output in `~/.config/sonar/logs/<group>/<service>.log`, and with
@@ -312,9 +356,20 @@ with a port.
 ```
 
 A service that fails to start is reported on its own line and makes the command
-exit non-zero, whatever else came up. Stop them all again with
-`sonar kill -g my-app`. `sonar up` needs the daemon and starts it if it is not
-already running.
+exit non-zero, whatever else came up. Stop them all again with `sonar down`.
+`sonar up` needs the daemon and starts it if it is not already running.
+
+### `sonar down`
+
+```sh
+sonar down            # the project in the nearest sonar.yaml
+sonar down my-app     # a group by name
+```
+
+Stops every service of the project — every port it listens on, and every
+service sonar started for it that holds no port, like a worker — and releases
+the ports sonar claimed for its `port: auto` services. `sonar kill -g my-app`
+stops the ports and releases nothing.
 
 ### `sonar groups` and `sonar init`
 
@@ -889,7 +944,7 @@ silences the notices, and `--json` output never carries them.
 | `sonar runs` | `sonar start --list` |
 | `sonar list --tag X` | `sonar list --group X` |
 | `sonar kill-all --filter docker` | `sonar kill --all --filter docker` |
-| `sonar down X` | `sonar kill -g X` |
+| `sonar down X` (a profile) | `sonar kill -g X`; `sonar down` now stops a `sonar.yaml` project |
 | `sonar profile create X` | `sonar init` |
 | `sonar profile show X` | `sonar groups X` |
 | `sonar up X` (checked a profile) | `sonar up X` now *starts* the group |

--- a/docs/schema/protocol.schema.json
+++ b/docs/schema/protocol.schema.json
@@ -1457,6 +1457,9 @@
         "name": {
           "type": "string"
         },
+        "config_path": {
+          "type": "string"
+        },
         "force": {
           "type": "boolean"
         },
@@ -1464,6 +1467,9 @@
           "type": "integer"
         },
         "dry_run": {
+          "type": "boolean"
+        },
+        "release": {
           "type": "boolean"
         }
       },
@@ -1557,6 +1563,9 @@
         },
         "log_path": {
           "type": "string"
+        },
+        "log_offset": {
+          "type": "integer"
         },
         "skipped": {
           "type": "boolean"
@@ -1911,6 +1920,9 @@
             "$ref": "#/definitions/KillResult"
           },
           "type": "array"
+        },
+        "released": {
+          "type": "integer"
         }
       },
       "type": "object",

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
 	"github.com/raskrebs/sonar/internal/display"
 	"github.com/raskrebs/sonar/internal/killer"
 	"github.com/raskrebs/sonar/internal/ports"
@@ -13,56 +17,125 @@ import (
 var (
 	downYesFlag   bool
 	downForceFlag bool
+	downJSONFlag  bool
 )
 
-// downCmd is an alias for `sonar kill` over a profile's ports: it selects the
-// targets and hands them to the same killer.
+// downCmd is the other half of `sonar start`: it stops a project and gives back
+// the ports sonar picked for it.
 var downCmd = &cobra.Command{
-	Use:   "down <profile>",
-	Short: "Stop all ports listed in a profile",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		Hint(cmd, HintDownToKill(args[0]))
-		prof, err := profile.Load(args[0])
-		if err != nil {
-			return err
-		}
-
-		selectTargets := func(snapshot []ports.ListeningPort) ([]killer.Target, error) {
-			var targets []killer.Target
-			for _, entry := range prof.Ports {
-				for _, p := range snapshot {
-					if p.Port == entry.Port {
-						targets = append(targets, killer.Target{Port: p.Port, BindAddress: p.BindAddress})
-					}
-				}
-			}
-			return targets, nil
-		}
-
-		if onRemoteHost() {
-			fmt.Printf("Profile %s on %s:\n", display.Bold(prof.Name), display.Bold(remoteHostFlag))
-			return killSweepThroughDaemon(cmd.Context(), selectTargets,
-				killer.Options{Force: downForceFlag}, !downYesFlag, false)
-		}
-
-		snapshot := scanForKill()
-		targets, _ := selectTargets(snapshot)
-		if len(targets) == 0 {
-			fmt.Println("No profile ports are currently running.")
-			return nil
-		}
-
-		fmt.Printf("Profile %s:\n", display.Bold(prof.Name))
-		opts := killer.Options{Force: downForceFlag, Ports: snapshot}
-		return killRun(cmd.Context(), targets, snapshot, opts, !downYesFlag, false)
-	},
+	Use:   "down [group]",
+	Short: "Stop a project's services and release the ports sonar picked for them",
+	Long: "Stop every service of the project in the nearest sonar.yaml, or of the\n" +
+		"group named: every port it listens on, and every service sonar started\n" +
+		"for it that holds no port. The ports sonar claimed for its `port: auto`\n" +
+		"services are released.\n\n" +
+		"`sonar kill -g <group>` stops the ports and releases nothing.",
+	Args: cobra.MaximumNArgs(1),
+	RunE: downRun,
 }
 
 func init() {
-	downCmd.Flags().BoolVarP(&downYesFlag, "yes", "y", false, "Skip confirmation prompt")
+	downCmd.Flags().BoolVarP(&downYesFlag, "yes", "y", false, "Skip the confirmation prompt (for the old profile form)")
 	downCmd.Flags().BoolVarP(&downForceFlag, "force", "f", false, "Send SIGKILL instead of SIGTERM")
-	addHostFlag(downCmd, "Stop the profile's ports on a registered remote `host`")
+	downCmd.Flags().BoolVar(&downJSONFlag, "json", false, "Output as JSON")
+	addHostFlag(downCmd, "Stop the group on a registered remote `host`")
 	rootCmd.AddCommand(downCmd)
+}
+
+func downRun(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	params := rpc.GroupsKillParams{HostParams: hostParams(), Force: downForceFlag, Release: true}
+	if len(args) == 1 {
+		params.Name = strings.TrimSpace(args[0])
+	} else {
+		if onRemoteHost() {
+			return fmt.Errorf("name the group to stop on %s: `sonar down <group> --host %s`",
+				remoteHostFlag, remoteHostFlag)
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		cfg, err := nearestConfig(wd)
+		if err != nil {
+			return err
+		}
+		path := cfg.Path
+		params.ConfigPath = &path
+	}
+
+	c, err := connectForHostWrite(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	snapshot, err := hostSnapshot(cmd.Context(), c)
+	if err != nil {
+		return cliError(err)
+	}
+
+	var env rpc.KillEnvelope
+	if err := c.Call(cmd.Context(), "groups.kill", params, &env); err != nil {
+		// `sonar down <profile>` was the old command. A name that is only a
+		// profile still means that, with the notice saying what replaced it.
+		var re *rpc.Error
+		if len(args) == 1 && errors.As(err, &re) && re.Data.Code == "not_found" && hasProfile(args[0]) {
+			return downProfile(cmd, args[0])
+		}
+		return cliError(err)
+	}
+	if downJSONFlag {
+		return writeJSON(env)
+	}
+
+	var reportErr error
+	if len(env.Results) == 0 {
+		fmt.Println("Nothing was running.")
+	} else {
+		reportErr = reportKill(os.Stdout, env.Results, snapshot, false, false)
+	}
+	if env.Released > 0 {
+		fmt.Println(display.Dim(fmt.Sprintf("released %d claimed %s", env.Released, pluralWord(env.Released, "port"))))
+	}
+	return reportErr
+}
+
+// downProfile is the old `sonar down <profile>`: an alias for `sonar kill` over
+// a profile's ports. It selects the targets and hands them to the same killer.
+func downProfile(cmd *cobra.Command, name string) error {
+	Hint(cmd, HintDownToKill(name))
+	prof, err := profile.Load(name)
+	if err != nil {
+		return err
+	}
+
+	selectTargets := func(snapshot []ports.ListeningPort) ([]killer.Target, error) {
+		var targets []killer.Target
+		for _, entry := range prof.Ports {
+			for _, p := range snapshot {
+				if p.Port == entry.Port {
+					targets = append(targets, killer.Target{Port: p.Port, BindAddress: p.BindAddress})
+				}
+			}
+		}
+		return targets, nil
+	}
+
+	if onRemoteHost() {
+		fmt.Printf("Profile %s on %s:\n", display.Bold(prof.Name), display.Bold(remoteHostFlag))
+		return killSweepThroughDaemon(cmd.Context(), selectTargets,
+			killer.Options{Force: downForceFlag}, !downYesFlag, false)
+	}
+
+	snapshot := scanForKill()
+	targets, _ := selectTargets(snapshot)
+	if len(targets) == 0 {
+		fmt.Println("No profile ports are currently running.")
+		return nil
+	}
+
+	fmt.Printf("Profile %s:\n", display.Bold(prof.Name))
+	opts := killer.Options{Force: downForceFlag, Ports: snapshot}
+	return killRun(cmd.Context(), targets, snapshot, opts, !downYesFlag, false)
 }

--- a/internal/cmd/follow.go
+++ b/internal/cmd/follow.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/display"
+)
+
+// followPoll is how often a followed log is read again. A few reads a second
+// cost nothing and behave the same on every OS, which a file watcher does not.
+const followPoll = 200 * time.Millisecond
+
+// followColors are the colours service prefixes take in turn.
+var followColors = []func(string) string{display.Cyan, display.Magenta, display.Yellow, display.Green, display.Blue}
+
+// followPrefix is what `sonar start` puts in front of a service's log lines:
+// its name, padded to the widest name so the lines stay aligned, in a colour
+// of its own.
+func followPrefix(name string, width, i int) string {
+	return followColors[i%len(followColors)](padRight(name, width)) + display.Dim(" | ")
+}
+
+// lineWriter writes whole lines from several followers to one writer, so two
+// services never interleave inside a line.
+type lineWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (l *lineWriter) println(s string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintln(l.w, s)
+}
+
+// logFollower tails one service's log file from an offset and writes every
+// line with the service's name in front, the way `docker compose up` does. The
+// file is appended to across runs, so the offset is where this run began.
+type logFollower struct {
+	prefix string
+	path   string
+	offset int64
+	out    *lineWriter
+
+	partial []byte
+	buf     []byte
+	stop    chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newLogFollower(out *lineWriter, prefix, path string, offset int64) *logFollower {
+	return &logFollower{
+		prefix: prefix, path: path, offset: offset, out: out,
+		buf:  make([]byte, 32<<10),
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+}
+
+// Start follows the file until Stop.
+func (f *logFollower) Start() { go f.run() }
+
+// Stop reads what is left, writes a last unterminated line if there is one,
+// and returns once the follower has finished.
+func (f *logFollower) Stop() {
+	f.once.Do(func() { close(f.stop) })
+	<-f.done
+}
+
+func (f *logFollower) run() {
+	defer close(f.done)
+	t := time.NewTicker(followPoll)
+	defer t.Stop()
+	for {
+		f.poll()
+		select {
+		case <-f.stop:
+			f.poll()
+			if len(f.partial) > 0 {
+				f.emit(string(f.partial))
+				f.partial = nil
+			}
+			return
+		case <-t.C:
+		}
+	}
+}
+
+// poll reads whatever was appended since the last read.
+func (f *logFollower) poll() {
+	file, err := os.Open(f.path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return
+	}
+	if info.Size() < f.offset {
+		// Rotated or truncated: the service is writing a new file from the top.
+		f.offset = 0
+		f.partial = nil
+	}
+	if info.Size() == f.offset {
+		return
+	}
+	if _, err := file.Seek(f.offset, io.SeekStart); err != nil {
+		return
+	}
+	for {
+		n, err := file.Read(f.buf)
+		if n > 0 {
+			f.offset += int64(n)
+			f.feed(f.buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// feed splits new bytes into lines, keeping an unterminated tail for later.
+func (f *logFollower) feed(data []byte) {
+	f.partial = append(f.partial, data...)
+	for {
+		i := bytes.IndexByte(f.partial, '\n')
+		if i < 0 {
+			break
+		}
+		f.emit(string(f.partial[:i]))
+		f.partial = f.partial[i+1:]
+	}
+	f.partial = append([]byte(nil), f.partial...)
+}
+
+func (f *logFollower) emit(line string) {
+	f.out.println(f.prefix + strings.TrimRight(line, "\r"))
+}

--- a/internal/cmd/follow_test.go
+++ b/internal/cmd/follow_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func appendTo(t *testing.T, path, s string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(s); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// waitFor polls what the follower wrote until it contains want.
+func waitForOutput(t *testing.T, out *lineWriter, buf *bytes.Buffer, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		out.mu.Lock()
+		got := buf.String()
+		out.mu.Unlock()
+		if strings.Contains(got, want) {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("output never contained %q:\n%s", want, got)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestLogFollowerStartsAtTheOffset: what an earlier run wrote is not replayed,
+// and a line written in two pieces comes out as one.
+func TestLogFollowerStartsAtTheOffset(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "api.log")
+	appendTo(t, path, "an earlier run\n")
+
+	var buf bytes.Buffer
+	out := &lineWriter{w: &buf}
+	f := newLogFollower(out, "api | ", path, int64(len("an earlier run\n")))
+	f.Start()
+	defer f.Stop()
+
+	appendTo(t, path, "first\nsecond, written ")
+	time.Sleep(3 * followPoll)
+	appendTo(t, path, "in two pieces\n")
+
+	got := waitForOutput(t, out, &buf, "api | second, written in two pieces")
+	if strings.Contains(got, "earlier run") {
+		t.Errorf("replayed an earlier run:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "api | first\n") {
+		t.Errorf("output = %q, want it to start with the first new line", got)
+	}
+}
+
+// TestLogFollowerStartsOverAfterARotation: an offset past the end of the file
+// means the file was replaced, so the follower reads the new one from the top.
+func TestLogFollowerStartsOverAfterARotation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "api.log")
+	appendTo(t, path, "fresh file\n")
+
+	var buf bytes.Buffer
+	out := &lineWriter{w: &buf}
+	f := newLogFollower(out, "api | ", path, 10<<20)
+	f.Start()
+	defer f.Stop()
+
+	waitForOutput(t, out, &buf, "api | fresh file")
+}
+
+// TestLogFollowerFlushesOnStop: a last line without a newline still comes out.
+func TestLogFollowerFlushesOnStop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "api.log")
+	var buf bytes.Buffer
+	out := &lineWriter{w: &buf}
+	f := newLogFollower(out, "api | ", path, 0)
+	f.Start()
+
+	appendTo(t, path, "no newline at the end")
+	f.Stop()
+	if got := buf.String(); got != "api | no newline at the end\n" {
+		t.Errorf("output = %q", got)
+	}
+}

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -46,10 +46,15 @@ var (
 const registerTimeout = 5 * time.Second
 
 var startCmd = &cobra.Command{
-	Use:   "start [--group <name>] [--name <name>] [--port <port>] [--detach] -- <command> [args...]",
-	Short: "Start a command as a named service in a group",
-	Long: "Start <command> and record it so sonar can attribute every port it (or\n" +
-		"anything it spawns) opens to a group and a service name.\n\n" +
+	Use:   "start [-d] [<dir>] [<service>...] | start [flags] -- <command> [args...]",
+	Short: "Start a project from its sonar.yaml, or one command as a named service",
+	Long: "With no command, start the project described by the nearest sonar.yaml —\n" +
+		"or the one in or above <dir> — in depends_on order. Name services to\n" +
+		"start only those. In the foreground sonar follows their logs with the\n" +
+		"service name in front of every line, and Ctrl+C stops the services it\n" +
+		"started. -d starts them in the background instead, like `sonar up`.\n\n" +
+		"After --, start <command> and record it so sonar can attribute every\n" +
+		"port it (or anything it spawns) opens to a group and a service name.\n\n" +
 		"The group is --group, else the nearest sonar.yaml, else the git\n" +
 		"checkout the command runs in, else the directory name. The name is\n" +
 		"--name, else the matching sonar.yaml service, else inferred from the\n" +
@@ -67,9 +72,9 @@ func init() {
 	startCmd.Flags().StringVar(&startGroup, "group", "", "Group to attribute this run to (default: sonar.yaml, git root, or directory name)")
 	startCmd.Flags().StringVar(&startName, "name", "", "Service name for this run (default: inferred from the command)")
 	startCmd.Flags().IntVar(&startPort, "port", 0, "Port this command is expected to bind; the run shows as starting until it does")
-	startCmd.Flags().BoolVar(&startDetach, "detach", false, "Run in the background, logging to ~/.config/sonar/logs/<group>/<name>.log")
+	startCmd.Flags().BoolVarP(&startDetach, "detach", "d", false, "Run in the background, logging to ~/.config/sonar/logs/<group>/")
 	startCmd.Flags().BoolVar(&startList, "list", false, "List the runs sonar started and exit")
-	startCmd.Flags().BoolVar(&startJSON, "json", false, "Output as JSON (with --list)")
+	startCmd.Flags().BoolVar(&startJSON, "json", false, "Output as JSON (with --list, or with -d for a project)")
 	rootCmd.AddCommand(startCmd)
 }
 
@@ -77,16 +82,18 @@ func startRun(cmd *cobra.Command, args []string) error {
 	if startList {
 		return listRuns(cmd.Context())
 	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving the working directory: %w", err)
+	}
+	if handled, err := startProjectIfAsked(cmd, cwd, args); handled {
+		return err
+	}
 	if len(args) == 0 {
 		return errors.New("no command given; usage: sonar start [flags] -- <command> [args...]")
 	}
 	if startPort < 0 || startPort > 65535 {
 		return fmt.Errorf("--port %d is not a port number", startPort)
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("resolving the working directory: %w", err)
 	}
 	res := spawn.Resolve(cwd, args, startGroup, startName)
 	// The agent session is detected here, in the process the agent actually

--- a/internal/cmd/start_args.go
+++ b/internal/cmd/start_args.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/raskrebs/sonar/internal/groups"
+)
+
+// projectRequest is `sonar start` asked to start a project rather than one
+// command: the sonar.yaml to start and, when named, which of its services.
+type projectRequest struct {
+	cfg      *groups.Config
+	services []string
+}
+
+// classifyStart decides what `sonar start` was asked to do. dash is cobra's
+// ArgsLenAtDash: -1 when there was no `--`.
+//
+//	sonar start                   every service in the nearest sonar.yaml
+//	sonar start <dir> [service…]  the sonar.yaml in or above dir
+//	sonar start <service…>        those services of the nearest sonar.yaml
+//	sonar start -- <command>      one command
+//
+// It returns nil for a command. A command given without `--` still runs as
+// one, as it always has: arguments that are not a directory, a config file or
+// services of the nearest file are a command.
+func classifyStart(cwd string, args []string, dash int) (*projectRequest, error) {
+	switch {
+	case dash == 0:
+		return nil, nil
+	case dash > 0:
+		return nil, fmt.Errorf("`sonar start %s -- …`: name services, or give a command after --, not both",
+			strings.Join(args[:dash], " "))
+	}
+
+	if len(args) == 0 {
+		cfg, err := nearestConfig(cwd)
+		if err != nil {
+			return nil, err
+		}
+		return &projectRequest{cfg: cfg}, nil
+	}
+
+	if dir, ok := projectDirArg(cwd, args[0]); ok {
+		cfg, err := nearestConfig(dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range args[1:] {
+			if _, ok := cfg.ServiceNamed(name); !ok {
+				return nil, unknownService(cfg, name)
+			}
+		}
+		return &projectRequest{cfg: cfg, services: args[1:]}, nil
+	}
+
+	cfg, err := nearestConfig(cwd)
+	if err != nil {
+		return nil, nil
+	}
+	for _, name := range args {
+		if _, ok := cfg.ServiceNamed(name); !ok {
+			return nil, nil
+		}
+	}
+	return &projectRequest{cfg: cfg, services: args}, nil
+}
+
+// projectDirArg reports whether an argument names a project rather than a
+// command: a path to a directory, a directory holding a config, or a config
+// file itself. It returns the directory to look for the config from.
+func projectDirArg(cwd, arg string) (string, bool) {
+	looksLikePath := arg == "." || arg == ".." || strings.ContainsAny(arg, `/\`) || strings.HasPrefix(arg, "~")
+	path := arg
+	if strings.HasPrefix(path, "~") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+		}
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cwd, path)
+	}
+	info, err := os.Stat(path)
+	switch {
+	case err != nil:
+		return "", false
+	case info.IsDir():
+		// A bare directory name counts only when it holds a config itself: a
+		// command that happens to share its name with a folder here must still
+		// run as a command.
+		if looksLikePath || len(groups.FilesIn(path)) > 0 {
+			return path, true
+		}
+		return "", false
+	case groups.IsConfigName(filepath.Base(path)):
+		return filepath.Dir(path), true
+	}
+	return "", false
+}
+
+// nearestConfig is the sonar.yaml at or above dir, confined to dir's own
+// checkout when that is a linked worktree.
+func nearestConfig(dir string) (*groups.Config, error) {
+	index := groups.NewIndex()
+	index.Observe(dir)
+	if cfg := index.NearestFor(dir); cfg != nil {
+		return cfg, nil
+	}
+	if bad := index.Invalid(); len(bad) > 0 {
+		return nil, fmt.Errorf("%s cannot be used: %w", groups.ConfigName, bad[0].Err)
+	}
+	return nil, fmt.Errorf("no %s at or above %s\nhint: `sonar init` writes one, or start a single command: `sonar start -- <command>`",
+		groups.ConfigName, shortPath(dir))
+}
+
+func unknownService(cfg *groups.Config, name string) error {
+	known := make([]string, 0, len(cfg.Services))
+	for _, s := range cfg.Services {
+		known = append(known, s.Name)
+	}
+	return &groups.UnknownServiceError{Path: cfg.Path, Name: name, Known: known}
+}

--- a/internal/cmd/start_args_test.go
+++ b/internal/cmd/start_args_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/raskrebs/sonar/internal/groups"
+)
+
+// startProjectDir is a checkout holding a sonar.yaml with api and web, plus a
+// dev.sh, a subdirectory, and a sibling checkout with no config at all.
+func startProjectDir(t *testing.T) (repo, bare string) {
+	t.Helper()
+	base := t.TempDir()
+	if real, err := filepath.EvalSymlinks(base); err == nil {
+		base = real
+	}
+	repo = filepath.Join(base, "repo")
+	bare = filepath.Join(base, "bare")
+	for _, d := range []string{filepath.Join(repo, ".git"), filepath.Join(repo, "backend"), filepath.Join(bare, ".git")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := "name: shop\nservices:\n  - name: api\n    cmd: run-api\n  - name: web\n    cmd: run-web\n"
+	if err := os.WriteFile(filepath.Join(repo, groups.ConfigName), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "dev.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return repo, bare
+}
+
+func TestClassifyStart(t *testing.T) {
+	repo, _ := startProjectDir(t)
+	backend := filepath.Join(repo, "backend")
+
+	for _, tt := range []struct {
+		name     string
+		cwd      string
+		args     []string
+		dash     int
+		project  bool
+		services string
+	}{
+		{"no arguments is the nearest file", repo, nil, -1, true, ""},
+		{"from a subdirectory too", backend, nil, -1, true, ""},
+		{"a dot", backend, []string{"."}, -1, true, ""},
+		{"a path and services", backend, []string{"..", "web"}, -1, true, "web"},
+		{"the config file itself", backend, []string{"../sonar.yaml"}, -1, true, ""},
+		{"service names", repo, []string{"api", "web"}, -1, true, "api,web"},
+		{"a command without --", repo, []string{"npm", "run", "dev"}, -1, false, ""},
+		{"a service name followed by a command word", repo, []string{"api", "--verbose"}, -1, false, ""},
+		{"a script path", repo, []string{"./dev.sh"}, -1, false, ""},
+		{"a command after --", repo, []string{"npm", "run", "dev"}, 0, false, ""},
+		{"a folder that is not a project", repo, []string{"backend"}, -1, false, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := classifyStart(tt.cwd, tt.args, tt.dash)
+			if err != nil {
+				t.Fatalf("classifyStart: %v", err)
+			}
+			if (req != nil) != tt.project {
+				t.Fatalf("project = %v, want %v", req != nil, tt.project)
+			}
+			if req == nil {
+				return
+			}
+			if req.cfg.Name != "shop" {
+				t.Errorf("config = %s, want the shop project", req.cfg.Path)
+			}
+			if got := strings.Join(req.services, ","); got != tt.services {
+				t.Errorf("services = %q, want %q", got, tt.services)
+			}
+		})
+	}
+}
+
+func TestClassifyStartErrors(t *testing.T) {
+	repo, bare := startProjectDir(t)
+
+	if _, err := classifyStart(repo, []string{"api", "npm"}, 1); err == nil || !strings.Contains(err.Error(), "not both") {
+		t.Errorf("services and a command: err = %v", err)
+	}
+	if _, err := classifyStart(repo, []string{".", "nope"}, -1); err == nil || !strings.Contains(err.Error(), `no service "nope"`) {
+		t.Errorf("an unknown service after a path: err = %v", err)
+	}
+	if _, err := classifyStart(bare, nil, -1); err == nil || !strings.Contains(err.Error(), "sonar init") {
+		t.Errorf("no config: err = %v, want the sonar init hint", err)
+	}
+	// With no config, words are a command, as they always were.
+	if req, err := classifyStart(bare, []string{"npm", "run", "dev"}, -1); err != nil || req != nil {
+		t.Errorf("a command in a project with no config = %+v, %v", req, err)
+	}
+}

--- a/internal/cmd/start_project.go
+++ b/internal/cmd/start_project.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/client"
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/display"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/runs"
+	"github.com/spf13/cobra"
+)
+
+// exitPoll is how often the foreground `sonar start` checks whether the
+// services it started are still running.
+const exitPoll = 500 * time.Millisecond
+
+// stopStartedTimeout bounds the kill a Ctrl+C sends. The killer's own escalation
+// finishes well inside it.
+const stopStartedTimeout = 30 * time.Second
+
+// startProjectIfAsked runs `sonar start` for a project when that is what the
+// arguments ask for, and reports whether it did.
+func startProjectIfAsked(cmd *cobra.Command, cwd string, args []string) (bool, error) {
+	req, err := classifyStart(cwd, args, cmd.ArgsLenAtDash())
+	if err != nil {
+		return true, err
+	}
+	if req == nil {
+		return false, nil
+	}
+	if startGroup != "" || startName != "" || startPort != 0 {
+		return true, fmt.Errorf("--group, --name and --port are for a single command; a project's services are named in %s",
+			shortPath(req.cfg.Path))
+	}
+	return true, startProject(cmd, req)
+}
+
+// startProject starts a project's services through the daemon, exactly as
+// `sonar up` does. With -d it returns once they are started; otherwise it
+// stays in the foreground and follows them.
+func startProject(cmd *cobra.Command, req *projectRequest) error {
+	ctx := cmd.Context()
+
+	// Caught before anything starts: a Ctrl+C while the first service is
+	// coming up must still stop it.
+	sigs := make(chan os.Signal, 2)
+	if !startDetach {
+		signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigs)
+	}
+
+	c, err := connectDaemon(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	path := req.cfg.Path
+	params := rpc.GroupsStartParams{ConfigPath: &path, Only: req.services, Env: callerEnv()}
+	var res rpc.GroupsStartResult
+	stream, err := c.Stream(ctx, "groups.start", params, &res)
+	if err != nil {
+		return daemonError(err)
+	}
+	defer stream.Close()
+
+	if startDetach {
+		return consumeStart(stream, startJSON)
+	}
+	return followProject(c, stream, req.cfg, sigs)
+}
+
+// followProject is the foreground `sonar start`: it prints each service as the
+// daemon starts it, then follows the logs of the ones it started with their
+// names in front, the way `docker compose up` does. Ctrl+C stops those
+// services — and only those: one that was already running is left alone. It
+// also returns once every service it started has exited.
+func followProject(c *client.Client, stream *client.Stream, cfg *groups.Config, sigs <-chan os.Signal) error {
+	width := 0
+	colour := map[string]int{}
+	for i, s := range cfg.Services {
+		width = max(width, len(s.Name))
+		colour[s.Name] = i
+	}
+	prefix := func(name string) string { return followPrefix(name, width, colour[name]) }
+
+	out := &lineWriter{w: os.Stdout}
+	var (
+		started   []rpc.GroupsStartChunk
+		followers []*logFollower
+	)
+	stopFollowing := func() {
+		for _, f := range followers {
+			f.Stop()
+		}
+	}
+
+	chunks := stream.Chunks()
+	for chunks != nil {
+		select {
+		case raw, ok := <-chunks:
+			if !ok {
+				chunks = nil
+				continue
+			}
+			var ch rpc.GroupsStartChunk
+			if err := json.Unmarshal(raw, &ch); err != nil {
+				continue
+			}
+			out.mu.Lock()
+			printStartChunk(ch)
+			out.mu.Unlock()
+			if ch.PID <= 0 || ch.Error != "" || ch.Skipped {
+				continue
+			}
+			started = append(started, ch)
+			if ch.LogPath != "" {
+				f := newLogFollower(out, prefix(ch.Service), ch.LogPath, ch.LogOffset)
+				f.Start()
+				followers = append(followers, f)
+			}
+		case <-sigs:
+			ctx, cancel := context.WithTimeout(context.Background(), registerTimeout)
+			_ = stream.Cancel(ctx)
+			cancel()
+			return stopStarted(c, started, stopFollowing, sigs)
+		}
+	}
+
+	end := <-stream.End()
+	var summary rpc.GroupsStartEnd
+	failed := false
+	switch {
+	case end.Err != nil:
+		failed = true
+		if len(started) == 0 {
+			stopFollowing()
+			return daemonError(end.Err)
+		}
+		fmt.Fprintln(os.Stderr, daemonError(end.Err))
+	case end.Decode(&summary) == nil:
+		failed = len(summary.Errors) > 0
+		out.mu.Lock()
+		printStartSummary(summary)
+		out.mu.Unlock()
+	}
+
+	if len(started) == 0 {
+		stopFollowing()
+		if failed {
+			return errSilent
+		}
+		out.println(display.Dim("nothing new was started; `sonar logs <port>` follows a service that is running"))
+		return nil
+	}
+	out.println(display.Dim(fmt.Sprintf("following the logs; Ctrl+C stops the %d %s started here",
+		len(started), pluralWord(len(started), "service"))))
+
+	alive := make(map[int]bool, len(started))
+	for _, s := range started {
+		alive[s.PID] = true
+	}
+	t := time.NewTicker(exitPoll)
+	defer t.Stop()
+	for {
+		select {
+		case <-sigs:
+			return stopStarted(c, started, stopFollowing, sigs)
+		case <-t.C:
+			left := 0
+			for _, s := range started {
+				if !alive[s.PID] {
+					continue
+				}
+				if !runs.PIDAlive(s.PID) {
+					alive[s.PID] = false
+					out.println(prefix(s.Service) + display.Dim("exited"))
+					continue
+				}
+				left++
+			}
+			if left == 0 {
+				stopFollowing()
+				if failed {
+					return errSilent
+				}
+				return nil
+			}
+		}
+	}
+}
+
+// stopStarted stops the services this `sonar start` started, through the
+// daemon, each with its whole process tree. The logs keep being followed while
+// they shut down, so what a service prints on its way out is still shown. A
+// second Ctrl+C stops waiting.
+func stopStarted(c *client.Client, started []rpc.GroupsStartChunk, stopFollowing func(), sigs <-chan os.Signal) error {
+	var targets []rpc.Selector
+	for _, s := range started {
+		if runs.PIDAlive(s.PID) {
+			pid := s.PID
+			targets = append(targets, rpc.Selector{PID: &pid})
+		}
+	}
+	if len(targets) == 0 {
+		stopFollowing()
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "\nstopping %d %s…\n", len(targets), pluralWord(len(targets), "service"))
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), stopStartedTimeout)
+		defer cancel()
+		var env rpc.KillEnvelope
+		done <- c.Call(ctx, "ports.kill", rpc.PortsKillParams{Targets: targets, Tree: true}, &env)
+	}()
+
+	select {
+	case err := <-done:
+		stopFollowing()
+		if err != nil {
+			return daemonError(err)
+		}
+		fmt.Fprintln(os.Stderr, display.Dim("stopped"))
+		return nil
+	case <-sigs:
+		fmt.Fprintln(os.Stderr, "not waiting any longer; `sonar down` stops whatever is left")
+		return errSilent
+	}
+}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -67,7 +67,7 @@ func upRun(cmd *cobra.Command, args []string) error {
 	}
 	defer stream.Close()
 
-	return consumeStart(stream)
+	return consumeStart(stream, upJSON)
 }
 
 // upParams turns the command line into groups.start params: a name when one was
@@ -116,7 +116,7 @@ func upParams(args []string) (rpc.GroupsStartParams, error) {
 // consumeStart prints one line per service as the daemon reports it, then the
 // summary. It exits non-zero when any service failed to start (spec, "Error
 // handling": a partial failure is still a failure).
-func consumeStart(stream *client.Stream) error {
+func consumeStart(stream *client.Stream, asJSON bool) error {
 	var chunks []rpc.GroupsStartChunk
 
 	for chunk := range stream.Chunks() {
@@ -125,7 +125,7 @@ func consumeStart(stream *client.Stream) error {
 			continue
 		}
 		chunks = append(chunks, c)
-		if !upJSON {
+		if !asJSON {
 			printStartChunk(c)
 		}
 	}
@@ -139,7 +139,7 @@ func consumeStart(stream *client.Stream) error {
 		return err
 	}
 
-	if upJSON {
+	if asJSON {
 		if err := writeJSON(struct {
 			Services []rpc.GroupsStartChunk `json:"services"`
 			rpc.GroupsStartEnd

--- a/internal/daemon/groups_kill.go
+++ b/internal/daemon/groups_kill.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/raskrebs/sonar/internal/daemon/rpc"
+	"github.com/raskrebs/sonar/internal/groups"
+	"github.com/raskrebs/sonar/internal/killer"
+	"github.com/raskrebs/sonar/internal/state"
+)
+
+// handleGroupsKill stops a group's listening ports. With release it is
+// `sonar down`: it also stops the runs sonar started in the group that hold no
+// port, and gives back the claims the group's `port: auto` services hold.
+func handleGroupsKill(ctx context.Context, req *Request) (any, error) {
+	var p rpc.GroupsKillParams
+	if err := req.Bind(&p); err != nil {
+		return nil, err
+	}
+	name, cfg, err := killGroupName(req.Runtime, p)
+	if err != nil {
+		return nil, err
+	}
+
+	snap, err := killSnapshot(req)
+	if err != nil {
+		return nil, err
+	}
+
+	targets := groupTargets(snap, name)
+	var runPIDs []int
+	if p.Release {
+		runPIDs = req.Runtime.Runs().GroupPIDs(name)
+		if cfg == nil {
+			cfg = configForGroup(req.Runtime, name)
+		}
+	}
+	if len(targets) == 0 && len(runPIDs) == 0 {
+		if !p.Release || cfg == nil {
+			return nil, killRPCError(&killer.CodedError{
+				Code:   killer.CodeNotFound,
+				Detail: "no listening port belongs to group " + name,
+				Hint:   "run `sonar groups` to see what is grouped right now",
+			})
+		}
+		// Nothing is running, but a project with a config still has claims
+		// to give back.
+		env := killEnvelope(nil)
+		if !p.DryRun {
+			n, err := ReleaseServicePorts(req.Runtime, cfg)
+			if err != nil {
+				return nil, err
+			}
+			env.Released = n
+		}
+		return env, nil
+	}
+
+	opts := killer.Options{
+		Force:  p.Force,
+		Grace:  time.Duration(p.GraceMs) * time.Millisecond,
+		DryRun: p.DryRun,
+		Ports:  killerRows(snap),
+	}
+	var rows []state.KillResult
+	if len(targets) > 0 {
+		rows = killer.KillPorts(ctx, targets, opts)
+	}
+	if p.Release && !p.DryRun {
+		// Runs that held no port — a worker, a service still starting — are
+		// stopped by pid, each with its whole tree. The registry is read again
+		// after the port kill: most runs went down with their ports.
+		var pidTargets []killer.Target
+		for _, pid := range req.Runtime.Runs().GroupPIDs(name) {
+			pidTargets = append(pidTargets, killer.Target{PID: pid})
+		}
+		if len(pidTargets) > 0 {
+			tree := opts
+			tree.Tree = true
+			rows = append(rows, killer.KillPorts(ctx, pidTargets, tree)...)
+		}
+	}
+	afterKill(req, opts.DryRun)
+
+	env := killEnvelope(rows)
+	if p.Release && !p.DryRun && cfg != nil {
+		n, err := ReleaseServicePorts(req.Runtime, cfg)
+		if err != nil {
+			// The services are down; a claim left behind expires on its own.
+			req.Runtime.Logger.Warn("releasing a group's claims", "group", name, "error", err)
+		}
+		env.Released = n
+	}
+	return env, nil
+}
+
+// killGroupName is the group a groups.kill call is about: the name it sent, or
+// the group the daemon publishes a config's services under. The config comes
+// back too when the call named one.
+func killGroupName(rt *Runtime, p rpc.GroupsKillParams) (string, *groups.Config, error) {
+	if name := strings.TrimSpace(p.Name); name != "" {
+		return name, nil, nil
+	}
+	if p.ConfigPath != nil && strings.TrimSpace(*p.ConfigPath) != "" {
+		path := strings.TrimSpace(*p.ConfigPath)
+		cfg, ok := rt.Scanner.ConfigAt(path)
+		if !ok {
+			if err := rt.Scanner.LoadConfig(path); err != nil {
+				return "", nil, configError(path, err)
+			}
+			if cfg, ok = rt.Scanner.ConfigAt(path); !ok {
+				return "", nil, rpc.NewError(rpc.CodeNotFound, "no usable "+groups.ConfigName+" at "+path, "")
+			}
+		}
+		return rt.Scanner.GroupOf(cfg), cfg, nil
+	}
+	return "", nil, rpc.NewError(rpc.CodeInvalidParams, "name or config_path is required",
+		`send {"name": "my-app"} or {"config_path": "/repo/sonar.yaml"}`)
+}

--- a/internal/daemon/groupstart/start.go
+++ b/internal/daemon/groupstart/start.go
@@ -111,6 +111,7 @@ func run(ctx context.Context, rt *daemon.Runtime, s *daemon.Stream,
 			continue
 		}
 
+		offset := logSize(spawn.LogPath(group, svc.Name))
 		h, err := start(ctx, rt, cfg, group, svc, book, p)
 		if err != nil {
 			rt.Logger.Warn("starting a service", "group", group, "service", svc.Name, "error", err)
@@ -118,7 +119,10 @@ func run(ctx context.Context, rt *daemon.Runtime, s *daemon.Stream,
 			end.Errors = append(end.Errors, svc.Name)
 			continue
 		}
-		_ = s.Send(rpc.GroupsStartChunk{Service: svc.Name, PID: h.PID, Port: h.PortHint, LogPath: h.LogPath})
+		_ = s.Send(rpc.GroupsStartChunk{
+			Service: svc.Name, PID: h.PID, Port: h.PortHint,
+			LogPath: h.LogPath, LogOffset: offset,
+		})
 		end.Started = append(end.Started, svc.Name)
 	}
 	return end
@@ -157,6 +161,18 @@ func start(ctx context.Context, rt *daemon.Runtime, cfg *groups.Config, group st
 		PortHint: port,
 		LogPath:  spawn.LogPath(group, svc.Name),
 	})
+}
+
+// logSize is how far a service's log file already reaches: where this run's
+// output will begin, since the file is appended to across runs. A file that is
+// rotated when the service opens it starts over at zero, which a follower
+// notices by the file being shorter than the offset.
+func logSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }
 
 // serviceEnv is the environment a service starts in, each layer winning over

--- a/internal/daemon/handlers_sessions_test.go
+++ b/internal/daemon/handlers_sessions_test.go
@@ -32,6 +32,16 @@ func (f *fakeRuns) Run(p state.Port) (state.Run, bool) {
 
 func (f *fakeRuns) Prune() {}
 
+func (f *fakeRuns) GroupPIDs(group string) []int {
+	var out []int
+	for _, l := range f.live {
+		if l.Group == group {
+			out = append(out, l.PID)
+		}
+	}
+	return out
+}
+
 func (f *fakeRuns) Session(p state.Port) (state.Session, bool) {
 	for _, l := range f.live {
 		if l.PID == p.PID {

--- a/internal/daemon/kill_handlers.go
+++ b/internal/daemon/kill_handlers.go
@@ -58,41 +58,6 @@ func handlePortsKill(ctx context.Context, req *Request) (any, error) {
 	return killEnvelope(rows), nil
 }
 
-func handleGroupsKill(ctx context.Context, req *Request) (any, error) {
-	var p rpc.GroupsKillParams
-	if err := req.Bind(&p); err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(p.Name) == "" {
-		return nil, rpc.NewError(rpc.CodeInvalidParams, "name is required",
-			`send {"name": "my-app"}`)
-	}
-
-	snap, err := killSnapshot(req)
-	if err != nil {
-		return nil, err
-	}
-
-	targets := groupTargets(snap, p.Name)
-	if len(targets) == 0 {
-		return nil, killRPCError(&killer.CodedError{
-			Code:   killer.CodeNotFound,
-			Detail: "no listening port belongs to group " + p.Name,
-			Hint:   "run `sonar groups` to see what is grouped right now",
-		})
-	}
-
-	opts := killer.Options{
-		Force:  p.Force,
-		Grace:  time.Duration(p.GraceMs) * time.Millisecond,
-		DryRun: p.DryRun,
-		Ports:  killerRows(snap),
-	}
-	rows := killer.KillPorts(ctx, targets, opts)
-	afterKill(req, opts.DryRun)
-	return killEnvelope(rows), nil
-}
-
 // afterKill rescans and publishes, so the ports that just went away are gone
 // from the very next read and their port_down rows reach the history ring even
 // when nobody is subscribed. Without it the caller's own `sonar list` would

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -49,6 +49,8 @@ type RunRegistry interface {
 	Run(p state.Port) (run state.Run, ok bool)
 	// Prune drops runs whose process is gone.
 	Prune()
+	// GroupPIDs lists the live runs recorded under a group.
+	GroupPIDs(group string) []int
 }
 
 // noRuns is the stand-in used before a registry is installed, so callers never
@@ -57,6 +59,7 @@ type noRuns struct{}
 
 func (noRuns) Run(state.Port) (state.Run, bool) { return state.Run{}, false }
 func (noRuns) Prune()                           {}
+func (noRuns) GroupPIDs(string) []int           { return nil }
 
 // SetRuns installs the run registry. Called once, from an OnStart hook.
 func (r *Runtime) SetRuns(reg RunRegistry) {

--- a/internal/daemon/rpc/methods.go
+++ b/internal/daemon/rpc/methods.go
@@ -64,6 +64,9 @@ type MutationResult struct {
 type KillEnvelope struct {
 	MutationResult
 	Results []state.KillResult `json:"results"`
+	// Released is how many claimed ports a `groups.kill` with release gave
+	// back (`sonar down`). Zero for every other kill.
+	Released int `json:"released,omitempty"`
 }
 
 // Empty is the params or result of a method that takes or returns nothing.
@@ -357,10 +360,19 @@ type GroupsInspectResult struct {
 
 type GroupsKillParams struct {
 	HostParams
-	Name    string `json:"name"`
-	Force   bool   `json:"force,omitempty"`
-	GraceMs int    `json:"grace_ms,omitempty"`
-	DryRun  bool   `json:"dry_run,omitempty"`
+	Name string `json:"name"`
+	// ConfigPath names the group by its sonar.yaml instead of by name, for a
+	// caller that knows the file but not the name the daemon publishes its
+	// group under (`<project>@<worktree>` in a linked worktree, an alias).
+	ConfigPath *string `json:"config_path,omitempty"`
+	Force      bool    `json:"force,omitempty"`
+	GraceMs    int     `json:"grace_ms,omitempty"`
+	DryRun     bool    `json:"dry_run,omitempty"`
+	// Release is `sonar down`: besides the group's listening ports it stops
+	// every run sonar started in the group, port or not, and releases the
+	// claims the group's `port: auto` services hold. A group with a config
+	// and nothing running is not an error then: its claims are still released.
+	Release bool `json:"release,omitempty"`
 }
 
 type GroupsStartParams struct {
@@ -391,9 +403,13 @@ type GroupsStartChunk struct {
 	// or the one assigned for `port: auto`. Zero for a service with none.
 	Port    int    `json:"port,omitempty"`
 	LogPath string `json:"log_path,omitempty"`
-	Skipped bool   `json:"skipped,omitempty"`
-	Reason  string `json:"reason,omitempty"`
-	Error   string `json:"error,omitempty"`
+	// LogOffset is how long log_path already was before this start. The file
+	// is appended to across runs, so a client following it starts here to
+	// show this run and not the ones before.
+	LogOffset int64  `json:"log_offset,omitempty"`
+	Skipped   bool   `json:"skipped,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	Error     string `json:"error,omitempty"`
 }
 
 type GroupsStartEnd struct {

--- a/internal/daemon/runsreg/registry.go
+++ b/internal/daemon/runsreg/registry.go
@@ -215,6 +215,19 @@ func (r *Registry) PortHint(group, service string) (int, bool) {
 	return 0, false
 }
 
+// GroupPIDs lists the live runs recorded under a group, so `sonar down` can
+// stop the ones that hold no port — a worker, or a service still starting —
+// which a kill by port never reaches.
+func (r *Registry) GroupPIDs(group string) []int {
+	var out []int
+	for _, rec := range r.List() {
+		if rec.Group == group {
+			out = append(out, rec.PID)
+		}
+	}
+	return out
+}
+
 // Session implements groups.SessionRegistry: it reports the agent session that
 // started the run owning this port, using the same PPID walk the run
 // attribution uses, so a port and its run can never disagree about who started

--- a/internal/daemon/service_ports.go
+++ b/internal/daemon/service_ports.go
@@ -1,6 +1,9 @@
 package daemon
 
-import "github.com/raskrebs/sonar/internal/claims"
+import (
+	"github.com/raskrebs/sonar/internal/claims"
+	"github.com/raskrebs/sonar/internal/groups"
+)
 
 // AcquireServicePort claims the port a `port: auto` service runs on, for the
 // checkout the service's `sonar.yaml` sits in (dir). It is the same claim
@@ -28,4 +31,45 @@ func AcquireServicePort(rt *Runtime, dir, service string) (int, error) {
 		return 0, claimsError("claiming a port for "+service, err)
 	}
 	return res.Ports[0], nil
+}
+
+// ReleaseServicePorts gives back the claims a config's `port: auto` services
+// hold, for `sonar down`. It reports how many ports went.
+func ReleaseServicePorts(rt *Runtime, cfg *groups.Config) (int, error) {
+	if cfg == nil {
+		return 0, nil
+	}
+	project, worktree := claims.Identity(cfg.Dir, "", "")
+	claimsMu.Lock()
+	defer claimsMu.Unlock()
+	m, err := claimsManager(rt)
+	if err != nil {
+		return 0, err
+	}
+	released := 0
+	for _, svc := range cfg.Services {
+		if !svc.PortAuto {
+			continue
+		}
+		n, err := m.Release(claims.ServiceKey(project, worktree, svc.Name))
+		if err != nil {
+			return released, claimsError("releasing the port of "+svc.Name, err)
+		}
+		released += n
+	}
+	return released, nil
+}
+
+// configForGroup is the sonar.yaml whose services are published under a group
+// name, or nil for a group no config describes.
+func configForGroup(rt *Runtime, name string) *groups.Config {
+	if rt.Scanner == nil {
+		return nil
+	}
+	for _, cfg := range rt.Scanner.Configs() {
+		if rt.Scanner.GroupOf(cfg) == name {
+			return cfg
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## What does this PR do?
<!-- Brief description of the change -->

## Related issue
<!-- Link to the issue this addresses, e.g. Fixes #123 -->

## How was this tested?
<!-- How did you verify this works? -->

## Checklist
- [ ] I have tested this on my platform (macOS / Linux)
- [ ] My changes don't break existing functionality
- [ ] I have updated documentation if needed
